### PR TITLE
Add support for field documentation.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/Schema.java
+++ b/api/src/main/java/com/netflix/iceberg/Schema.java
@@ -226,7 +226,7 @@ public class Schema implements Serializable {
   public String toString() {
     return String.format("table {\n%s\n}",
         NEWLINE.join(struct.fields().stream()
-            .map(f -> "  " + f)
+            .map(f -> "  " + f + (f.doc() == null ? "" : " COMMENT '" + f.doc() + "'"))
             .collect(Collectors.toList())));
   }
 }

--- a/api/src/main/java/com/netflix/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/com/netflix/iceberg/types/AssignFreshIds.java
@@ -53,9 +53,9 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
       Types.NestedField field = fields.get(i);
       Type type = types.next();
       if (field.isOptional()) {
-        newFields.add(Types.NestedField.optional(newIds.get(i), field.name(), type));
+        newFields.add(Types.NestedField.optional(newIds.get(i), field.name(), type, field.doc()));
       } else {
-        newFields.add(Types.NestedField.required(newIds.get(i), field.name(), type));
+        newFields.add(Types.NestedField.required(newIds.get(i), field.name(), type, field.doc()));
       }
     }
 

--- a/api/src/main/java/com/netflix/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/com/netflix/iceberg/types/PruneColumns.java
@@ -53,10 +53,10 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
         sameTypes = false; // signal that some types were altered
         if (field.isOptional()) {
           selectedFields.add(
-              Types.NestedField.optional(field.fieldId(), field.name(), projectedType));
+              Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc()));
         } else {
           selectedFields.add(
-              Types.NestedField.required(field.fieldId(), field.name(), projectedType));
+              Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc()));
         }
       }
     }

--- a/api/src/main/java/com/netflix/iceberg/types/ReassignIds.java
+++ b/api/src/main/java/com/netflix/iceberg/types/ReassignIds.java
@@ -58,9 +58,9 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
       Types.NestedField field = fields.get(i);
       int sourceFieldId = sourceStruct.field(field.name()).fieldId();
       if (field.isRequired()) {
-        newFields.add(Types.NestedField.required(sourceFieldId, field.name(), types.get(i)));
+        newFields.add(Types.NestedField.required(sourceFieldId, field.name(), types.get(i), field.doc()));
       } else {
-        newFields.add(Types.NestedField.optional(sourceFieldId, field.name(), types.get(i)));
+        newFields.add(Types.NestedField.optional(sourceFieldId, field.name(), types.get(i), field.doc()));
       }
     }
 

