### PR TITLE
Add snapshot summary and operation.

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/DataOperations.java
+++ b/api/src/main/java/com/netflix/iceberg/DataOperations.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+/**
+ * Data operations that produce snapshots.
+ * <p>
+ * A snapshot can return the operation that created the snapshot to help other components ignore
+ * snapshots that are not needed for some tasks. For example, snapshot expiration does not need to
+ * clean up deleted files for appends, which have no deleted files.
+ */
+public class DataOperations {
+  private DataOperations() {
+  }
+
+  /**
+   * New data is appended to the table and no data is removed or deleted.
+   * <p>
+   * This operation is implemented by {@link AppendFiles}.
+   */
+  public static final String APPEND = "append";
+
+  /**
+   * Files are removed and replaced, without changing the data in the table.
+   * <p>
+   * This operation is implemented by {@link RewriteFiles}.
+   */
+  public static final String REPLACE = "replace";
+
+  /**
+   * New data is added to overwrite existing data.
+   * <p>
+   * This operation is implemented by {@link OverwriteFiles} and {@link ReplacePartitions}.
+   */
+  public static final String OVERWRITE = "overwrite";
+
+  /**
+   * Data is deleted from the table and no data is added.
+   * <p>
+   * This operation is implemented by {@link DeleteFiles}.
+   */
+  public static final String DELETE = "delete";
+}

--- a/api/src/main/java/com/netflix/iceberg/Snapshot.java
+++ b/api/src/main/java/com/netflix/iceberg/Snapshot.java
@@ -20,6 +20,7 @@
 package com.netflix.iceberg;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A snapshot of the data in a table at a point in time.
