### PR TITLE
Support customizing table locations

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/Table.java
+++ b/api/src/main/java/com/netflix/iceberg/Table.java
@@ -97,6 +97,13 @@ public interface Table {
   UpdateProperties updateProperties();
 
   /**
+   * Create a new {@link UpdateLocation} to update table location and commit the changes.
+   *
+   * @return a new {@link UpdateLocation}
+   */
+  UpdateLocation updateLocation();
+
+  /**
    * Create a new {@link AppendFiles append API} to add files to this table and commit.
    *
    * @return a new {@link AppendFiles}

--- a/api/src/main/java/com/netflix/iceberg/Transaction.java
+++ b/api/src/main/java/com/netflix/iceberg/Transaction.java
@@ -41,6 +41,13 @@ public interface Transaction {
   UpdateProperties updateProperties();
 
   /**
+   * Create a new {@link UpdateLocation} to update table location.
+   *
+   * @return a new {@link UpdateLocation}
+   */
+  UpdateLocation updateLocation();
+
+  /**
    * Create a new {@link AppendFiles append API} to add files to this table.
    *
    * @return a new {@link AppendFiles}

--- a/api/src/main/java/com/netflix/iceberg/UpdateLocation.java
+++ b/api/src/main/java/com/netflix/iceberg/UpdateLocation.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+/**
+ * API for setting a table's base location.
+ */
+public interface UpdateLocation extends PendingUpdate<String> {
+  /**
+   * Set the table's location.
+   *
+   * @param location a String location
+   * @return this for method chaining
+   */
+  UpdateLocation setLocation(String location);
+}

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
@@ -126,7 +126,12 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
 
   @Override
   public String metadataFileLocation(String fileName) {
-    return String.format("%s/%s/%s", baseLocation, METADATA_FOLDER_NAME, fileName);
+    String metadataLocation = current().properties().get(TableProperties.WRITE_METADATA_LOCATION);
+    if (metadataLocation != null) {
+      return String.format("%s/%s", metadataLocation, fileName);
+    } else {
+      return String.format("%s/%s/%s", baseLocation, METADATA_FOLDER_NAME, fileName);
+    }
   }
 
   @Override

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
@@ -48,7 +48,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
 
   private static final String METADATA_FOLDER_NAME = "metadata";
   private static final String DATA_FOLDER_NAME = "data";
-  private static final String HIVE_LOCATION_FOLDER_NAME = "empty";
 
   private final Configuration conf;
   private final FileIO fileIo;
@@ -81,10 +80,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
 
   protected void requestRefresh() {
     this.shouldRefresh = true;
-  }
-
-  public String hiveTableLocation() {
-    return String.format("%s/%s", current().location(), HIVE_LOCATION_FOLDER_NAME);
   }
 
   protected String writeNewMetadata(TableMetadata metadata, int version) {

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTableOperations.java
@@ -56,7 +56,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   private TableMetadata currentMetadata = null;
   private String currentMetadataLocation = null;
   private boolean shouldRefresh = true;
-  private String baseLocation = null;
   private int version = -1;
 
   protected BaseMetastoreTableOperations(Configuration conf) {
@@ -85,15 +84,11 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   }
 
   public String hiveTableLocation() {
-    return String.format("%s/%s", baseLocation, HIVE_LOCATION_FOLDER_NAME);
+    return String.format("%s/%s", current().location(), HIVE_LOCATION_FOLDER_NAME);
   }
 
   protected String writeNewMetadata(TableMetadata metadata, int version) {
-    if (baseLocation == null) {
-      baseLocation = metadata.location();
-    }
-
-    String newTableMetadataFilePath = newTableMetadataFilePath(baseLocation, version);
+    String newTableMetadataFilePath = newTableMetadataFilePath(metadata, version);
     OutputFile newMetadataLocation = fileIo.newOutputFile(newTableMetadataFilePath);
 
     // write the new metadata
@@ -114,24 +109,29 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
       Tasks.foreach(newLocation)
           .retry(numRetries).exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */ )
           .suppressFailureWhenFinished()
-          .run(location -> {
-            this.currentMetadata = read(this, fromLocation(location, conf));
-            this.currentMetadataLocation = location;
-            this.baseLocation = currentMetadata.location();
-            this.version = parseVersion(location);
+          .run(metadataLocation -> {
+            this.currentMetadata = read(this, fromLocation(metadataLocation, conf));
+            this.currentMetadataLocation = metadataLocation;
+            this.version = parseVersion(metadataLocation);
           });
     }
     this.shouldRefresh = false;
   }
 
-  @Override
-  public String metadataFileLocation(String fileName) {
-    String metadataLocation = current().properties().get(TableProperties.WRITE_METADATA_LOCATION);
+  private String metadataFileLocation(TableMetadata metadata, String filename) {
+    String metadataLocation = metadata.properties()
+        .get(TableProperties.WRITE_METADATA_LOCATION);
+
     if (metadataLocation != null) {
-      return String.format("%s/%s", metadataLocation, fileName);
+      return String.format("%s/%s", metadataLocation, filename);
     } else {
-      return String.format("%s/%s/%s", baseLocation, METADATA_FOLDER_NAME, fileName);
+      return String.format("%s/%s/%s", metadata.location(), METADATA_FOLDER_NAME, filename);
     }
+  }
+
+  @Override
+  public String metadataFileLocation(String filename) {
+    return metadataFileLocation(current(), filename);
   }
 
   @Override
@@ -139,13 +139,9 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     return fileIo;
   }
 
-  private String newTableMetadataFilePath(String baseLocation, int newVersion) {
-    return String.format("%s/%s/%05d-%s%s",
-            baseLocation,
-            METADATA_FOLDER_NAME,
-            newVersion,
-            UUID.randomUUID(),
-            getFileExtension(this.conf));
+  private String newTableMetadataFilePath(TableMetadata meta, int newVersion) {
+    return metadataFileLocation(meta,
+        String.format("%05d-%s%s", newVersion, UUID.randomUUID(), getFileExtension(this.conf)));
   }
 
   private static int parseVersion(String metadataLocation) {

--- a/core/src/main/java/com/netflix/iceberg/BaseTable.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTable.java
@@ -91,6 +91,11 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public UpdateLocation updateLocation() {
+    return new SetLocation(ops);
+  }
+
+  @Override
   public AppendFiles newAppend() {
     return new MergeAppend(ops);
   }

--- a/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
@@ -107,6 +107,14 @@ class BaseTransaction implements Transaction {
   }
 
   @Override
+  public UpdateLocation updateLocation() {
+    checkLastOperationCommitted("UpdateLocation");
+    UpdateLocation setLocation = new SetLocation(transactionOps);
+    updates.add(setLocation);
+    return setLocation;
+  }
+
+  @Override
   public AppendFiles newAppend() {
     checkLastOperationCommitted("AppendFiles");
     AppendFiles append = new MergeAppend(transactionOps);
@@ -324,6 +332,11 @@ class BaseTransaction implements Transaction {
     @Override
     public UpdateProperties updateProperties() {
       return BaseTransaction.this.updateProperties();
+    }
+
+    @Override
+    public UpdateLocation updateLocation() {
+      return BaseTransaction.this.updateLocation();
     }
 
     @Override

--- a/core/src/main/java/com/netflix/iceberg/SetLocation.java
+++ b/core/src/main/java/com/netflix/iceberg/SetLocation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.netflix.iceberg.exceptions.CommitFailedException;
+import com.netflix.iceberg.util.Tasks;
+
+import static com.netflix.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static com.netflix.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
+import static com.netflix.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static com.netflix.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static com.netflix.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static com.netflix.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
+import static com.netflix.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
+import static com.netflix.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
+
+public class SetLocation implements UpdateLocation {
+  private final TableOperations ops;
+  private String newLocation;
+
+  public SetLocation(TableOperations ops) {
+    this.ops = ops;
+    this.newLocation = null;
+  }
+
+  @Override
+  public UpdateLocation setLocation(String location) {
+    this.newLocation = location;
+    return this;
+  }
+
+  @Override
+  public String apply() {
+    return newLocation;
+  }
+
+  @Override
+  public void commit() {
+    TableMetadata base = ops.refresh();
+    Tasks.foreach(ops)
+        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+        .exponentialBackoff(
+            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+            2.0 /* exponential */ )
+        .onlyRetryOn(CommitFailedException.class)
+        .run(ops -> ops.commit(base, base.updateLocation(newLocation)));
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/TableMetadata.java
+++ b/core/src/main/java/com/netflix/iceberg/TableMetadata.java
@@ -428,6 +428,12 @@ public class TableMetadata {
         -1, snapshots, ImmutableList.of());
   }
 
+  public TableMetadata updateLocation(String newLocation) {
+    return new TableMetadata(ops, null, newLocation,
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        currentSnapshotId, snapshots, snapshotLog);
+  }
+
   private static PartitionSpec freshSpec(int specId, Schema schema, PartitionSpec partitionSpec) {
     PartitionSpec.Builder specBuilder = PartitionSpec.builderFor(schema)
         .withSpecId(specId);

--- a/core/src/main/java/com/netflix/iceberg/TableProperties.java
+++ b/core/src/main/java/com/netflix/iceberg/TableProperties.java
@@ -67,10 +67,15 @@ public class TableProperties {
 
   public static final String OBJECT_STORE_PATH = "write.object-storage.path";
 
-  // This only applies to files written after this property is set. Files previously written aren't relocated to
-  // reflect this parameter.
+  // This only applies to files written after this property is set. Files previously written aren't
+  // relocated to reflect this parameter.
   // If not set, defaults to a "data" folder underneath the root path of the table.
   public static final String WRITE_NEW_DATA_LOCATION = "write.folder-storage.path";
+
+  // This only applies to files written after this property is set. Files previously written aren't
+  // relocated to reflect this parameter.
+  // If not set, defaults to a "meatdata" folder underneath the root path of the table.
+  public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
 
   public static final String MANIFEST_LISTS_ENABLED = "write.manifest-lists.enabled";
   public static final boolean MANIFEST_LISTS_ENABLED_DEFAULT = true;

--- a/core/src/main/java/com/netflix/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/hadoop/HadoopTableOperations.java
@@ -109,6 +109,8 @@ public class HadoopTableOperations implements TableOperations {
       return;
     }
 
+    Preconditions.checkArgument(base == null || base.location().equals(metadata.location()),
+        "Hadoop path-based tables cannot be relocated");
     Preconditions.checkArgument(
         !metadata.properties().containsKey(TableProperties.WRITE_METADATA_LOCATION),
         "Hadoop path-based tables cannot relocate metadata");

--- a/core/src/main/java/com/netflix/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/com/netflix/iceberg/hadoop/HadoopTableOperations.java
@@ -19,10 +19,12 @@
 
 package com.netflix.iceberg.hadoop;
 
+import com.google.common.base.Preconditions;
 import com.netflix.iceberg.FileIO;
 import com.netflix.iceberg.TableMetadata;
 import com.netflix.iceberg.TableMetadataParser;
 import com.netflix.iceberg.TableOperations;
+import com.netflix.iceberg.TableProperties;
 import com.netflix.iceberg.exceptions.CommitFailedException;
 import com.netflix.iceberg.exceptions.RuntimeIOException;
 import com.netflix.iceberg.exceptions.ValidationException;
@@ -106,6 +108,10 @@ public class HadoopTableOperations implements TableOperations {
       LOG.info("Nothing to commit.");
       return;
     }
+
+    Preconditions.checkArgument(
+        !metadata.properties().containsKey(TableProperties.WRITE_METADATA_LOCATION),
+        "Hadoop path-based tables cannot relocate metadata");
 
     Path tempMetadataFile = metadataPath(UUID.randomUUID().toString() + getFileExtension(conf));
     TableMetadataParser.write(metadata, io().newOutputFile(tempMetadataFile.toString()));

--- a/hive/src/main/java/com/netflix/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/com/netflix/iceberg/hive/HiveTableOperations.java
@@ -136,7 +136,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
                 (int) currentTimeMillis / 1000,
                 (int) currentTimeMillis / 1000,
                 Integer.MAX_VALUE,
-                storageDescriptor(metadata.schema()),
+                storageDescriptor(metadata),
                 Collections.emptyList(),
                 new HashMap<>(),
                 null,
@@ -144,7 +144,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
                 ICEBERG_TABLE_TYPE_VALUE);
       }
 
-      tbl.setSd(storageDescriptor(metadata.schema())); // set to pickup any schema changes
+      tbl.setSd(storageDescriptor(metadata)); // set to pickup any schema changes
       final String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
       if (!Objects.equals(currentMetadataLocation(), metadataLocation)) {
         throw new CommitFailedException(format("metadataLocation = %s is not same as table metadataLocation %s for %s.%s",
@@ -189,11 +189,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     tbl.setParameters(parameters);
   }
 
-  private StorageDescriptor storageDescriptor(Schema schema) {
+  private StorageDescriptor storageDescriptor(TableMetadata metadata) {
 
     final StorageDescriptor storageDescriptor = new StorageDescriptor();
-    storageDescriptor.setCols(columns(schema));
-    storageDescriptor.setLocation(hiveTableLocation());
+    storageDescriptor.setCols(columns(metadata.schema()));
+    storageDescriptor.setLocation(metadata.location());
     storageDescriptor.setOutputFormat("org.apache.hadoop.mapred.FileInputFormat");
     storageDescriptor.setInputFormat("org.apache.hadoop.mapred.FileOutputFormat");
     SerDeInfo serDeInfo = new SerDeInfo();

--- a/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
+++ b/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
@@ -206,7 +206,7 @@ class HiveTableBaseTest {
   }
 
   String getTableLocation(String tableName) {
-    return new Path("file", null, Paths.get(getTableBasePath(tableName), "empty").toString()).toString();
+    return new Path("file", null, Paths.get(getTableBasePath(tableName)).toString()).toString();
   }
 
   String metadataLocation(String tableName) {


### PR DESCRIPTION
This adds two features for customizing file locations:

* Support for setting the metadata location using `write.metadata.path`, like the data file location update in #6.
* Support for updating the table location for metastore tables.