--- a/api/src/main/java/com/netflix/iceberg/types/Types.java
+++ b/api/src/main/java/com/netflix/iceberg/types/Types.java
@@ -411,25 +411,35 @@ public class Types {
 
   public static class NestedField implements Serializable {
     public static NestedField optional(int id, String name, Type type) {
-      return new NestedField(true, id, name, type);
+      return new NestedField(true, id, name, type, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc) {
+      return new NestedField(true, id, name, type, doc);
     }
 
     public static NestedField required(int id, String name, Type type) {
-      return new NestedField(false, id, name, type);
+      return new NestedField(false, id, name, type, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc) {
+      return new NestedField(false, id, name, type, doc);
     }
 
     private final boolean isOptional;
     private final int id;
     private final String name;
     private final Type type;
+    private final String doc;
 
-    private NestedField(boolean isOptional, int id, String name, Type type) {
+    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
       this.isOptional = isOptional;
       this.id = id;
       this.name = name;
       this.type = type;
+      this.doc = doc;
     }
 
     public boolean isOptional() {
@@ -452,6 +462,10 @@ public class Types {
       return type;
     }
 
+    public String doc() {
+      return doc;
+    }
+
     @Override
     public String toString() {
       return String.format("%d: %s: %s %s",
@@ -472,6 +486,8 @@ public class Types {
       } else if (id != that.id) {
         return false;
       } else if (!name.equals(that.name)) {
+        return false;
+      } else if (!Objects.equals(doc, that.doc)) {
         return false;
       }
       return type.equals(that.type);

--- a/api/src/main/java/com/netflix/iceberg/types/Types.java
+++ b/api/src/main/java/com/netflix/iceberg/types/Types.java
@@ -469,7 +469,8 @@ public class Types {
     @Override
     public String toString() {
       return String.format("%d: %s: %s %s",
-          id, name, isOptional ? "optional" : "required", type);
+          id, name, isOptional ? "optional" : "required", type) +
+          (doc != null ? " (" + doc + ")" : "");
     }
 
     @Override

--- a/core/src/main/java/com/netflix/iceberg/SchemaParser.java
+++ b/core/src/main/java/com/netflix/iceberg/SchemaParser.java
@@ -44,6 +44,7 @@ public class SchemaParser {
   private static final String ELEMENT = "element";
   private static final String KEY = "key";
   private static final String VALUE = "value";
+  private static final String DOC = "doc";
   private static final String NAME = "name";
   private static final String ID = "id";
   private static final String ELEMENT_ID = "element-id";
@@ -65,6 +66,9 @@ public class SchemaParser {
       generator.writeBooleanField(REQUIRED, field.isRequired());
       generator.writeFieldName(TYPE);
       toJson(field.type(), generator);
+      if (field.doc() != null) {
+        generator.writeStringField(DOC, field.doc());
+      }
       generator.writeEndObject();
     }
     generator.writeEndArray();
@@ -185,11 +189,12 @@ public class SchemaParser {
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(field.get(TYPE));
 
+      String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);
       if (isRequired) {
-        fields.add(Types.NestedField.required(id, name, type));
+        fields.add(Types.NestedField.required(id, name, type, doc));
       } else {
-        fields.add(Types.NestedField.optional(id, name, type));
+        fields.add(Types.NestedField.optional(id, name, type, doc));
       }
     }
 

--- a/core/src/main/java/com/netflix/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/com/netflix/iceberg/util/JsonUtil.java
@@ -73,6 +73,16 @@ public class JsonUtil {
     return pNode.asText();
   }
 
+  public static String getStringOrNull(String property, JsonNode node) {
+    if (!node.has(property)) {
+      return null;
+    }
+    JsonNode pNode = node.get(property);
+    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isTextual(),
+        "Cannot parse %s from non-string value: %s", property, pNode);
+    return pNode.asText();
+  }
+
   public static Map<String, String> getStringMap(String property, JsonNode node) {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing map %s", property);
     JsonNode pNode = node.get(property);

--- a/core/src/test/java/com/netflix/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/com/netflix/iceberg/TestSchemaUpdate.java
@@ -41,7 +41,7 @@ public class TestSchemaUpdate {
       optional(3, "preferences", Types.StructType.of(
           required(8, "feature1", Types.BooleanType.get()),
           optional(9, "feature2", Types.BooleanType.get())
-      )),
+      ), "struct of named boolean options"),
       required(4, "locations", Types.MapType.ofRequired(10, 11,
           Types.StructType.of(
               required(20, "address", Types.StringType.get()),
@@ -52,19 +52,19 @@ public class TestSchemaUpdate {
           Types.StructType.of(
               required(12, "lat", Types.FloatType.get()),
               required(13, "long", Types.FloatType.get())
-          ))),
+          )), "map of address to coordinate"),
       optional(5, "points", Types.ListType.ofOptional(14,
           Types.StructType.of(
               required(15, "x", Types.LongType.get()),
               required(16, "y", Types.LongType.get())
-          ))),
+          )), "2-D cartesian points"),
       required(6, "doubles", Types.ListType.ofRequired(17,
           Types.DoubleType.get()
       )),
       optional(7, "properties", Types.MapType.ofOptional(18, 19,
           Types.StringType.get(),
           Types.StringType.get()
-      ))
+      ), "string map of properties")
   );
 
   private static final int SCHEMA_LAST_COLUMN_ID = 23;
