### PR TITLE
Allow Tables implementations to override table paths.

### DIFF
--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
@@ -107,8 +107,8 @@ public abstract class BaseMetastoreTables implements Tables {
     }
   }
 
-  private static String defaultWarehouseLocation(Configuration conf,
-                                                 String database, String table) {
+  protected String defaultWarehouseLocation(Configuration conf,
+                                            String database, String table) {
     String warehouseLocation = conf.get("hive.metastore.warehouse.dir");
     Preconditions.checkNotNull(warehouseLocation,
         "Warehouse location is not set: hive.metastore.warehouse.dir=null");


### PR DESCRIPTION
Hive databases can have set locations where tables get created. Iceberg should use these locations, so the metastore tables implementation should allow overriding the table location.