### PR TITLE
Fix commit retry with manfiest lists.

### DIFF
--- a/core/src/test/java/com/netflix/iceberg/TestFastAppend.java
+++ b/core/src/test/java/com/netflix/iceberg/TestFastAppend.java
@@ -171,7 +171,32 @@ public class TestFastAppend extends TableTestBase {
   }
 
   @Test
-  public void testRecovery() {
+  public void testRecoveryWithManifestList() {
+    table.updateProperties().set(TableProperties.MANIFEST_LISTS_ENABLED, "true").commit();
+
+    // inject 3 failures, the last try will succeed
+    TestTables.TestTableOperations ops = table.ops();
+    ops.failCommits(3);
+
+    AppendFiles append = table.newFastAppend().appendFile(FILE_B);
+    Snapshot pending = append.apply();
+    ManifestFile newManifest = pending.manifests().get(0);
+    Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
+
+    append.commit();
+
+    TableMetadata metadata = readMetadata();
+
+    validateSnapshot(null, metadata.currentSnapshot(), FILE_B);
+    Assert.assertTrue("Should commit same new manifest", new File(newManifest.path()).exists());
+    Assert.assertTrue("Should commit the same new manifest",
+        metadata.currentSnapshot().manifests().contains(newManifest));
+  }
+
+  @Test
+  public void testRecoveryWithoutManifestList() {
+    table.updateProperties().set(TableProperties.MANIFEST_LISTS_ENABLED, "false").commit();
+
     // inject 3 failures, the last try will succeed
     TestTables.TestTableOperations ops = table.ops();
     ops.failCommits(3);


### PR DESCRIPTION
A manifest list is created for every commit attempt. Before this update,
the same file was used, which caused retries to fail trying to create
the same list file. This uses a new location for every manifest list,
keeps track of old lists, and cleans up unused lists after a commit
succeeds.