@@ -61,6 +62,21 @@ public interface Snapshot {
    * @return a list of fully-qualified manifest locations
    */
   List<ManifestFile> manifests();
+
+  /**
+   * Return the name of the {@link DataOperations data operation} that produced this snapshot.
+   *
+   * @return the operation that produced this snapshot, or null if the operation is unknown
+   * @see DataOperations
+   */
+  String operation();
+
+  /**
+   * Return a string map of summary data for the operation that produced this snapshot.
+   *
+   * @return a string map of summary data.
+   */
+  Map<String, String> summary();
 
   /**
    * Return all files added to the table in this snapshot.

--- a/core/src/main/java/com/netflix/iceberg/FastAppend.java
+++ b/core/src/main/java/com/netflix/iceberg/FastAppend.java
@@ -44,6 +44,11 @@ class FastAppend extends SnapshotUpdate implements AppendFiles {
   }
 
   @Override
+  protected String operation() {
+    return DataOperations.APPEND;
+  }
+
+  @Override
   public FastAppend appendFile(DataFile file) {
     this.hasNewFiles = true;
     newFiles.add(file);

--- a/core/src/main/java/com/netflix/iceberg/FastAppend.java
+++ b/core/src/main/java/com/netflix/iceberg/FastAppend.java
@@ -25,6 +25,7 @@ import com.netflix.iceberg.exceptions.RuntimeIOException;
 import com.netflix.iceberg.io.OutputFile;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -34,6 +35,7 @@ import java.util.Set;
  */
 class FastAppend extends SnapshotUpdate implements AppendFiles {
   private final PartitionSpec spec;
+  private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
   private final List<DataFile> newFiles = Lists.newArrayList();
   private ManifestFile newManifest = null;
   private boolean hasNewFiles = false;
@@ -49,9 +51,15 @@ class FastAppend extends SnapshotUpdate implements AppendFiles {
   }
 
   @Override
+  protected Map<String, String> summary() {
+    return summaryBuilder.build();
+  }
+
+  @Override
   public FastAppend appendFile(DataFile file) {
     this.hasNewFiles = true;
     newFiles.add(file);
+    summaryBuilder.addedFile(spec, file);
     return this;
   }
 

--- a/core/src/main/java/com/netflix/iceberg/MergeAppend.java
+++ b/core/src/main/java/com/netflix/iceberg/MergeAppend.java
@@ -32,6 +32,11 @@ class MergeAppend extends MergingSnapshotUpdate implements AppendFiles {
   }
 
   @Override
+  protected String operation() {
+    return DataOperations.APPEND;
+  }
+
+  @Override
   public MergeAppend appendFile(DataFile file) {
     add(file);
     return this;

--- a/core/src/main/java/com/netflix/iceberg/OverwriteData.java
+++ b/core/src/main/java/com/netflix/iceberg/OverwriteData.java
@@ -34,6 +34,11 @@ public class OverwriteData extends MergingSnapshotUpdate implements OverwriteFil
   }
 
   @Override
+  protected String operation() {
+    return DataOperations.OVERWRITE;
+  }
+
+  @Override
   public OverwriteFiles overwriteByRowFilter(Expression expr) {
     deleteByRowFilter(expr);
     return this;

--- a/core/src/main/java/com/netflix/iceberg/ReplaceFiles.java
+++ b/core/src/main/java/com/netflix/iceberg/ReplaceFiles.java
@@ -31,6 +31,11 @@ class ReplaceFiles extends MergingSnapshotUpdate implements RewriteFiles {
   }
 
   @Override
+  protected String operation() {
+    return DataOperations.REPLACE;
+  }
+
+  @Override
   public RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd) {
     Preconditions.checkArgument(filesToDelete != null && !filesToDelete.isEmpty(),
         "Files to delete cannot be null or empty");

--- a/core/src/main/java/com/netflix/iceberg/ReplacePartitionsOperation.java
+++ b/core/src/main/java/com/netflix/iceberg/ReplacePartitionsOperation.java
@@ -29,6 +29,11 @@ public class ReplacePartitionsOperation extends MergingSnapshotUpdate implements
   }
 
   @Override
+  protected String operation() {
+    return DataOperations.OVERWRITE;
+  }
+
+  @Override
   public ReplacePartitions addFile(DataFile file) {
     dropPartition(file.partition());
     add(file);

--- a/core/src/main/java/com/netflix/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/com/netflix/iceberg/SnapshotSummary.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import java.util.Map;
+import java.util.Set;
+
+public class SnapshotSummary {
+  public static final String ADDED_FILES_PROP = "added-data-files";
+  public static final String DELETED_FILES_PROP = "deleted-data-files";
+  public static final String TOTAL_FILES_PROP = "total-data-files";
+  public static final String ADDED_RECORDS_PROP = "added-records";
+  public static final String DELETED_RECORDS_PROP = "deleted-records";
+  public static final String TOTAL_RECORDS_PROP = "total-records";
+  public static final String DELETED_DUPLICATE_FILES = "deleted-duplicate-files";
+  public static final String CHANGED_PARTITION_COUNT_PROP = "changed-partition-count";
+
+  private SnapshotSummary() {
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    // commit summary tracking
+    private Set<String> changedPartitions = Sets.newHashSet();
+    private long addedFiles = 0L;
+    private long deletedFiles = 0L;
+    private long deletedDuplicateFiles = 0L;
+    private long addedRecords = 0L;
+    private long deletedRecords = 0L;
+
+    public void clear() {
+      changedPartitions.clear();
+      this.addedFiles = 0L;
+      this.deletedFiles = 0L;
+      this.deletedDuplicateFiles = 0L;
+      this.addedRecords = 0L;
+      this.deletedRecords = 0L;
+    }
+
+    public void incrementDuplicateDeletes() {
+      this.deletedDuplicateFiles += 1;
+    }
+
+    public void deletedFile(PartitionSpec spec, DataFile file) {
+      changedPartitions.add(spec.partitionToPath(file.partition()));
+      this.deletedFiles += 1;
+      this.deletedRecords += file.recordCount();
+    }
+
+    public void addedFile(PartitionSpec spec, DataFile file) {
+      changedPartitions.add(spec.partitionToPath(file.partition()));
+      this.addedFiles += 1;
+      this.addedRecords += file.recordCount();
+    }
+
+    public Map<String, String> build() {
+      ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+      setIf(addedFiles > 0, builder, ADDED_FILES_PROP, addedFiles);
+      setIf(deletedFiles > 0, builder, DELETED_FILES_PROP, deletedFiles);
+      setIf(deletedDuplicateFiles > 0, builder, DELETED_DUPLICATE_FILES, deletedDuplicateFiles);
+      setIf(addedRecords > 0, builder, ADDED_RECORDS_PROP, addedRecords);
+      setIf(deletedRecords > 0, builder, DELETED_RECORDS_PROP, deletedRecords);
+      setIf(true, builder, CHANGED_PARTITION_COUNT_PROP, changedPartitions.size());
+
+      return builder.build();
+    }
+
+    private static void setIf(boolean expression, ImmutableMap.Builder<String, String> builder,
+                              String property, Object value) {
+      if (expression) {
+        builder.put(property, String.valueOf(value));
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/SnapshotUpdate.java
+++ b/core/src/main/java/com/netflix/iceberg/SnapshotUpdate.java
@@ -146,6 +146,9 @@ abstract class SnapshotUpdate implements PendingUpdate<Snapshot> {
 
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
+    // copy all summary properties from the implementation
+    builder.putAll(summary);
+
     updateTotal(
         builder, previousSummary, SnapshotSummary.TOTAL_RECORDS_PROP,
         summary, SnapshotSummary.ADDED_RECORDS_PROP, SnapshotSummary.DELETED_RECORDS_PROP);

--- a/core/src/main/java/com/netflix/iceberg/SnapshotUpdate.java
+++ b/core/src/main/java/com/netflix/iceberg/SnapshotUpdate.java
@@ -22,6 +22,7 @@ package com.netflix.iceberg;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.iceberg.exceptions.CommitFailedException;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -102,6 +104,22 @@ abstract class SnapshotUpdate implements PendingUpdate<Snapshot> {
    */
   protected abstract void cleanUncommitted(Set<ManifestFile> committed);
 
+  /**
+   * A string that describes the action that produced the new snapshot.
+   *
+   * @return a string operation
+   */
+  protected abstract String operation();
+
+  /**
+   * A string map with a summary of the changes in this snapshot update.
+   *
+   * @return a string map that summarizes the update
+   */
+  protected Map<String, String> summary() {
+    return ImmutableMap.of();
+  }
+
   @Override
   public Snapshot apply() {
     this.base = ops.refresh();
@@ -139,12 +157,13 @@ abstract class SnapshotUpdate implements PendingUpdate<Snapshot> {
       }
 
       return new BaseSnapshot(ops,
-          snapshotId(), parentSnapshotId, System.currentTimeMillis(),
+          snapshotId(), parentSnapshotId, System.currentTimeMillis(), operation(), summary(),
           ops.io().newInputFile(manifestList.location()));
 
     } else {
       return new BaseSnapshot(ops,
-          snapshotId(), parentSnapshotId, System.currentTimeMillis(), manifests);
+          snapshotId(), parentSnapshotId, System.currentTimeMillis(), operation(), summary(),
+          manifests);
     }
   }
 

--- a/core/src/main/java/com/netflix/iceberg/StreamingDelete.java
+++ b/core/src/main/java/com/netflix/iceberg/StreamingDelete.java
@@ -33,6 +33,11 @@ class StreamingDelete extends MergingSnapshotUpdate implements DeleteFiles {
   }
 
   @Override
+  protected String operation() {
+    return DataOperations.DELETE;
+  }
+
+  @Override
   public StreamingDelete deleteFile(CharSequence path) {
     delete(path);
     return this;

--- a/core/src/test/java/com/netflix/iceberg/TestTableMetadataJson.java
+++ b/core/src/test/java/com/netflix/iceberg/TestTableMetadataJson.java
@@ -68,11 +68,11 @@ public class TestTableMetadataJson {
 
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
-        null, previousSnapshotId, null, previousSnapshotId, ImmutableList.of(
+        ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
-        null, currentSnapshotId, previousSnapshotId, currentSnapshotId, ImmutableList.of(
+        ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
 
     List<SnapshotLogEntry> snapshotLog = ImmutableList.<SnapshotLogEntry>builder()
@@ -130,11 +130,11 @@ public class TestTableMetadataJson {
 
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
-        ops, previousSnapshotId, null, previousSnapshotId, ImmutableList.of(
+        ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
-        ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, ImmutableList.of(
+        ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
 
     List<SnapshotLogEntry> reversedSnapshotLog = Lists.newArrayList();
@@ -175,12 +175,13 @@ public class TestTableMetadataJson {
 
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
-        ops, previousSnapshotId, null, previousSnapshotId, ImmutableList.of(
+        ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
-        ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, ImmutableList.of(
+        ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
+
 
     TableMetadata expected = new TableMetadata(ops, null, "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 6, ImmutableList.of(spec),

--- a/core/src/test/java/com/netflix/iceberg/avro/AvroTestHelpers.java
+++ b/core/src/test/java/com/netflix/iceberg/avro/AvroTestHelpers.java
@@ -21,19 +21,11 @@ package com.netflix.iceberg.avro;
 
 import com.netflix.iceberg.types.Type;
 import com.netflix.iceberg.types.Types;
-import com.netflix.iceberg.util.CharSequenceWrapper;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.junit.Assert;
-
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
This adds a "summary" field to each snapshot stored in the metadata file.

The purpose of this extra information is to speed up operations by ignoring some snapshots. For example, when finding data to process incrementally, snapshots produced by a delete or replace operation can be ignored because no new data is added.

The summary is stored in the metadata file's list of snapshot objects as "summary". Each summary is an object with at least one key, "operation" that describes the operation that produced the snapshot. Possible values are "append", "replace", "overwrite" and "delete". These are defined in DataOperations.