### PR TITLE
Allow schema updates in transactions.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/Transaction.java
+++ b/api/src/main/java/com/netflix/iceberg/Transaction.java
@@ -34,6 +34,13 @@ public interface Transaction {
   Table table();
 
   /**
+   * Create a new {@link UpdateSchema} to alter the columns of this table.
+   *
+   * @return a new {@link UpdateSchema}
+   */
+  UpdateSchema updateSchema();
+
+  /**
    * Create a new {@link UpdateProperties} to update table properties.
    *
    * @return a new {@link UpdateProperties}

--- a/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
@@ -99,6 +99,14 @@ class BaseTransaction implements Transaction {
   }
 
   @Override
+  public UpdateSchema updateSchema() {
+    checkLastOperationCommitted("UpdateSchema");
+    UpdateSchema schemaChange = new SchemaUpdate(transactionOps);
+    updates.add(schemaChange);
+    return schemaChange;
+  }
+
+  @Override
   public UpdateProperties updateProperties() {
     checkLastOperationCommitted("UpdateProperties");
     UpdateProperties props = new PropertiesUpdate(transactionOps);
@@ -318,7 +326,7 @@ class BaseTransaction implements Transaction {
 
     @Override
     public UpdateSchema updateSchema() {
-      throw new UnsupportedOperationException("Transaction tables do not support schema updates");
+      return BaseTransaction.this.updateSchema();
     }
 
     @Override


### PR DESCRIPTION
This is safe because schema updates can always read older data. If a
transaction includes a write followed by a schema update, the new schema
can read the data that was just written. Also, writers are allowed to
write with older schemas because the current schema can read any file
written with an older schema. If a transaction includes a schema update
followed by a write, using either the original schema or the new schema
will work.