@@ -104,7 +104,7 @@ public class TestSchemaUpdate {
         optional(3, "preferences", Types.StructType.of(
             required(8, "feature1", Types.BooleanType.get()),
             optional(9, "feature2", Types.BooleanType.get())
-        )),
+        ), "struct of named boolean options"),
         required(4, "locations", Types.MapType.ofRequired(10, 11,
             Types.StructType.of(
                 required(20, "address", Types.StringType.get()),
@@ -115,19 +115,19 @@ public class TestSchemaUpdate {
             Types.StructType.of(
                 required(12, "lat", Types.DoubleType.get()),
                 required(13, "long", Types.DoubleType.get())
-            ))),
+            )), "map of address to coordinate"),
         optional(5, "points", Types.ListType.ofOptional(14,
             Types.StructType.of(
                 required(15, "x", Types.LongType.get()),
                 required(16, "y", Types.LongType.get())
-            ))),
+            )), "2-D cartesian points"),
         required(6, "doubles", Types.ListType.ofRequired(17,
             Types.DoubleType.get()
         )),
         optional(7, "properties", Types.MapType.ofOptional(18, 19,
             Types.StringType.get(),
             Types.StringType.get()
-        ))
+        ), "string map of properties")
     );
 
     Schema updated = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -185,7 +185,7 @@ public class TestSchemaUpdate {
         optional(3, "options", Types.StructType.of(
             required(8, "feature1", Types.BooleanType.get()),
             optional(9, "newfeature", Types.BooleanType.get())
-        )),
+        ), "struct of named boolean options"),
         required(4, "locations", Types.MapType.ofRequired(10, 11,
             Types.StructType.of(
                 required(20, "address", Types.StringType.get()),
@@ -196,19 +196,19 @@ public class TestSchemaUpdate {
             Types.StructType.of(
                 required(12, "latitude", Types.FloatType.get()),
                 required(13, "long", Types.FloatType.get())
-            ))),
+            )), "map of address to coordinate"),
         optional(5, "points", Types.ListType.ofOptional(14,
             Types.StructType.of(
                 required(15, "X", Types.LongType.get()),
                 required(16, "y.y", Types.LongType.get())
-            ))),
+            )), "2-D cartesian points"),
         required(6, "doubles", Types.ListType.ofRequired(17,
             Types.DoubleType.get()
         )),
         optional(7, "properties", Types.MapType.ofOptional(18, 19,
             Types.StringType.get(),
             Types.StringType.get()
-        ))
+        ), "string map of properties")
     );
 
     Schema renamed = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -231,7 +231,7 @@ public class TestSchemaUpdate {
         optional(3, "preferences", Types.StructType.of(
             required(8, "feature1", Types.BooleanType.get()),
             optional(9, "feature2", Types.BooleanType.get())
-        )),
+        ), "struct of named boolean options"),
         required(4, "locations", Types.MapType.ofRequired(10, 11,
             Types.StructType.of(
                 required(20, "address", Types.StringType.get()),
@@ -243,21 +243,21 @@ public class TestSchemaUpdate {
                 required(12, "lat", Types.FloatType.get()),
                 required(13, "long", Types.FloatType.get()),
                 optional(25, "alt", Types.FloatType.get())
-            ))),
+            )), "map of address to coordinate"),
         optional(5, "points", Types.ListType.ofOptional(14,
             Types.StructType.of(
                 required(15, "x", Types.LongType.get()),
                 required(16, "y", Types.LongType.get()),
                 optional(26, "z", Types.LongType.get()),
                 optional(27, "t.t", Types.LongType.get())
-            ))),
+            )), "2-D cartesian points"),
         required(6, "doubles", Types.ListType.ofRequired(17,
             Types.DoubleType.get()
         )),
         optional(7, "properties", Types.MapType.ofOptional(18, 19,
             Types.StringType.get(),
             Types.StringType.get()
-        )),
+        ), "string map of properties"),
         optional(24, "toplevel", Types.DecimalType.of(9, 2))
     );
 
