### PR TITLE
Store multiple partition specs in table metadata.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/PartitionSpec.java
+++ b/api/src/main/java/com/netflix/iceberg/PartitionSpec.java
@@ -146,6 +146,13 @@ public class PartitionSpec implements Serializable {
     return sb.toString();
   }
 
+  /**
+   * Returns true if this spec is equivalent to the other, with field names ignored. That is, if
+   * both specs have the same number of fields, field order, source columns, and transforms.
+   *
+   * @param other another PartitionSpec
+   * @return true if the specs have the same fields, source columns, and transforms.
+   */
   public boolean compatibleWith(PartitionSpec other) {
     if (equals(other)) {
       return true;

--- a/core/src/main/java/com/netflix/iceberg/ManifestReader.java
+++ b/core/src/main/java/com/netflix/iceberg/ManifestReader.java
@@ -99,7 +99,12 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
       throw new RuntimeIOException(e);
     }
     this.schema = SchemaParser.fromJson(metadata.get("schema"));
-    this.spec = PartitionSpecParser.fromJson(schema, metadata.get("partition-spec"));
+    int specId = TableMetadata.INITIAL_SPEC_ID;
+    String specProperty = metadata.get("partition-spec-id");
+    if (specProperty != null) {
+      specId = Integer.parseInt(specProperty);
+    }
+    this.spec = PartitionSpecParser.fromJsonFields(schema, specId, metadata.get("partition-spec"));
     this.entries = null;
   }
 

