### PR TITLE
Update ScanSummary behavior.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/Table.java
+++ b/api/src/main/java/com/netflix/iceberg/Table.java
@@ -69,7 +69,7 @@ public interface Table {
   String location();
 
   /**
-   * Get the current {@link Snapshot snapshot} for this table.
+   * Get the current {@link Snapshot snapshot} for this table, or null if there are no snapshots.
    *
    * @return the current table Snapshot.
    */


### PR DESCRIPTION
* Use all manifests created after the start of the time range
* Fail when the time range may include expired snapshots
* Filter manifest files in ManifestGroup using the data filter