### PR TITLE
Set derby log system property earlier

### DIFF
--- a/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
+++ b/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
@@ -152,7 +152,7 @@ class HiveTableBaseTest {
 
   private String getDerbyPath() {
     final File metastore_db = new File(hiveLocalDir, "metastore_db");
-    return metastore_db.getAbsolutePath();
+    return metastore_db.getPath();
   }
 
   private TServer thriftServer() throws IOException,

--- a/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
+++ b/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
@@ -146,7 +146,6 @@ class HiveTableBaseTest {
     hiveConf.set(COMPACTOR_INITIATOR_ON.getVarname(), "true");
     hiveConf.set(COMPACTOR_WORKER_THREADS.getVarname(), "1");
     hiveConf.set(HIVE_SUPPORT_CONCURRENCY.getVarname(), "true");
-    hiveConf.set("derby.system.home", getDerbyPath());
 
     return hiveConf;
   }


### PR DESCRIPTION
Otherwise a `hive/derby.log` file is generated, likely by default when starting the thrift server.