@@ -366,12 +366,12 @@ public class TestSchemaUpdate {
   @Test
   public void testMixedChanges() {
     Schema expected = new Schema(
-        required(1, "id", Types.LongType.get()),
+        required(1, "id", Types.LongType.get(), "unique id"),
         optional(2, "json", Types.StringType.get()),
         optional(3, "options", Types.StructType.of(
             required(8, "feature1", Types.BooleanType.get()),
             optional(9, "newfeature", Types.BooleanType.get())
-        )),
+        ), "struct of named boolean options"),
         required(4, "locations", Types.MapType.ofRequired(10, 11,
             Types.StructType.of(
                 required(20, "address", Types.StringType.get()),
@@ -380,16 +380,16 @@ public class TestSchemaUpdate {
                 required(23, "zip", Types.IntegerType.get())
             ),
             Types.StructType.of(
-                required(12, "latitude", Types.DoubleType.get()),
+                required(12, "latitude", Types.DoubleType.get(), "latitude"),
                 optional(25, "alt", Types.FloatType.get())
-            ))),
+            )), "map of address to coordinate"),
         optional(5, "points", Types.ListType.ofOptional(14,
             Types.StructType.of(
                 required(15, "X", Types.LongType.get()),
                 required(16, "y.y", Types.LongType.get()),
                 optional(26, "z", Types.LongType.get()),
-                optional(27, "t.t", Types.LongType.get())
-            ))),
+                optional(27, "t.t", Types.LongType.get(), "name with '.'")
+            )), "2-D cartesian points"),
         required(6, "doubles", Types.ListType.ofRequired(17,
             Types.DoubleType.get()
         )),