--- a/core/src/main/java/com/netflix/iceberg/ManifestWriter.java
+++ b/core/src/main/java/com/netflix/iceberg/ManifestWriter.java
@@ -108,7 +108,8 @@ class ManifestWriter implements FileAppender<DataFile> {
               .schema(manifestSchema)
               .named("manifest_entry")
               .meta("schema", SchemaParser.toJson(spec.schema()))
-              .meta("partition-spec", PartitionSpecParser.toJson(spec))
+              .meta("partition-spec", PartitionSpecParser.toJsonFields(spec))
+              .meta("partition-spec-id", String.valueOf(spec.specId()))
               .build();
         default:
           throw new IllegalArgumentException("Unsupported format: " + format);

--- a/core/src/main/java/com/netflix/iceberg/PartitionSpecParser.java
+++ b/core/src/main/java/com/netflix/iceberg/PartitionSpecParser.java
@@ -37,20 +37,18 @@ public class PartitionSpecParser {
   private PartitionSpecParser() {
   }
 
+  private static final String SPEC_ID = "spec-id";
+  private static final String FIELDS = "fields";
   private static final String SOURCE_ID = "source-id";
   private static final String TRANSFORM = "transform";
   private static final String NAME = "name";
 
   public static void toJson(PartitionSpec spec, JsonGenerator generator) throws IOException {
-    generator.writeStartArray();
-    for (PartitionField field : spec.fields()) {
-      generator.writeStartObject();
-      generator.writeStringField(NAME, field.name());
-      generator.writeStringField(TRANSFORM, field.transform().toString());
-      generator.writeNumberField(SOURCE_ID, field.sourceId());
-      generator.writeEndObject();
-    }
-    generator.writeEndArray();
+    generator.writeStartObject();
+    generator.writeNumberField(SPEC_ID, spec.specId());
+    generator.writeFieldName(FIELDS);
+    toJsonFields(spec, generator);
+    generator.writeEndObject();
   }
 
   public static String toJson(PartitionSpec spec) {
@@ -74,23 +72,10 @@ public class PartitionSpecParser {
   }
 
   public static PartitionSpec fromJson(Schema schema, JsonNode json) {
-    Preconditions.checkArgument(json.isArray(),
-        "Cannot parse partition spec, not an array: %s", json);
-
-    PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
-    Iterator<JsonNode> elements = json.elements();
-    while (elements.hasNext()) {
-      JsonNode element = elements.next();
-      Preconditions.checkArgument(element.isObject(),
-          "Cannot parse partition field, not an object: %s", element);
-
-      String name = JsonUtil.getString(NAME, element);
-      String transform = JsonUtil.getString(TRANSFORM, element);
-      int sourceId = JsonUtil.getInt(SOURCE_ID, element);
-
-      builder.add(sourceId, name, transform);
-    }
-
+    Preconditions.checkArgument(json.isObject(), "Cannot parse spec from non-object: %s", json);
+    int specId = JsonUtil.getInt(SPEC_ID, json);
+    PartitionSpec.Builder builder = PartitionSpec.builderFor(schema).withSpecId(specId);
+    buildFromJsonFields(builder, json.get(FIELDS));
     return builder.build();
   }
 
@@ -111,6 +96,63 @@ public class PartitionSpecParser {
       } else {
         throw new RuntimeException("Failed to parse partition spec: " + json, e.getCause());
       }
+    }
+  }
+
+  static void toJsonFields(PartitionSpec spec, JsonGenerator generator) throws IOException {
+    generator.writeStartArray();
+    for (PartitionField field : spec.fields()) {
+      generator.writeStartObject();
+      generator.writeStringField(NAME, field.name());
+      generator.writeStringField(TRANSFORM, field.transform().toString());
+      generator.writeNumberField(SOURCE_ID, field.sourceId());
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
+  }
+
+  static String toJsonFields(PartitionSpec spec) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      toJsonFields(spec, generator);
+      generator.flush();
+      return writer.toString();
+
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
+    }
+  }
+
+  static PartitionSpec fromJsonFields(Schema schema, int specId, JsonNode json) {
+    PartitionSpec.Builder builder = PartitionSpec.builderFor(schema).withSpecId(specId);
+    buildFromJsonFields(builder, json);
+    return builder.build();
+  }
+
+  static PartitionSpec fromJsonFields(Schema schema, int specId, String json) {
+    try {
+      return fromJsonFields(schema, specId, JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to parse partition spec fields: " + json);
+    }
+  }
+
+  private static void buildFromJsonFields(PartitionSpec.Builder builder, JsonNode json) {
+    Preconditions.checkArgument(json.isArray(),
+        "Cannot parse partition spec fields, not an array: %s", json);
+
+    Iterator<JsonNode> elements = json.elements();
+    while (elements.hasNext()) {
+      JsonNode element = elements.next();
+      Preconditions.checkArgument(element.isObject(),
+          "Cannot parse partition field, not an object: %s", element);
+
+      String name = JsonUtil.getString(NAME, element);
+      String transform = JsonUtil.getString(TRANSFORM, element);
+      int sourceId = JsonUtil.getInt(SOURCE_ID, element);
+
+      builder.add(sourceId, name, transform);
     }
   }
 }

--- a/core/src/main/java/com/netflix/iceberg/TableMetadata.java
+++ b/core/src/main/java/com/netflix/iceberg/TableMetadata.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.exceptions.ValidationException;
 import com.netflix.iceberg.io.InputFile;
@@ -71,7 +72,7 @@ public class TableMetadata {
 
     return new TableMetadata(ops, null, location,
         System.currentTimeMillis(),
-        lastColumnId.get(), freshSchema, freshSpec,
+        lastColumnId.get(), freshSchema, 0, ImmutableMap.of(0, freshSpec),
         ImmutableMap.copyOf(properties), -1, ImmutableList.of(), ImmutableList.of());
   }
 
