### PR TITLE
Lazily submit tasks in ParallelIterable and add cancellation.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/io/CloseableGroup.java
+++ b/api/src/main/java/com/netflix/iceberg/io/CloseableGroup.java
@@ -47,6 +47,9 @@ public abstract class CloseableGroup implements Closeable {
 
     public ClosingIterable(Iterable<T> iterable, Iterable<Closeable> closeables) {
       this.iterable = iterable;
+      if (iterable instanceof Closeable) {
+        addCloseable((Closeable) iterable);
+      }
       for (Closeable closeable : closeables) {
         addCloseable(closeable);
       }

--- a/core/src/main/java/com/netflix/iceberg/BaseTableScan.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTableScan.java
@@ -34,7 +34,6 @@ import com.netflix.iceberg.expressions.Binder;
 import com.netflix.iceberg.expressions.Expression;
 import com.netflix.iceberg.expressions.Expressions;
 import com.netflix.iceberg.expressions.InclusiveManifestEvaluator;
-import com.netflix.iceberg.expressions.Projections;
 import com.netflix.iceberg.expressions.ResidualEvaluator;
 import com.netflix.iceberg.io.CloseableIterable;
 import com.netflix.iceberg.types.TypeUtil;
@@ -51,7 +50,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.netflix.iceberg.util.ThreadPools.getPlannerPool;
 import static com.netflix.iceberg.util.ThreadPools.getWorkerPool;
 
 /**
@@ -190,7 +188,7 @@ class BaseTableScan implements TableScan {
 
       if (PLAN_SCANS_WITH_WORKER_POOL && snapshot.manifests().size() > 1) {
         return CloseableIterable.combine(
-            new ParallelIterable<>(readers, getPlannerPool(), getWorkerPool()),
+            new ParallelIterable<>(readers, getWorkerPool()),
             toClose);
       } else {
         return CloseableIterable.combine(Iterables.concat(readers), toClose);

--- a/core/src/main/java/com/netflix/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/com/netflix/iceberg/util/ThreadPools.java
@@ -27,41 +27,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class ThreadPools {
-  public static final String PLANNER_THREAD_POOL_SIZE_PROP =
-      SystemProperties.PLANNER_THREAD_POOL_SIZE_PROP;
   public static final String WORKER_THREAD_POOL_SIZE_PROP =
       SystemProperties.WORKER_THREAD_POOL_SIZE_PROP;
 
-  private static ExecutorService PLANNER_POOL = MoreExecutors.getExitingExecutorService(
-      (ThreadPoolExecutor) Executors.newFixedThreadPool(
-          getPoolSize(PLANNER_THREAD_POOL_SIZE_PROP, 4),
-          new ThreadFactoryBuilder()
-              .setDaemon(true)
-              .setNameFormat("iceberg-planner-pool-%d")
-              .build()));
+  public static final int WORKER_THREAD_POOL_SIZE = getPoolSize(
+      WORKER_THREAD_POOL_SIZE_PROP,
+      Runtime.getRuntime().availableProcessors());
 
   private static ExecutorService WORKER_POOL = MoreExecutors.getExitingExecutorService(
       (ThreadPoolExecutor) Executors.newFixedThreadPool(
-          getPoolSize(WORKER_THREAD_POOL_SIZE_PROP, Runtime.getRuntime().availableProcessors()),
+          WORKER_THREAD_POOL_SIZE,
           new ThreadFactoryBuilder()
               .setDaemon(true)
               .setNameFormat("iceberg-worker-pool-%d")
               .build()));
-
-  /**
-   * Return an {@link ExecutorService} that uses the "planner" thread-pool.
-   * <p>
-   * The size of the planner pool limits the number of concurrent planning operations in the base
-   * table implementation.
-   * <p>
-   * The size of this thread-pool is controlled by the Java system property
-   * {@code iceberg.planner.num-threads}.
-   *
-   * @return an {@link ExecutorService} that uses the planner pool
-   */
-  public static ExecutorService getPlannerPool() {
-    return PLANNER_POOL;
-  }
 
   /**
    * Return an {@link ExecutorService} that uses the "worker" thread-pool.

--- a/core/src/test/java/com/netflix/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/com/netflix/iceberg/hadoop/TestHadoopCommits.java
@@ -55,7 +55,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
         metadataDir.exists() && metadataDir.isDirectory());
     Assert.assertTrue("Should create v1 metadata",
         version(1).exists() && version(1).isFile());
-    Assert.assertFalse("Should not create v2 or newer verions",
+    Assert.assertFalse("Should not create v2 or newer versions",
         version(2).exists());
     Assert.assertTrue("Should create version hint file",
         versionHintFile.exists());


### PR DESCRIPTION
This removes the planner pool from ParallelIterable, which was used to
submit all of the iterable tasks in parallel. This was used to queue
up tasks to read every manifest in a snapshot. However, when a caller
stopped reading early, all tasks would still run and add results to the
queue.

Now, tasks are submitted from the thread consuming the iterator as it
runs hasNext. If the caller stops consuming the iterator, then no new
tasks are submitted. This also keeps track of the submitted tasks and
will cancel them when the iterator is closed.