@@ -400,15 +400,16 @@ public class TestSchemaUpdate {
         .addColumn("toplevel", Types.DecimalType.of(9, 2))
         .addColumn("locations", "alt", Types.FloatType.get()) // map of structs
         .addColumn("points", "z", Types.LongType.get()) // list of structs
-        .addColumn("points", "t.t", Types.LongType.get()) // name with '.'
+        .addColumn("points", "t.t", Types.LongType.get(), "name with '.'")
         .renameColumn("data", "json")
         .renameColumn("preferences", "options")
         .renameColumn("preferences.feature2", "newfeature") // inside a renamed column
         .renameColumn("locations.lat", "latitude")
         .renameColumn("points.x", "X")
         .renameColumn("points.y", "y.y") // has a '.' in the field name
-        .updateColumn("id", Types.LongType.get())
+        .updateColumn("id", Types.LongType.get(), "unique id")
         .updateColumn("locations.lat", Types.DoubleType.get()) // use the original name
+        .updateColumnDoc("locations.lat", "latitude")
         .deleteColumn("locations.long")
         .deleteColumn("properties")
         .apply();
@@ -572,6 +573,32 @@ public class TestSchemaUpdate {
     AssertHelpers.assertThrows("Should reject update map key",
         IllegalArgumentException.class, "Cannot update map keys", () -> {
           new SchemaUpdate(schema, 3).updateColumn("m.key", Types.LongType.get()).apply();
+        }
+    );
+  }
+
+  @Test
+  public void testUpdateAddedColumnDoc() {
+    Schema schema = new Schema(required(1, "i", Types.IntegerType.get()));
+    AssertHelpers.assertThrows("Should reject add and update doc",
+        IllegalArgumentException.class, "Cannot update missing column", () -> {
+          new SchemaUpdate(schema, 3)
+              .addColumn("value", Types.LongType.get())
+              .updateColumnDoc("value", "a value")
+              .apply();
+        }
+    );
+  }
+
+  @Test
+  public void testUpdateDeletedColumnDoc() {
+    Schema schema = new Schema(required(1, "i", Types.IntegerType.get()));
+    AssertHelpers.assertThrows("Should reject add and update doc",
+        IllegalArgumentException.class, "Cannot update a column that will be deleted", () -> {
+          new SchemaUpdate(schema, 3)
+              .deleteColumn("i")
+              .updateColumnDoc("i", "a value")
+              .apply();
         }
     );
   }

--- a/core/src/test/java/com/netflix/iceberg/TestTableMetadataJson.java
+++ b/core/src/test/java/com/netflix/iceberg/TestTableMetadataJson.java
@@ -60,7 +60,7 @@ public class TestTableMetadataJson {
   public void testJsonConversion() throws Exception {
     Schema schema = new Schema(
         Types.NestedField.required(1, "x", Types.LongType.get()),
-        Types.NestedField.required(2, "y", Types.LongType.get()),
+        Types.NestedField.required(2, "y", Types.LongType.get(), "comment"),
         Types.NestedField.required(3, "z", Types.LongType.get())
     );
 

--- a/core/src/test/java/com/netflix/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/com/netflix/iceberg/hadoop/HadoopTableTestBase.java
@@ -46,18 +46,18 @@ import static com.netflix.iceberg.types.Types.NestedField.required;
 public class HadoopTableTestBase {
   // Schema passed to create tables
   static final Schema SCHEMA = new Schema(
-      required(3, "id", Types.IntegerType.get()),
+      required(3, "id", Types.IntegerType.get(), "unique ID"),
       required(4, "data", Types.StringType.get())
   );
 
   // This is the actual schema for the table, with column IDs reassigned
   static final Schema TABLE_SCHEMA = new Schema(
-      required(1, "id", Types.IntegerType.get()),
+      required(1, "id", Types.IntegerType.get(), "unique ID"),
       required(2, "data", Types.StringType.get())
   );
 
   static final Schema UPDATED_SCHEMA = new Schema(
-      required(1, "id", Types.IntegerType.get()),
+      required(1, "id", Types.IntegerType.get(), "unique ID"),
       required(2, "data", Types.StringType.get()),
       optional(3, "n", Types.IntegerType.get())
   );

--- a/spark/src/main/java/com/netflix/iceberg/spark/SparkTypeToType.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/SparkTypeToType.java
@@ -80,10 +80,12 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
         id = getNextId();
       }
 
+      String doc = field.getComment().isDefined() ? field.getComment().get() : null;
+
       if (field.nullable()) {
-        newFields.add(Types.NestedField.optional(id, field.name(), type));
+        newFields.add(Types.NestedField.optional(id, field.name(), type, doc));
       } else {
-        newFields.add(Types.NestedField.required(id, field.name(), type));
+        newFields.add(Types.NestedField.required(id, field.name(), type, doc));
       }
     }
 

--- a/spark/src/main/java/com/netflix/iceberg/spark/TypeToSparkType.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/TypeToSparkType.java
@@ -59,7 +59,12 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
     for (int i = 0; i < fields.size(); i += 1) {
       Types.NestedField field = fields.get(i);
       DataType type = fieldResults.get(i);
-      sparkFields.add(StructField.apply(field.name(), type, field.isOptional(), Metadata.empty()));
+      StructField sparkField = StructField.apply(
+          field.name(), type, field.isOptional(), Metadata.empty());
+      if (field.doc() != null) {
+        sparkField = sparkField.withComment(field.doc());
+      }
+      sparkFields.add(sparkField);
     }
 
     return StructType$.MODULE$.apply(sparkFields);


### PR DESCRIPTION
This adds an optional documentation string to the field level in Iceberg schemas.

Support for doc strings is added to Spark field conversion and to the UpdateSchema API.

To store field documentation, this adds a "doc" field to each nested field in the JSON representation of types. The spec has also been updated. This is a forward compatible change. Older readers will ignore the new doc field.

This fixes #38.