@@ -126,7 +127,8 @@ public class TableMetadata {
   private final long lastUpdatedMillis;
   private final int lastColumnId;
   private final Schema schema;
-  private final PartitionSpec spec;
+  private final int defaultSpecId;
+  private final Map<Integer, PartitionSpec> specs;
   private final Map<String, String> properties;
   private final long currentSnapshotId;
   private final List<Snapshot> snapshots;
@@ -139,7 +141,8 @@ public class TableMetadata {
                 long lastUpdatedMillis,
                 int lastColumnId,
                 Schema schema,
-                PartitionSpec spec,
+                int defaultSpecId,
+                Map<Integer, PartitionSpec> specs,
                 Map<String, String> properties,
                 long currentSnapshotId,
                 List<Snapshot> snapshots,
@@ -150,7 +153,8 @@ public class TableMetadata {
     this.lastUpdatedMillis = lastUpdatedMillis;
     this.lastColumnId = lastColumnId;
     this.schema = schema;
-    this.spec = spec;
+    this.specs = specs;
+    this.defaultSpecId = defaultSpecId;
     this.properties = properties;
     this.currentSnapshotId = currentSnapshotId;
     this.snapshots = snapshots;
@@ -194,7 +198,19 @@ public class TableMetadata {
   }
 
   public PartitionSpec spec() {
-    return spec;
+    return specs.get(defaultSpecId);
+  }
+
+  public int defaultSpecId() {
+    return defaultSpecId;
+  }
+
+  public PartitionSpec spec(int id) {
+    return specs.get(id);
+  }
+
+  public Map<Integer, PartitionSpec> specs() {
+    return specs;
   }
 
   public String location() {
@@ -239,15 +255,42 @@ public class TableMetadata {
 
   public TableMetadata updateTableLocation(String newLocation) {
     return new TableMetadata(ops, null, newLocation,
-        System.currentTimeMillis(), lastColumnId, schema, spec, properties, currentSnapshotId,
-        snapshots, snapshotLog);
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        currentSnapshotId, snapshots, snapshotLog);
   }
 
   public TableMetadata updateSchema(Schema schema, int lastColumnId) {
-    PartitionSpec.checkCompatibility(spec, schema);
+    PartitionSpec.checkCompatibility(spec(), schema);
     return new TableMetadata(ops, null, location,
-        System.currentTimeMillis(), lastColumnId, schema, spec, properties, currentSnapshotId,
-        snapshots,snapshotLog);
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        currentSnapshotId, snapshots, snapshotLog);
+  }
+
+  public TableMetadata updatePartitionSpec(PartitionSpec spec) {
+    PartitionSpec.checkCompatibility(spec, schema);
+
+    // if the spec already exists, use the same ID. otherwise, use 1 more than the highest ID.
+    int newDefaultSpecId = 0;
+    for (Map.Entry<Integer, PartitionSpec> entry : specs.entrySet()) {
+      if (spec.equals(entry.getValue())) {
+        newDefaultSpecId = entry.getKey();
+        break;
+      } else if (newDefaultSpecId <= entry.getKey()) {
+        newDefaultSpecId = entry.getKey() + 1;
+      }
+    }
+
+    Preconditions.checkArgument(defaultSpecId != newDefaultSpecId,
+        "Cannot set default partition spec to the current default");
+
+    Map<Integer, PartitionSpec> newSpecs = Maps.newHashMap();
+    newSpecs.putAll(specs);
+    newSpecs.put(newDefaultSpecId, spec);
+
+    return new TableMetadata(ops, null, location,
+        System.currentTimeMillis(), lastColumnId, schema, newDefaultSpecId,
+        ImmutableMap.copyOf(newSpecs), properties,
+        currentSnapshotId, snapshots, snapshotLog);
   }
 
   public TableMetadata replaceCurrentSnapshot(Snapshot snapshot) {
@@ -260,8 +303,8 @@ public class TableMetadata {
         .add(new SnapshotLogEntry(snapshot.timestampMillis(), snapshot.snapshotId()))
         .build();
     return new TableMetadata(ops, null, location,
-        snapshot.timestampMillis(), lastColumnId, schema, spec, properties, snapshot.snapshotId(),
-        newSnapshots, newSnapshotLog);
+        snapshot.timestampMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        snapshot.snapshotId(), newSnapshots, newSnapshotLog);
   }
 
   public TableMetadata removeSnapshotsIf(Predicate<Snapshot> removeIf) {
@@ -291,8 +334,8 @@ public class TableMetadata {
     }
 
     return new TableMetadata(ops, null, location,
-        System.currentTimeMillis(), lastColumnId, schema, spec, properties, currentSnapshotId,
-        filtered, ImmutableList.copyOf(newSnapshotLog));
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        currentSnapshotId, filtered, ImmutableList.copyOf(newSnapshotLog));
   }
 
   public TableMetadata rollbackTo(Snapshot snapshot) {
@@ -306,15 +349,15 @@ public class TableMetadata {
         .build();
 
     return new TableMetadata(ops, null, location,
-        nowMillis, lastColumnId, schema, spec, properties, snapshot.snapshotId(), snapshots,
-        newSnapshotLog);
+        nowMillis, lastColumnId, schema, defaultSpecId, specs, properties,
+        snapshot.snapshotId(), snapshots, newSnapshotLog);
   }
 
   public TableMetadata replaceProperties(Map<String, String> newProperties) {
     ValidationException.check(newProperties != null, "Cannot set properties to null");
     return new TableMetadata(ops, null, location,
-        System.currentTimeMillis(), lastColumnId, schema, spec, newProperties, currentSnapshotId,
-        snapshots, snapshotLog);
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, newProperties,
+        currentSnapshotId, snapshots, snapshotLog);
   }
 
   public TableMetadata removeSnapshotLogEntries(Set<Long> snapshotIds) {
@@ -330,8 +373,8 @@ public class TableMetadata {
             Iterables.getLast(newSnapshotLog).snapshotId() == currentSnapshotId,
         "Cannot set invalid snapshot log: latest entry is not the current snapshot");
     return new TableMetadata(ops, null, location,
-        System.currentTimeMillis(), lastColumnId, schema, spec, properties, currentSnapshotId,
-        snapshots, newSnapshotLog);
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        currentSnapshotId, snapshots, newSnapshotLog);
   }
 
   public TableMetadata buildReplacement(Schema schema, PartitionSpec partitionSpec,
@@ -351,12 +394,28 @@ public class TableMetadata {
     }
     PartitionSpec freshSpec = specBuilder.build();
 
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    builder.putAll(this.properties);
-    builder.putAll(properties);
+    // if the spec already exists, use the same ID. otherwise, use 1 more than the highest ID.
+    int specId = 0;
+    for (Map.Entry<Integer, PartitionSpec> entry : specs.entrySet()) {
+      if (freshSpec.equals(entry.getValue())) {
+        specId = entry.getKey();
+        break;
+      } else if (specId <= entry.getKey()) {
+        specId = entry.getKey() + 1;
+      }
+    }
+
+    Map<Integer, PartitionSpec> newSpecs = Maps.newHashMap();
+    newSpecs.putAll(specs);
+    newSpecs.put(specId, freshSpec);
+
+    Map<String, String> newProperties = Maps.newHashMap();
+    newProperties.putAll(this.properties);
+    newProperties.putAll(properties);
 
     return new TableMetadata(ops, null, location,
-        System.currentTimeMillis(), lastColumnId.get(), freshSchema, freshSpec, properties, -1,
-        snapshots, ImmutableList.of());
+        System.currentTimeMillis(), lastColumnId.get(), freshSchema,
+        specId, ImmutableMap.copyOf(newSpecs), ImmutableMap.copyOf(newProperties),
+        -1, snapshots, ImmutableList.of());
   }
 }

