### PR TITLE
Use a UUID-based approach to generate snapshot ids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,18 +138,24 @@ project(':iceberg-data') {
 }
 
 project(':iceberg-hive') {
-    dependencies {
-      compile project(':iceberg-core')
+  dependencies {
+    compile project(':iceberg-core')
 
-      compileOnly "org.apache.hive:hive-standalone-metastore:$hiveVersion"
+    compileOnly "org.apache.avro:avro:$avroVersion"
 
-      testCompile "org.apache.hive:hive-exec:3.1.0"
-
-      compileOnly('org.apache.hadoop:hadoop-client:2.7.3') {
-        exclude group: 'org.apache.avro', module: 'avro'
-        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-      }
+    compileOnly("org.apache.hive:hive-standalone-metastore:$hiveVersion") {
+      exclude group: 'org.apache.avro', module: 'avro'
     }
+
+    testCompile("org.apache.hive:hive-exec:$hiveVersion") {
+      exclude group: 'org.apache.avro', module: 'avro'
+    }
+
+    compileOnly("org.apache.hadoop:hadoop-client:$hadoopVersion") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    }
+  }
 }
 
 project(':iceberg-orc') {

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
@@ -134,11 +134,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     return fileIo;
   }
 
-  @Override
-  public long newSnapshotId() {
-    return System.currentTimeMillis();
-  }
-
   private String newTableMetadataFilePath(String baseLocation, int newVersion) {
     return String.format("%s/%s/%05d-%s%s",
             baseLocation,

--- a/core/src/main/java/com/netflix/iceberg/TableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/TableOperations.java
@@ -19,6 +19,8 @@
 
 package com.netflix.iceberg;
 
+import java.util.UUID;
+
 import com.netflix.iceberg.io.OutputFile;
 
 /**
@@ -73,6 +75,11 @@ public interface TableOperations {
    *
    * @return a long snapshot ID
    */
-  long newSnapshotId();
+  default long newSnapshotId() {
+    UUID uuid = UUID.randomUUID();
+    long mostSignificantBits = uuid.getMostSignificantBits();
+    long leastSignificantBits = uuid.getLeastSignificantBits();
+    return Math.abs(mostSignificantBits ^ leastSignificantBits);
+  }
 
 }

--- a/core/src/main/java/com/netflix/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/hadoop/HadoopTableOperations.java
@@ -154,11 +154,6 @@ public class HadoopTableOperations implements TableOperations {
     return metadataPath(fileName).toString();
   }
 
-  @Override
-  public long newSnapshotId() {
-    return System.currentTimeMillis();
-  }
-
   private Path metadataFile(int version) {
     return metadataPath("v" + version + getFileExtension(conf));
   }

--- a/hive/src/main/java/com/netflix/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/com/netflix/iceberg/hive/HiveTableOperations.java
@@ -57,6 +57,9 @@ import static java.lang.String.format;
 /**
  * TODO we should be able to extract some more commonalities to BaseMetastoreTableOperations to
  * avoid code duplication between this class and Metacat Tables.
+ *
+ * Note! This class is not thread-safe as {@link ThriftHiveMetastore.Client} does not behave
+ * correctly in a multi-threaded environment.
  */
 public class HiveTableOperations extends BaseMetastoreTableOperations {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTableOperations.class);

--- a/hive/src/test/java/com/netflix/iceberg/hive/HiveTablesTest.java
+++ b/hive/src/test/java/com/netflix/iceberg/hive/HiveTablesTest.java
@@ -15,8 +15,12 @@
  */
 package com.netflix.iceberg.hive;
 
+import com.netflix.iceberg.DataFile;
+import com.netflix.iceberg.DataFiles;
+import com.netflix.iceberg.FileFormat;
 import com.netflix.iceberg.exceptions.CommitFailedException;
 import com.netflix.iceberg.types.Types;
+import com.netflix.iceberg.util.Tasks;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 import org.junit.Assert;
@@ -24,11 +28,14 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.netflix.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static com.netflix.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static com.netflix.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static com.netflix.iceberg.util.ThreadPools.getWorkerPool;
 
 public class HiveTablesTest extends HiveTableBaseTest {
   @Test
@@ -86,5 +93,39 @@ public class HiveTablesTest extends HiveTableBaseTest {
     icebergTable.updateSchema()
             .addColumn("data", Types.LongType.get())
             .commit();
+  }
+
+  @Test
+  public void testConcurrentFastAppends() {
+    HiveTables hiveTables = new HiveTables(hiveConf);
+    com.netflix.iceberg.Table icebergTable = hiveTables.load(DB_NAME, TABLE_NAME);
+    com.netflix.iceberg.Table anotherIcebergTable = hiveTables.load(DB_NAME, TABLE_NAME);
+
+    String fileName = UUID.randomUUID().toString();
+    DataFile file = DataFiles.builder(icebergTable.spec())
+      .withPath(FileFormat.PARQUET.addExtension(fileName))
+      .withRecordCount(2)
+      .withFileSizeInBytes(0)
+      .build();
+
+    Tasks.foreach(icebergTable, anotherIcebergTable)
+      .stopOnFailure().throwFailureWhenFinished()
+      .executeWith(getWorkerPool())
+      .run(table -> {
+        for (int numCommittedFiles = 0; numCommittedFiles < 10; numCommittedFiles++) {
+          long commitStartTime = System.currentTimeMillis();
+          table.newFastAppend().appendFile(file).commit();
+          long commitEndTime = System.currentTimeMillis();
+          long commitDuration = commitEndTime - commitStartTime;
+          try {
+            TimeUnit.MILLISECONDS.sleep(200 - commitDuration);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+
+    icebergTable.refresh();
+    Assert.assertEquals(20, icebergTable.currentSnapshot().manifests().size());
   }
 }


### PR DESCRIPTION
This PR proposes a new approach for generating snapshot ids. 

Right now, Iceberg uses `System$currentTimeMillis()` as snapshot ids. If we have two concurrent writers, they might produce snapshots ids at the same time (up to milliseconds). As a consequence, we will have different snapshots with identical ids. Of course, only one writer will succeed. The failed one will retry but it will keep the old snapshot id (according to `SnapshotUpdate$snapshotId`). This will become a problem in `TableMetadata` when Iceberg builds `ImmutableMap<Long, Snapshot>`.

One way to eliminate collisions is to generate new snapshot ids on retries. However, this would mean Iceberg has to rewrite all created manifest files for the commit.

The proposed approach relies on UUID and XOR operations. To make snapshot ids positive, the result is wrapped into `Math$abs`. An alternative way to generate positive ids is `result & Long.MAX_VALUE`. Both options have identical performance (around 1 microsecond).

We can also consider [other approaches to generate unique long values](https://stackoverflow.com/a/5685869) or even switch to a different representation (e.g., UUID). The latter will have an impact on the metadata file sizes. Also, we do not have to make ids ordered as this is not required by logic and Iceberg already stores `timestamp-ms` for each snapshot.