### PR TITLE
Fix propagation of Hive configs

### DIFF
--- a/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
+++ b/hive/src/test/java/com/netflix/iceberg/hive/HiveTableBaseTest.java
@@ -66,13 +66,7 @@ import static com.netflix.iceberg.types.Types.NestedField.required;
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.AUTO_CREATE_ALL;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.COMPACTOR_INITIATOR_ON;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.COMPACTOR_WORKER_THREADS;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.CONNECT_URL_KEY;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.HIVE_SUPPORT_CONCURRENCY;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.HIVE_TXN_MANAGER;
-import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.SCHEMA_VERIFICATION;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.THRIFT_URIS;
 import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.WAREHOUSE;
 
@@ -135,18 +129,10 @@ class HiveTableBaseTest {
 
   private HiveConf hiveConf(Configuration conf, int port) {
     final HiveConf hiveConf = new HiveConf(conf, this.getClass());
-    // Setting AUTO_CREATE_ALL in hadoop config somehow still reverts to false.
-    hiveConf.set(SCHEMA_VERIFICATION.getVarname(), "false");
     hiveConf.set(THRIFT_URIS.getVarname(), "thrift://localhost:" + port);
     hiveConf.set(WAREHOUSE.getVarname(), "file:" + hiveLocalDir.getAbsolutePath());
     hiveConf.set(WAREHOUSE.getHiveName(), "file:" + hiveLocalDir.getAbsolutePath());
     hiveConf.set(CONNECT_URL_KEY.getVarname(), "jdbc:derby:" + getDerbyPath() + ";create=true");
-    hiveConf.set(AUTO_CREATE_ALL.getVarname(), "true");
-    hiveConf.set(HIVE_TXN_MANAGER.getVarname(), "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager");
-    hiveConf.set(COMPACTOR_INITIATOR_ON.getVarname(), "true");
-    hiveConf.set(COMPACTOR_WORKER_THREADS.getVarname(), "1");
-    hiveConf.set(HIVE_SUPPORT_CONCURRENCY.getVarname(), "true");
-
     return hiveConf;
   }
 

--- a/hive/src/test/resources/metastore-site.xml
+++ b/hive/src/test/resources/metastore-site.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+  <property>
+    <name>hive.support.concurrency</name>
+      <value>true</value>
+  </property>
+  <property>
+    <name>metastore.compactor.worker.threads</name>
+      <value>1</value>
+  </property>
+  <property>
+    <name>metastore.compactor.initiator.on</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hive.txn.manager</name>
+    <value>org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager</value>
+  </property>
+</configuration>


### PR DESCRIPTION
This PR adds `metastore-site.xml` to propagate Hive config values set in `HiveTableBaseTest`.

Right now, Iceberg sets all config options dynamically in `HiveTableBaseTest$hiveConf`. Unfortunately, the values are not always taken into account.

As far as I understand the lifecycle of Hive `ObjectStore`, `setConf` is called first. It ignores properties other than `Metastore$dataNucleusAndJdoConfs`. Later, `ObjectStore` will create a metastore conf via `MetastoreConf.newMetastoreConf()`. This method will look for configuration files and will ignore what is set in Iceberg tests. As a consequence, properties like `"metastore.schema.verification"` will revert to their default values. Because `"metastore.schema.verification"` is 'true' by default, it will force `"datanucleus.schema.autoCreateAll"` to be 'false'. The last point explains this statement in Iceberg tests: "Setting AUTO_CREATE_ALL in hadoop config somehow still reverts to 'false'".

**Config Changes**

- `"datanucleus.schema.autoCreateAll"` - This property is needed to auto-generate the schema. This config was never applied and Iceberg generated the schema via `ScriptRunner`. Therefore, I removed setting this property to 'true'. The default values is 'false'.
- `"metastore.schema.verification"` - I removed setting this property to 'false' as`"datanucleus.schema.autoCreateAll"` is no longer set to 'true'. The default value is 'true'. If 'true', this enforces `"datanucleus.schema.autoCreateAll"` to be 'false' in `"MetastoreConf$newMetastoreConf"`.
 
This change was tested by exploring the log.

```
10:02:34.675 [main] INFO  org.apache.hadoop.hive.metastore.conf.MetastoreConf - Unable to find config file hive-site.xml
10:02:34.675 [main] INFO  org.apache.hadoop.hive.metastore.conf.MetastoreConf - Found configuration file null
10:02:34.675 [main] INFO  org.apache.hadoop.hive.metastore.conf.MetastoreConf - Unable to find config file hivemetastore-site.xml
10:02:34.675 [main] INFO  org.apache.hadoop.hive.metastore.conf.MetastoreConf - Found configuration file null
10:02:34.675 [main] INFO  org.apache.hadoop.hive.metastore.conf.MetastoreConf - Found configuration file file:/PATH/hive/out/test/resources/metastore-site.xml
10:02:34.686 [main] DEBUG org.apache.hadoop.hive.metastore.conf.MetastoreConf - MetastoreConf object:
Used metastore-site file: file:/PATH/hive/out/test/resources/metastore-site.xml
…
Key: <hive.support.concurrency> old hive key: <hive.support.concurrency>  value: <true>
Key: <metastore.compactor.worker.threads> old hive key: <hive.compactor.worker.threads>  value: <1>
Key: <metastore.compactor.initiator.on> old hive key: <hive.compactor.initiator.on>  value: <true>
Key: <hive.txn.manager> old hive key: <hive.txn.manager>  value: <org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager>
```

We still need to set the remaining configs as `hiveConf` in `HiveTableBaseTest` is used in many places.