### PR TITLE
Ignore .avro, .avro.crc, and hive/derby.log.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build
 out
 # web site build
 site/site
+*.avro
+*.avro.crc
+hive/derby.log


### PR DESCRIPTION
These files are generated when running tests locally using Gradle. Longer term fix is to generate these files under the machine's `/tmp` folder instead, instead of inside the repository itself.