--- a/core/src/main/java/com/netflix/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/com/netflix/iceberg/TableMetadataParser.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.TableMetadata.SnapshotLogEntry;
@@ -46,18 +47,22 @@ import java.util.SortedSet;
 
 public class TableMetadataParser {
 
-  private static final String FORMAT_VERSION = "format-version";
-  private static final String LOCATION = "location";
-  private static final String LAST_UPDATED_MILLIS = "last-updated-ms";
-  private static final String LAST_COLUMN_ID = "last-column-id";
-  private static final String SCHEMA = "schema";
-  private static final String PARTITION_SPEC = "partition-spec";
-  private static final String PROPERTIES = "properties";
-  private static final String CURRENT_SNAPSHOT_ID = "current-snapshot-id";
-  private static final String SNAPSHOTS = "snapshots";
-  private static final String SNAPSHOT_ID = "snapshot-id";
-  private static final String TIMESTAMP_MS = "timestamp-ms";
-  private static final String SNAPSHOT_LOG = "snapshot-log";
+  // visible for testing
+  static final String FORMAT_VERSION = "format-version";
+  static final String LOCATION = "location";
+  static final String LAST_UPDATED_MILLIS = "last-updated-ms";
+  static final String LAST_COLUMN_ID = "last-column-id";
+  static final String SCHEMA = "schema";
+  static final String PARTITION_SPEC = "partition-spec";
+  static final String PARTITION_SPECS = "partition-specs";
+  static final String SPEC_ID = "spec-id";
+  static final String DEFAULT_SPEC_ID = "default-spec-id";
+  static final String PROPERTIES = "properties";
+  static final String CURRENT_SNAPSHOT_ID = "current-snapshot-id";
+  static final String SNAPSHOTS = "snapshots";
+  static final String SNAPSHOT_ID = "snapshot-id";
+  static final String TIMESTAMP_MS = "timestamp-ms";
+  static final String SNAPSHOT_LOG = "snapshot-log";
 
   public static String toJson(TableMetadata metadata) {
     StringWriter writer = new StringWriter();
@@ -100,8 +105,21 @@ public class TableMetadataParser {
     generator.writeFieldName(SCHEMA);
     SchemaParser.toJson(metadata.schema(), generator);
 
+    // for older readers, continue writing the default spec as "partition-spec"
     generator.writeFieldName(PARTITION_SPEC);
     PartitionSpecParser.toJson(metadata.spec(), generator);
+
+    // write the default spec ID and spec list
+    generator.writeNumberField(DEFAULT_SPEC_ID, metadata.defaultSpecId());
+    generator.writeArrayFieldStart(PARTITION_SPECS);
+    for (Map.Entry<Integer, PartitionSpec> entry : metadata.specs().entrySet()) {
+      generator.writeStartObject();
+      generator.writeNumberField(SPEC_ID, entry.getKey());
+      generator.writeFieldName(PARTITION_SPEC);
+      PartitionSpecParser.toJson(entry.getValue(), generator);
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
 
     generator.writeObjectFieldStart(PROPERTIES);
     for (Map.Entry<String, String> keyValue : metadata.properties().entrySet()) {
@@ -150,7 +168,35 @@ public class TableMetadataParser {
     String location = JsonUtil.getString(LOCATION, node);
     int lastAssignedColumnId = JsonUtil.getInt(LAST_COLUMN_ID, node);
     Schema schema = SchemaParser.fromJson(node.get(SCHEMA));
-    PartitionSpec spec = PartitionSpecParser.fromJson(schema, node.get(PARTITION_SPEC));
+
+    JsonNode specArray = node.get(PARTITION_SPECS);
+    Map<Integer, PartitionSpec> specs;
+    int defaultSpecId = 0;
+    if (specArray != null) {
+      Preconditions.checkArgument(specArray.isArray(),
+          "Cannot parse partition specs from non-array: %s", specArray);
+      // default spec ID is required when the spec array is present
+      defaultSpecId = JsonUtil.getInt(DEFAULT_SPEC_ID, node);
+
+      // parse the spec array
+      ImmutableMap.Builder<Integer, PartitionSpec> builder = ImmutableMap.builder();
+      Iterator<JsonNode> iterator = specArray.iterator();
+      while (iterator.hasNext()) {
+        JsonNode specObject = iterator.next();
+        int specId = JsonUtil.getInt(SPEC_ID, specObject);
+        PartitionSpec spec = PartitionSpecParser.fromJson(schema, specObject.get(PARTITION_SPEC));
+        builder.put(specId, spec);
+      }
+      specs = builder.build();
+
+    } else {
+      // partition spec is required for older readers, but is always set to the default if the spec
+      // array is set. it is only used to default the spec map is missing, indicating that the
+      // table metadata was written by an older writer.
+      PartitionSpec spec = PartitionSpecParser.fromJson(schema, node.get(PARTITION_SPEC));
+      specs = ImmutableMap.of(defaultSpecId, spec);
+    }
+
     Map<String, String> properties = JsonUtil.getStringMap(PROPERTIES, node);
     long currentVersionId = JsonUtil.getLong(CURRENT_SNAPSHOT_ID, node);
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
@@ -177,8 +223,8 @@ public class TableMetadataParser {
     }
 
     return new TableMetadata(ops, file, location,
-        lastUpdatedMillis, lastAssignedColumnId, schema, spec, properties, currentVersionId,
-        snapshots, ImmutableList.copyOf(entries.iterator()));
+        lastUpdatedMillis, lastAssignedColumnId, schema, defaultSpecId, specs, properties,
+        currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()));
   }
 
 }

--- a/core/src/test/java/com/netflix/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/com/netflix/iceberg/TestMergeAppend.java
@@ -19,7 +19,6 @@
 
 package com.netflix.iceberg;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.ManifestEntry.Status;
@@ -236,16 +235,14 @@ public class TestMergeAppend extends TableTestBase {
         1, base.currentSnapshot().manifests().size());
     String initialManifest = base.currentSnapshot().manifests().get(0);
 
-    PartitionSpec newSpec = PartitionSpec.builderFor(SCHEMA)
+    // build the new spec using the table's schema, which uses fresh IDs
+    PartitionSpec newSpec = PartitionSpec.builderFor(base.schema())
         .bucket("data", 16)
         .bucket("id", 4)
         .build();
 
     // commit the new partition spec to the table manually
-    TableMetadata updated = new TableMetadata(table.ops(), null, base.location(),
-        System.currentTimeMillis(), base.lastColumnId(), base.schema(), newSpec, base.properties(),
-        base.currentSnapshot().snapshotId(), base.snapshots(), ImmutableList.of());
-    table.ops().commit(base, updated);
+    table.ops().commit(base, base.updatePartitionSpec(newSpec));
 
     DataFile newFileC = DataFiles.builder(newSpec)
         .copy(FILE_C)
@@ -284,16 +281,14 @@ public class TestMergeAppend extends TableTestBase {
         2, base.currentSnapshot().manifests().size());
     String manifest = base.currentSnapshot().manifests().get(0);
 
-    PartitionSpec newSpec = PartitionSpec.builderFor(SCHEMA)
+    // build the new spec using the table's schema, which uses fresh IDs
+    PartitionSpec newSpec = PartitionSpec.builderFor(base.schema())
         .bucket("data", 16)
         .bucket("id", 4)
         .build();
 
     // commit the new partition spec to the table manually
-    TableMetadata updated = new TableMetadata(table.ops(), null, base.location(),
-        System.currentTimeMillis(), base.lastColumnId(), base.schema(), newSpec, base.properties(),
-        base.currentSnapshot().snapshotId(), base.snapshots(), ImmutableList.of());
-    table.ops().commit(base, updated);
+    table.ops().commit(base, base.updatePartitionSpec(newSpec));
 
     DataFile newFileC = DataFiles.builder(newSpec)
         .copy(FILE_C)


### PR DESCRIPTION
The purpose of this change is to enable future partition spec changes
and to assign IDs to specs that can be easily encoded in an Avro file
that tracks a snapshot's manifests.

This updates TableMetadata and the metadata parser to support multiple
partition specs. This change is forward-compatible for older readers
because the "partition-spec" field in table metadata is still set to the
default spec.

Multiple specs are now stored in an array in table metadata called
"partition-specs". Each entry in the array is an object with two fields,
a "spec-id" field with an integer ID value, and "fields" with a partition
spec value (an array of partition fields). This also adds
"default-spec-id" that points to the spec that should be used when
writing.