### PR TITLE
Make expression binding support a case sensitivity flag

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/expressions/Binder.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Binder.java
@@ -51,31 +51,35 @@ public class Binder {
    *
    * @param struct The {@link StructType struct type} to resolve references by name.
    * @param expr An {@link Expression expression} to rewrite with bound references.
+   * @param caseSensitive A boolean flag to control whether the bind should enforce case sensitivity.
    * @return the expression rewritten with bound references
    * @throws ValidationException if literals do not match bound references
    * @throws IllegalStateException if any references are already bound
    */
   public static Expression bind(StructType struct,
-                                Expression expr) {
-    return ExpressionVisitors.visit(expr, new BindVisitor(struct));
+                                Expression expr,
+                                boolean caseSensitive) {
+    return ExpressionVisitors.visit(expr, new BindVisitor(struct, caseSensitive));
   }
 
-  public static Set<Integer> boundReferences(StructType struct, List<Expression> exprs) {
+  public static Set<Integer> boundReferences(StructType struct, List<Expression> exprs, boolean caseSensitive) {
     if (exprs == null) {
       return ImmutableSet.of();
     }
     ReferenceVisitor visitor = new ReferenceVisitor();
     for (Expression expr : exprs) {
-      ExpressionVisitors.visit(bind(struct, expr), visitor);
+      ExpressionVisitors.visit(bind(struct, expr, caseSensitive), visitor);
     }
     return visitor.references;
   }
 
   private static class BindVisitor extends ExpressionVisitor<Expression> {
     private final StructType struct;
+    private final boolean caseSensitive;
 
-    private BindVisitor(StructType struct) {
+    private BindVisitor(StructType struct, boolean caseSensitive) {
       this.struct = struct;
+      this.caseSensitive = caseSensitive;
     }
 
     @Override
@@ -110,7 +114,7 @@ public class Binder {
 
     @Override
     public <T> Expression predicate(UnboundPredicate<T> pred) {
-      return pred.bind(struct);
+      return pred.bind(struct, caseSensitive);
     }
   }
 

--- a/api/src/main/java/com/netflix/iceberg/expressions/Binder.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Binder.java
@@ -62,6 +62,34 @@ public class Binder {
     return ExpressionVisitors.visit(expr, new BindVisitor(struct, caseSensitive));
   }
 
+  /**
+   * Replaces all unbound/named references with bound references to fields in the given struct,
+   * defaulting to case sensitive mode.
+   *
+   * Access modifier is package-private, to only allow use from existing tests.
+   *
+   * <p>
+   * When a reference is resolved, any literal used in a predicate for that field is converted to
+   * the field's type using {@link Literal#to(Type)}. If automatic conversion to that type isn't
+   * allowed, a {@link ValidationException validation exception} is thrown.
+   * <p>
+   * The result expression may be simplified when constructed. For example, {@code isNull("a")} is
+   * replaced with {@code alwaysFalse()} when {@code "a"} is resolved to a required field.
+   * <p>
+   * The expression cannot contain references that are already bound, or an
+   * {@link IllegalStateException} will be thrown.
+   *
+   * @param struct The {@link StructType struct type} to resolve references by name.
+   * @param expr An {@link Expression expression} to rewrite with bound references.
+   * @return the expression rewritten with bound references
+   *
+   * @throws IllegalStateException if any references are already bound
+   */
+  static Expression bind(StructType struct,
+                                   Expression expr) {
+    return Binder.bind(struct, expr, true);
+  }
+
   public static Set<Integer> boundReferences(StructType struct, List<Expression> exprs, boolean caseSensitive) {
     if (exprs == null) {
       return ImmutableSet.of();

--- a/api/src/main/java/com/netflix/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Evaluator.java
@@ -44,7 +44,7 @@ public class Evaluator implements Serializable {
   }
 
   public Evaluator(Types.StructType struct, Expression unbound) {
-    this.expr = Binder.bind(struct, unbound);
+    this.expr = Binder.bind(struct, unbound, true);
   }
 
   public boolean eval(StructLike data) {

--- a/api/src/main/java/com/netflix/iceberg/expressions/InclusiveManifestEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/InclusiveManifestEvaluator.java
@@ -54,7 +54,7 @@ public class InclusiveManifestEvaluator {
 
   public InclusiveManifestEvaluator(PartitionSpec spec, Expression rowFilter) {
     this.struct = spec.partitionType();
-    this.expr = Binder.bind(struct, rewriteNot(Projections.inclusive(spec).project(rowFilter)));
+    this.expr = Binder.bind(struct, rewriteNot(Projections.inclusive(spec).project(rowFilter)), true);
   }
 
   /**

--- a/api/src/main/java/com/netflix/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -56,7 +56,7 @@ public class InclusiveMetricsEvaluator {
   public InclusiveMetricsEvaluator(Schema schema, Expression unbound) {
     this.schema = schema;
     this.struct = schema.asStruct();
-    this.expr = Binder.bind(struct, rewriteNot(unbound));
+    this.expr = Binder.bind(struct, rewriteNot(unbound), true);
   }
 
   /**

--- a/api/src/main/java/com/netflix/iceberg/expressions/Projections.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Projections.java
@@ -135,7 +135,7 @@ public class Projections {
 
     @Override
     public <T> Expression predicate(UnboundPredicate<T> pred) {
-      Expression bound = pred.bind(spec.schema().asStruct());
+      Expression bound = pred.bind(spec.schema().asStruct(), true);
 
       if (bound instanceof BoundPredicate) {
         return predicate((BoundPredicate<?>) bound);

--- a/api/src/main/java/com/netflix/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/ResidualEvaluator.java
@@ -170,7 +170,7 @@ public class ResidualEvaluator implements Serializable {
           .projectStrict(part.name(), pred);
 
       if (strictProjection != null) {
-        Expression bound = strictProjection.bind(spec.partitionType());
+        Expression bound = strictProjection.bind(spec.partitionType(), true);
         if (bound instanceof BoundPredicate) {
           // the predicate methods will evaluate and return alwaysTrue or alwaysFalse
           return super.predicate((BoundPredicate<?>) bound);
@@ -184,7 +184,7 @@ public class ResidualEvaluator implements Serializable {
 
     @Override
     public <T> Expression predicate(UnboundPredicate<T> pred) {
-      Expression bound = pred.bind(spec.schema().asStruct());
+      Expression bound = pred.bind(spec.schema().asStruct(), true);
 
       if (bound instanceof BoundPredicate) {
         Expression boundResidual = predicate((BoundPredicate<?>) bound);

--- a/api/src/main/java/com/netflix/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/StrictMetricsEvaluator.java
@@ -57,7 +57,7 @@ public class StrictMetricsEvaluator {
   public StrictMetricsEvaluator(Schema schema, Expression unbound) {
     this.schema = schema;
     this.struct = schema.asStruct();
-    this.expr = Binder.bind(struct, rewriteNot(unbound));
+    this.expr = Binder.bind(struct, rewriteNot(unbound), true);
   }
 
   /**

--- a/api/src/main/java/com/netflix/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/UnboundPredicate.java
@@ -44,6 +44,27 @@ public class UnboundPredicate<T> extends Predicate<T, NamedReference> {
     return new UnboundPredicate<>(op().negate(), ref(), literal());
   }
 
+  /**
+   * Bind this UnboundPredicate, defaulting to case sensitive mode.
+   *
+   * Access modifier is package-private, to only allow use from existing tests.
+   *
+   * @param struct The {@link Types.StructType struct type} to resolve references by name.
+   * @return an {@link Expression}
+   * @throws ValidationException if literals do not match bound references, or if comparison on expression is invalid
+   */
+  Expression bind(Types.StructType struct) {
+    return bind(struct, true);
+  }
+
+  /**
+   * Bind this UnboundPredicate.
+   *
+   * @param struct The {@link Types.StructType struct type} to resolve references by name.
+   * @param caseSensitive A boolean flag to control whether the bind should enforce case sensitivity.
+   * @return an {@link Expression}
+   * @throws ValidationException if literals do not match bound references, or if comparison on expression is invalid
+   */
   public Expression bind(Types.StructType struct, boolean caseSensitive) {
     Types.NestedField field;
     if (caseSensitive) {

--- a/api/src/main/java/com/netflix/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/UnboundPredicate.java
@@ -44,8 +44,14 @@ public class UnboundPredicate<T> extends Predicate<T, NamedReference> {
     return new UnboundPredicate<>(op().negate(), ref(), literal());
   }
 
-  public Expression bind(Types.StructType struct) {
-    Types.NestedField field = struct.field(ref().name());
+  public Expression bind(Types.StructType struct, boolean caseSensitive) {
+    Types.NestedField field;
+    if (caseSensitive) {
+      field = struct.field(ref().name());
+    } else {
+      field = struct.caseInsensitiveField(ref().name());
+    }
+
     ValidationException.check(field != null,
         "Cannot find field '%s' in struct: %s", ref().name(), struct);
 

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionBinding.java
@@ -47,7 +47,7 @@ public class TestExpressionBinding {
   public void testMissingReference() {
     Expression expr = and(equal("t", 5), equal("x", 7));
     try {
-      Binder.bind(STRUCT, expr);
+      Binder.bind(STRUCT, expr, true);
       Assert.fail("Should not successfully bind to struct without field 't'");
     } catch (ValidationException e) {
       Assert.assertTrue("Should complain about missing field",
@@ -58,25 +58,37 @@ public class TestExpressionBinding {
   @Test(expected = IllegalStateException.class)
   public void testBoundExpressionFails() {
     Expression expr = not(equal("x", 7));
-    Binder.bind(STRUCT, Binder.bind(STRUCT, expr));
+    Binder.bind(STRUCT, Binder.bind(STRUCT, expr, true), true);
   }
 
   @Test
   public void testSingleReference() {
     Expression expr = not(equal("x", 7));
-    TestHelpers.assertAllReferencesBound("Single reference", Binder.bind(STRUCT, expr));
+    TestHelpers.assertAllReferencesBound("Single reference", Binder.bind(STRUCT, expr, true));
+  }
+
+  @Test
+  public void testCaseInsensitiveReference() {
+    Expression expr = not(equal("X", 7));
+    TestHelpers.assertAllReferencesBound("Single reference", Binder.bind(STRUCT, expr, false));
+  }
+
+  @Test(expected = ValidationException.class)
+  public void testCaseSensitiveReference() {
+    Expression expr = not(equal("X", 7));
+    Binder.bind(STRUCT, expr, true);
   }
 
   @Test
   public void testMultipleReferences() {
     Expression expr = or(and(equal("x", 7), lessThan("y", 100)), greaterThan("z", -100));
-    TestHelpers.assertAllReferencesBound("Multiple references", Binder.bind(STRUCT, expr));
+    TestHelpers.assertAllReferencesBound("Multiple references", Binder.bind(STRUCT, expr, true));
   }
 
   @Test
   public void testAnd() {
     Expression expr = and(equal("x", 7), lessThan("y", 100));
-    Expression boundExpr = Binder.bind(STRUCT, expr);
+    Expression boundExpr = Binder.bind(STRUCT, expr, true);
     TestHelpers.assertAllReferencesBound("And", boundExpr);
 
     // make sure the result is an And
@@ -92,7 +104,7 @@ public class TestExpressionBinding {
   @Test
   public void testOr() {
     Expression expr = or(greaterThan("z", -100), lessThan("y", 100));
-    Expression boundExpr = Binder.bind(STRUCT, expr);
+    Expression boundExpr = Binder.bind(STRUCT, expr, true);
     TestHelpers.assertAllReferencesBound("Or", boundExpr);
 
     // make sure the result is an Or
@@ -108,7 +120,7 @@ public class TestExpressionBinding {
   @Test
   public void testNot() {
     Expression expr = not(equal("x", 7));
-    Expression boundExpr = Binder.bind(STRUCT, expr);
+    Expression boundExpr = Binder.bind(STRUCT, expr, true);
     TestHelpers.assertAllReferencesBound("Not", boundExpr);
 
     // make sure the result is a Not
@@ -123,14 +135,14 @@ public class TestExpressionBinding {
   public void testAlwaysTrue() {
     Assert.assertEquals("Should not change alwaysTrue",
         alwaysTrue(),
-        Binder.bind(STRUCT, alwaysTrue()));
+        Binder.bind(STRUCT, alwaysTrue(), true));
   }
 
   @Test
   public void testAlwaysFalse() {
     Assert.assertEquals("Should not change alwaysFalse",
         alwaysFalse(),
-        Binder.bind(STRUCT, alwaysFalse()));
+        Binder.bind(STRUCT, alwaysFalse(), true));
   }
 
   @Test
@@ -141,12 +153,14 @@ public class TestExpressionBinding {
     // the second predicate is always true once it is bound because z is an integer and the literal
     // is less than any 32-bit integer value
     Assert.assertEquals("Should simplify or expression to alwaysTrue",
-        alwaysTrue(), Binder.bind(STRUCT, or(lessThan("y", 100), greaterThan("z", -9999999999L))));
+        alwaysTrue(),
+        Binder.bind(STRUCT, or(lessThan("y", 100), greaterThan("z", -9999999999L)), true));
     // similarly, the second predicate is always false
     Assert.assertEquals("Should simplify and expression to predicate",
-        alwaysFalse(), Binder.bind(STRUCT, and(lessThan("y", 100), lessThan("z", -9999999999L))));
+        alwaysFalse(),
+        Binder.bind(STRUCT, and(lessThan("y", 100), lessThan("z", -9999999999L)), true));
 
-    Expression bound = Binder.bind(STRUCT, not(not(lessThan("y", 100))));
+    Expression bound = Binder.bind(STRUCT, not(not(lessThan("y", 100))), true);
     BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
     Assert.assertEquals("Should have the correct bound field", 1, pred.ref().fieldId());
   }

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionBinding.java
@@ -47,7 +47,7 @@ public class TestExpressionBinding {
   public void testMissingReference() {
     Expression expr = and(equal("t", 5), equal("x", 7));
     try {
-      Binder.bind(STRUCT, expr, true);
+      Binder.bind(STRUCT, expr);
       Assert.fail("Should not successfully bind to struct without field 't'");
     } catch (ValidationException e) {
       Assert.assertTrue("Should complain about missing field",
@@ -58,7 +58,7 @@ public class TestExpressionBinding {
   @Test(expected = IllegalStateException.class)
   public void testBoundExpressionFails() {
     Expression expr = not(equal("x", 7));
-    Binder.bind(STRUCT, Binder.bind(STRUCT, expr, true), true);
+    Binder.bind(STRUCT, Binder.bind(STRUCT, expr));
   }
 
   @Test
@@ -82,13 +82,13 @@ public class TestExpressionBinding {
   @Test
   public void testMultipleReferences() {
     Expression expr = or(and(equal("x", 7), lessThan("y", 100)), greaterThan("z", -100));
-    TestHelpers.assertAllReferencesBound("Multiple references", Binder.bind(STRUCT, expr, true));
+    TestHelpers.assertAllReferencesBound("Multiple references", Binder.bind(STRUCT, expr));
   }
 
   @Test
   public void testAnd() {
     Expression expr = and(equal("x", 7), lessThan("y", 100));
-    Expression boundExpr = Binder.bind(STRUCT, expr, true);
+    Expression boundExpr = Binder.bind(STRUCT, expr);
     TestHelpers.assertAllReferencesBound("And", boundExpr);
 
     // make sure the result is an And
@@ -104,7 +104,7 @@ public class TestExpressionBinding {
   @Test
   public void testOr() {
     Expression expr = or(greaterThan("z", -100), lessThan("y", 100));
-    Expression boundExpr = Binder.bind(STRUCT, expr, true);
+    Expression boundExpr = Binder.bind(STRUCT, expr);
     TestHelpers.assertAllReferencesBound("Or", boundExpr);
 
     // make sure the result is an Or
@@ -120,7 +120,7 @@ public class TestExpressionBinding {
   @Test
   public void testNot() {
     Expression expr = not(equal("x", 7));
-    Expression boundExpr = Binder.bind(STRUCT, expr, true);
+    Expression boundExpr = Binder.bind(STRUCT, expr);
     TestHelpers.assertAllReferencesBound("Not", boundExpr);
 
     // make sure the result is a Not
@@ -135,14 +135,14 @@ public class TestExpressionBinding {
   public void testAlwaysTrue() {
     Assert.assertEquals("Should not change alwaysTrue",
         alwaysTrue(),
-        Binder.bind(STRUCT, alwaysTrue(), true));
+        Binder.bind(STRUCT, alwaysTrue()));
   }
 
   @Test
   public void testAlwaysFalse() {
     Assert.assertEquals("Should not change alwaysFalse",
         alwaysFalse(),
-        Binder.bind(STRUCT, alwaysFalse(), true));
+        Binder.bind(STRUCT, alwaysFalse()));
   }
 
   @Test
@@ -153,14 +153,12 @@ public class TestExpressionBinding {
     // the second predicate is always true once it is bound because z is an integer and the literal
     // is less than any 32-bit integer value
     Assert.assertEquals("Should simplify or expression to alwaysTrue",
-        alwaysTrue(),
-        Binder.bind(STRUCT, or(lessThan("y", 100), greaterThan("z", -9999999999L)), true));
+        alwaysTrue(), Binder.bind(STRUCT, or(lessThan("y", 100), greaterThan("z", -9999999999L))));
     // similarly, the second predicate is always false
     Assert.assertEquals("Should simplify and expression to predicate",
-        alwaysFalse(),
-        Binder.bind(STRUCT, and(lessThan("y", 100), lessThan("z", -9999999999L)), true));
+        alwaysFalse(), Binder.bind(STRUCT, and(lessThan("y", 100), lessThan("z", -9999999999L))));
 
-    Expression bound = Binder.bind(STRUCT, not(not(lessThan("y", 100))), true);
+    Expression bound = Binder.bind(STRUCT, not(not(lessThan("y", 100))));
     BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
     Assert.assertEquals("Should have the correct bound field", 1, pred.ref().fieldId());
   }

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionSerialization.java
@@ -47,7 +47,7 @@ public class TestExpressionSerialization {
         Expressions.not(Expressions.greaterThan("a", 10)),
         Expressions.and(Expressions.greaterThanOrEqual("a", 0), Expressions.lessThan("a", 3)),
         Expressions.or(Expressions.lessThan("a", 0), Expressions.greaterThan("a", 10)),
-        Expressions.equal("a", 5).bind(schema.asStruct())
+        Expressions.equal("a", 5).bind(schema.asStruct(), true)
     };
 
     for (Expression expression : expressions) {

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestExpressionSerialization.java
@@ -47,7 +47,7 @@ public class TestExpressionSerialization {
         Expressions.not(Expressions.greaterThan("a", 10)),
         Expressions.and(Expressions.greaterThanOrEqual("a", 0), Expressions.lessThan("a", 3)),
         Expressions.or(Expressions.lessThan("a", 0), Expressions.greaterThan("a", 10)),
-        Expressions.equal("a", 5).bind(schema.asStruct(), true)
+        Expressions.equal("a", 5).bind(schema.asStruct())
     };
 
     for (Expression expression : expressions) {

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestPredicateBinding.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestPredicateBinding.java
@@ -56,7 +56,7 @@ public class TestPredicateBinding {
 
     UnboundPredicate<Integer> unbound = new UnboundPredicate<>(LT, ref("y"), 6);
 
-    Expression expr = unbound.bind(struct, true);
+    Expression expr = unbound.bind(struct);
     BoundPredicate<Integer> bound = assertAndUnwrap(expr);
 
     Assert.assertEquals("Should reference correct field ID", 11, bound.ref().fieldId());
@@ -73,7 +73,7 @@ public class TestPredicateBinding {
 
     UnboundPredicate<Integer> unbound = new UnboundPredicate<>(LT, ref("missing"), 6);
     try {
-      unbound.bind(struct, true);
+      unbound.bind(struct);
       Assert.fail("Binding a missing field should fail");
     } catch (ValidationException e) {
       Assert.assertTrue("Validation should complain about missing field",
@@ -89,7 +89,7 @@ public class TestPredicateBinding {
     for (Expression.Operation op : COMPARISONS) {
       UnboundPredicate<Integer> unbound = new UnboundPredicate<>(op, ref("x"), 5);
 
-      Expression expr = unbound.bind(struct, true);
+      Expression expr = unbound.bind(struct);
       BoundPredicate<Integer> bound = assertAndUnwrap(expr);
 
       Assert.assertEquals("Should not alter literal value",
@@ -107,7 +107,7 @@ public class TestPredicateBinding {
     for (Expression.Operation op : COMPARISONS) {
       UnboundPredicate<String> unbound = new UnboundPredicate<>(op, ref("d"), "12.40");
 
-      Expression expr = unbound.bind(struct, true);
+      Expression expr = unbound.bind(struct);
       BoundPredicate<BigDecimal> bound = assertAndUnwrap(expr);
       Assert.assertEquals("Should convert literal value to decimal",
           new BigDecimal("12.40"), bound.literal().value());
@@ -124,7 +124,7 @@ public class TestPredicateBinding {
       UnboundPredicate<String> unbound = new UnboundPredicate<>(op, ref("f"), "12.40");
 
       try {
-        unbound.bind(struct, true);
+        unbound.bind(struct);
         Assert.fail("Should not convert string to float");
       } catch (ValidationException e) {
         Assert.assertEquals("Should ",
@@ -142,42 +142,42 @@ public class TestPredicateBinding {
     UnboundPredicate<Long> lt = new UnboundPredicate<>(
         LT, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Less than above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lt.bind(struct, true));
+        Expressions.alwaysTrue(), lt.bind(struct));
 
     UnboundPredicate<Long> lteq = new UnboundPredicate<>(
         LT_EQ, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Less than or equal above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lteq.bind(struct, true));
+        Expressions.alwaysTrue(), lteq.bind(struct));
 
     UnboundPredicate<Long> gt = new UnboundPredicate<>(
         GT, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Greater than below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gt.bind(struct, true));
+        Expressions.alwaysTrue(), gt.bind(struct));
 
     UnboundPredicate<Long> gteq = new UnboundPredicate<>(
         GT_EQ, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Greater than or equal below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gteq.bind(struct, true));
+        Expressions.alwaysTrue(), gteq.bind(struct));
 
     UnboundPredicate<Long> gtMax = new UnboundPredicate<>(
         GT, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Greater than above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gtMax.bind(struct, true));
+        Expressions.alwaysFalse(), gtMax.bind(struct));
 
     UnboundPredicate<Long> gteqMax = new UnboundPredicate<>(
         GT_EQ, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Greater than or equal above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gteqMax.bind(struct, true));
+        Expressions.alwaysFalse(), gteqMax.bind(struct));
 
     UnboundPredicate<Long> ltMin = new UnboundPredicate<>(
         LT, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Less than below min should be alwaysFalse",
-        Expressions.alwaysFalse(), ltMin.bind(struct, true));
+        Expressions.alwaysFalse(), ltMin.bind(struct));
 
     UnboundPredicate<Long> lteqMin = new UnboundPredicate<>(
         LT_EQ, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Less than or equal below min should be alwaysFalse",
-        Expressions.alwaysFalse(), lteqMin.bind(struct, true));
+        Expressions.alwaysFalse(), lteqMin.bind(struct));
 
     Expression ltExpr = new UnboundPredicate<>(LT, ref("i"), (long) Integer.MAX_VALUE).bind(struct, true);
     BoundPredicate<Integer> ltMax = assertAndUnwrap(ltExpr);
@@ -185,18 +185,18 @@ public class TestPredicateBinding {
         (Integer) Integer.MAX_VALUE, ltMax.literal().value());
 
     Expression lteqExpr = new UnboundPredicate<>(LT_EQ, ref("i"), (long) Integer.MAX_VALUE)
-        .bind(struct, true);
+        .bind(struct);
     BoundPredicate<Integer> lteqMax = assertAndUnwrap(lteqExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MAX_VALUE, lteqMax.literal().value());
 
-    Expression gtExpr = new UnboundPredicate<>(GT, ref("i"), (long) Integer.MIN_VALUE).bind(struct, true);
+    Expression gtExpr = new UnboundPredicate<>(GT, ref("i"), (long) Integer.MIN_VALUE).bind(struct);
     BoundPredicate<Integer> gtMin = assertAndUnwrap(gtExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MIN_VALUE, gtMin.literal().value());
 
     Expression gteqExpr = new UnboundPredicate<>(GT_EQ, ref("i"), (long) Integer.MIN_VALUE)
-        .bind(struct, true);
+        .bind(struct);
     BoundPredicate<Integer> gteqMin = assertAndUnwrap(gteqExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MIN_VALUE, gteqMin.literal().value());
@@ -210,61 +210,61 @@ public class TestPredicateBinding {
     UnboundPredicate<Double> lt = new UnboundPredicate<>(
         LT, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Less than above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lt.bind(struct, true));
+        Expressions.alwaysTrue(), lt.bind(struct));
 
     UnboundPredicate<Double> lteq = new UnboundPredicate<>(
         LT_EQ, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Less than or equal above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lteq.bind(struct, true));
+        Expressions.alwaysTrue(), lteq.bind(struct));
 
     UnboundPredicate<Double> gt = new UnboundPredicate<>(
         GT, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Greater than below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gt.bind(struct, true));
+        Expressions.alwaysTrue(), gt.bind(struct));
 
     UnboundPredicate<Double> gteq = new UnboundPredicate<>(
         GT_EQ, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Greater than or equal below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gteq.bind(struct, true));
+        Expressions.alwaysTrue(), gteq.bind(struct));
 
     UnboundPredicate<Double> gtMax = new UnboundPredicate<>(
         GT, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Greater than above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gtMax.bind(struct, true));
+        Expressions.alwaysFalse(), gtMax.bind(struct));
 
     UnboundPredicate<Double> gteqMax = new UnboundPredicate<>(
         GT_EQ, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Greater than or equal above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gteqMax.bind(struct, true));
+        Expressions.alwaysFalse(), gteqMax.bind(struct));
 
     UnboundPredicate<Double> ltMin = new UnboundPredicate<>(
         LT, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Less than below min should be alwaysFalse",
-        Expressions.alwaysFalse(), ltMin.bind(struct, true));
+        Expressions.alwaysFalse(), ltMin.bind(struct));
 
     UnboundPredicate<Double> lteqMin = new UnboundPredicate<>(
         LT_EQ, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Less than or equal below min should be alwaysFalse",
-        Expressions.alwaysFalse(), lteqMin.bind(struct, true));
+        Expressions.alwaysFalse(), lteqMin.bind(struct));
 
-    Expression ltExpr = new UnboundPredicate<>(LT, ref("f"), (double) Float.MAX_VALUE).bind(struct, true);
+    Expression ltExpr = new UnboundPredicate<>(LT, ref("f"), (double) Float.MAX_VALUE).bind(struct);
     BoundPredicate<Float> ltMax = assertAndUnwrap(ltExpr);
     Assert.assertEquals("Should translate bound to Float",
         (Float) Float.MAX_VALUE, ltMax.literal().value());
 
     Expression lteqExpr = new UnboundPredicate<>(LT_EQ, ref("f"), (double) Float.MAX_VALUE)
-        .bind(struct, true);
+        .bind(struct);
     BoundPredicate<Float> lteqMax = assertAndUnwrap(lteqExpr);
     Assert.assertEquals("Should translate bound to Float",
         (Float) Float.MAX_VALUE, lteqMax.literal().value());
 
-    Expression gtExpr = new UnboundPredicate<>(GT, ref("f"), (double) -Float.MAX_VALUE).bind(struct, true);
+    Expression gtExpr = new UnboundPredicate<>(GT, ref("f"), (double) -Float.MAX_VALUE).bind(struct);
     BoundPredicate<Float> gtMin = assertAndUnwrap(gtExpr);
     Assert.assertEquals("Should translate bound to Float",
         Float.valueOf(-Float.MAX_VALUE), gtMin.literal().value());
 
     Expression gteqExpr = new UnboundPredicate<>(GT_EQ, ref("f"), (double) -Float.MAX_VALUE)
-        .bind(struct, true);
+        .bind(struct);
     BoundPredicate<Float> gteqMin = assertAndUnwrap(gteqExpr);
     Assert.assertEquals("Should translate bound to Float",
         Float.valueOf(-Float.MAX_VALUE), gteqMin.literal().value());
@@ -276,7 +276,7 @@ public class TestPredicateBinding {
     StructType optional = StructType.of(optional(19, "s", Types.StringType.get()));
 
     UnboundPredicate<?> unbound = new UnboundPredicate<>(IS_NULL, ref("s"));
-    Expression expr = unbound.bind(optional, true);
+    Expression expr = unbound.bind(optional);
     BoundPredicate<?> bound = assertAndUnwrap(expr);
     Assert.assertEquals("Should use the same operation", IS_NULL, bound.op());
     Assert.assertEquals("Should use the correct field", 19, bound.ref().fieldId());
@@ -284,7 +284,7 @@ public class TestPredicateBinding {
 
     StructType required = StructType.of(required(20, "s", Types.StringType.get()));
     Assert.assertEquals("IsNull inclusive a required field should be alwaysFalse",
-        Expressions.alwaysFalse(), unbound.bind(required, true));
+        Expressions.alwaysFalse(), unbound.bind(required));
   }
 
   @Test
@@ -292,7 +292,7 @@ public class TestPredicateBinding {
     StructType optional = StructType.of(optional(21, "s", Types.StringType.get()));
 
     UnboundPredicate<?> unbound = new UnboundPredicate<>(NOT_NULL, ref("s"));
-    Expression expr = unbound.bind(optional, true);
+    Expression expr = unbound.bind(optional);
     BoundPredicate<?> bound = assertAndUnwrap(expr);
     Assert.assertEquals("Should use the same operation", NOT_NULL, bound.op());
     Assert.assertEquals("Should use the correct field", 21, bound.ref().fieldId());
@@ -300,6 +300,6 @@ public class TestPredicateBinding {
 
     StructType required = StructType.of(required(22, "s", Types.StringType.get()));
     Assert.assertEquals("NotNull inclusive a required field should be alwaysTrue",
-        Expressions.alwaysTrue(), unbound.bind(required, true));
+        Expressions.alwaysTrue(), unbound.bind(required));
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/expressions/TestPredicateBinding.java
+++ b/api/src/test/java/com/netflix/iceberg/expressions/TestPredicateBinding.java
@@ -56,7 +56,7 @@ public class TestPredicateBinding {
 
     UnboundPredicate<Integer> unbound = new UnboundPredicate<>(LT, ref("y"), 6);
 
-    Expression expr = unbound.bind(struct);
+    Expression expr = unbound.bind(struct, true);
     BoundPredicate<Integer> bound = assertAndUnwrap(expr);
 
     Assert.assertEquals("Should reference correct field ID", 11, bound.ref().fieldId());
@@ -73,7 +73,7 @@ public class TestPredicateBinding {
 
     UnboundPredicate<Integer> unbound = new UnboundPredicate<>(LT, ref("missing"), 6);
     try {
-      unbound.bind(struct);
+      unbound.bind(struct, true);
       Assert.fail("Binding a missing field should fail");
     } catch (ValidationException e) {
       Assert.assertTrue("Validation should complain about missing field",
@@ -89,7 +89,7 @@ public class TestPredicateBinding {
     for (Expression.Operation op : COMPARISONS) {
       UnboundPredicate<Integer> unbound = new UnboundPredicate<>(op, ref("x"), 5);
 
-      Expression expr = unbound.bind(struct);
+      Expression expr = unbound.bind(struct, true);
       BoundPredicate<Integer> bound = assertAndUnwrap(expr);
 
       Assert.assertEquals("Should not alter literal value",
@@ -107,7 +107,7 @@ public class TestPredicateBinding {
     for (Expression.Operation op : COMPARISONS) {
       UnboundPredicate<String> unbound = new UnboundPredicate<>(op, ref("d"), "12.40");
 
-      Expression expr = unbound.bind(struct);
+      Expression expr = unbound.bind(struct, true);
       BoundPredicate<BigDecimal> bound = assertAndUnwrap(expr);
       Assert.assertEquals("Should convert literal value to decimal",
           new BigDecimal("12.40"), bound.literal().value());
@@ -124,7 +124,7 @@ public class TestPredicateBinding {
       UnboundPredicate<String> unbound = new UnboundPredicate<>(op, ref("f"), "12.40");
 
       try {
-        unbound.bind(struct);
+        unbound.bind(struct, true);
         Assert.fail("Should not convert string to float");
       } catch (ValidationException e) {
         Assert.assertEquals("Should ",
@@ -142,61 +142,61 @@ public class TestPredicateBinding {
     UnboundPredicate<Long> lt = new UnboundPredicate<>(
         LT, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Less than above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lt.bind(struct));
+        Expressions.alwaysTrue(), lt.bind(struct, true));
 
     UnboundPredicate<Long> lteq = new UnboundPredicate<>(
         LT_EQ, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Less than or equal above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lteq.bind(struct));
+        Expressions.alwaysTrue(), lteq.bind(struct, true));
 
     UnboundPredicate<Long> gt = new UnboundPredicate<>(
         GT, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Greater than below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gt.bind(struct));
+        Expressions.alwaysTrue(), gt.bind(struct, true));
 
     UnboundPredicate<Long> gteq = new UnboundPredicate<>(
         GT_EQ, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Greater than or equal below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gteq.bind(struct));
+        Expressions.alwaysTrue(), gteq.bind(struct, true));
 
     UnboundPredicate<Long> gtMax = new UnboundPredicate<>(
         GT, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Greater than above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gtMax.bind(struct));
+        Expressions.alwaysFalse(), gtMax.bind(struct, true));
 
     UnboundPredicate<Long> gteqMax = new UnboundPredicate<>(
         GT_EQ, ref("i"), (long) Integer.MAX_VALUE + 1L);
     Assert.assertEquals("Greater than or equal above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gteqMax.bind(struct));
+        Expressions.alwaysFalse(), gteqMax.bind(struct, true));
 
     UnboundPredicate<Long> ltMin = new UnboundPredicate<>(
         LT, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Less than below min should be alwaysFalse",
-        Expressions.alwaysFalse(), ltMin.bind(struct));
+        Expressions.alwaysFalse(), ltMin.bind(struct, true));
 
     UnboundPredicate<Long> lteqMin = new UnboundPredicate<>(
         LT_EQ, ref("i"), (long) Integer.MIN_VALUE - 1L);
     Assert.assertEquals("Less than or equal below min should be alwaysFalse",
-        Expressions.alwaysFalse(), lteqMin.bind(struct));
+        Expressions.alwaysFalse(), lteqMin.bind(struct, true));
 
-    Expression ltExpr = new UnboundPredicate<>(LT, ref("i"), (long) Integer.MAX_VALUE).bind(struct);
+    Expression ltExpr = new UnboundPredicate<>(LT, ref("i"), (long) Integer.MAX_VALUE).bind(struct, true);
     BoundPredicate<Integer> ltMax = assertAndUnwrap(ltExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MAX_VALUE, ltMax.literal().value());
 
     Expression lteqExpr = new UnboundPredicate<>(LT_EQ, ref("i"), (long) Integer.MAX_VALUE)
-        .bind(struct);
+        .bind(struct, true);
     BoundPredicate<Integer> lteqMax = assertAndUnwrap(lteqExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MAX_VALUE, lteqMax.literal().value());
 
-    Expression gtExpr = new UnboundPredicate<>(GT, ref("i"), (long) Integer.MIN_VALUE).bind(struct);
+    Expression gtExpr = new UnboundPredicate<>(GT, ref("i"), (long) Integer.MIN_VALUE).bind(struct, true);
     BoundPredicate<Integer> gtMin = assertAndUnwrap(gtExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MIN_VALUE, gtMin.literal().value());
 
     Expression gteqExpr = new UnboundPredicate<>(GT_EQ, ref("i"), (long) Integer.MIN_VALUE)
-        .bind(struct);
+        .bind(struct, true);
     BoundPredicate<Integer> gteqMin = assertAndUnwrap(gteqExpr);
     Assert.assertEquals("Should translate bound to Integer",
         (Integer) Integer.MIN_VALUE, gteqMin.literal().value());
@@ -210,61 +210,61 @@ public class TestPredicateBinding {
     UnboundPredicate<Double> lt = new UnboundPredicate<>(
         LT, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Less than above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lt.bind(struct));
+        Expressions.alwaysTrue(), lt.bind(struct, true));
 
     UnboundPredicate<Double> lteq = new UnboundPredicate<>(
         LT_EQ, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Less than or equal above max should be alwaysTrue",
-        Expressions.alwaysTrue(), lteq.bind(struct));
+        Expressions.alwaysTrue(), lteq.bind(struct, true));
 
     UnboundPredicate<Double> gt = new UnboundPredicate<>(
         GT, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Greater than below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gt.bind(struct));
+        Expressions.alwaysTrue(), gt.bind(struct, true));
 
     UnboundPredicate<Double> gteq = new UnboundPredicate<>(
         GT_EQ, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Greater than or equal below min should be alwaysTrue",
-        Expressions.alwaysTrue(), gteq.bind(struct));
+        Expressions.alwaysTrue(), gteq.bind(struct, true));
 
     UnboundPredicate<Double> gtMax = new UnboundPredicate<>(
         GT, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Greater than above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gtMax.bind(struct));
+        Expressions.alwaysFalse(), gtMax.bind(struct, true));
 
     UnboundPredicate<Double> gteqMax = new UnboundPredicate<>(
         GT_EQ, ref("f"), (double) Float.MAX_VALUE * 2);
     Assert.assertEquals("Greater than or equal above max should be alwaysFalse",
-        Expressions.alwaysFalse(), gteqMax.bind(struct));
+        Expressions.alwaysFalse(), gteqMax.bind(struct, true));
 
     UnboundPredicate<Double> ltMin = new UnboundPredicate<>(
         LT, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Less than below min should be alwaysFalse",
-        Expressions.alwaysFalse(), ltMin.bind(struct));
+        Expressions.alwaysFalse(), ltMin.bind(struct, true));
 
     UnboundPredicate<Double> lteqMin = new UnboundPredicate<>(
         LT_EQ, ref("f"), (double) Float.MAX_VALUE * -2);
     Assert.assertEquals("Less than or equal below min should be alwaysFalse",
-        Expressions.alwaysFalse(), lteqMin.bind(struct));
+        Expressions.alwaysFalse(), lteqMin.bind(struct, true));
 
-    Expression ltExpr = new UnboundPredicate<>(LT, ref("f"), (double) Float.MAX_VALUE).bind(struct);
+    Expression ltExpr = new UnboundPredicate<>(LT, ref("f"), (double) Float.MAX_VALUE).bind(struct, true);
     BoundPredicate<Float> ltMax = assertAndUnwrap(ltExpr);
     Assert.assertEquals("Should translate bound to Float",
         (Float) Float.MAX_VALUE, ltMax.literal().value());
 
     Expression lteqExpr = new UnboundPredicate<>(LT_EQ, ref("f"), (double) Float.MAX_VALUE)
-        .bind(struct);
+        .bind(struct, true);
     BoundPredicate<Float> lteqMax = assertAndUnwrap(lteqExpr);
     Assert.assertEquals("Should translate bound to Float",
         (Float) Float.MAX_VALUE, lteqMax.literal().value());
 
-    Expression gtExpr = new UnboundPredicate<>(GT, ref("f"), (double) -Float.MAX_VALUE).bind(struct);
+    Expression gtExpr = new UnboundPredicate<>(GT, ref("f"), (double) -Float.MAX_VALUE).bind(struct, true);
     BoundPredicate<Float> gtMin = assertAndUnwrap(gtExpr);
     Assert.assertEquals("Should translate bound to Float",
         Float.valueOf(-Float.MAX_VALUE), gtMin.literal().value());
 
     Expression gteqExpr = new UnboundPredicate<>(GT_EQ, ref("f"), (double) -Float.MAX_VALUE)
-        .bind(struct);
+        .bind(struct, true);
     BoundPredicate<Float> gteqMin = assertAndUnwrap(gteqExpr);
     Assert.assertEquals("Should translate bound to Float",
         Float.valueOf(-Float.MAX_VALUE), gteqMin.literal().value());
@@ -276,7 +276,7 @@ public class TestPredicateBinding {
     StructType optional = StructType.of(optional(19, "s", Types.StringType.get()));
 
     UnboundPredicate<?> unbound = new UnboundPredicate<>(IS_NULL, ref("s"));
-    Expression expr = unbound.bind(optional);
+    Expression expr = unbound.bind(optional, true);
     BoundPredicate<?> bound = assertAndUnwrap(expr);
     Assert.assertEquals("Should use the same operation", IS_NULL, bound.op());
     Assert.assertEquals("Should use the correct field", 19, bound.ref().fieldId());
@@ -284,7 +284,7 @@ public class TestPredicateBinding {
 
     StructType required = StructType.of(required(20, "s", Types.StringType.get()));
     Assert.assertEquals("IsNull inclusive a required field should be alwaysFalse",
-        Expressions.alwaysFalse(), unbound.bind(required));
+        Expressions.alwaysFalse(), unbound.bind(required, true));
   }
 
   @Test
@@ -292,7 +292,7 @@ public class TestPredicateBinding {
     StructType optional = StructType.of(optional(21, "s", Types.StringType.get()));
 
     UnboundPredicate<?> unbound = new UnboundPredicate<>(NOT_NULL, ref("s"));
-    Expression expr = unbound.bind(optional);
+    Expression expr = unbound.bind(optional, true);
     BoundPredicate<?> bound = assertAndUnwrap(expr);
     Assert.assertEquals("Should use the same operation", NOT_NULL, bound.op());
     Assert.assertEquals("Should use the correct field", 21, bound.ref().fieldId());
@@ -300,6 +300,6 @@ public class TestPredicateBinding {
 
     StructType required = StructType.of(required(22, "s", Types.StringType.get()));
     Assert.assertEquals("NotNull inclusive a required field should be alwaysTrue",
-        Expressions.alwaysTrue(), unbound.bind(required));
+        Expressions.alwaysTrue(), unbound.bind(required, true));
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestProjection.java
@@ -71,7 +71,7 @@ public class TestProjection {
       UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
 
       // check inclusive the bound predicate to ensure the types are correct
-      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct()));
+      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), true));
 
       Assert.assertEquals("Field name should match partition struct field",
           "id", projected.ref().name());
@@ -109,7 +109,7 @@ public class TestProjection {
       UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
 
       // check inclusive the bound predicate to ensure the types are correct
-      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct()));
+      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), true));
 
       Assert.assertEquals("Field name should match partition struct field",
           "id", projected.ref().name());

--- a/core/src/main/java/com/netflix/iceberg/BaseTableScan.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTableScan.java
@@ -130,7 +130,7 @@ class BaseTableScan implements TableScan {
 
     // all of the filter columns are required
     requiredFieldIds.addAll(
-        Binder.boundReferences(table.schema().asStruct(), Collections.singletonList(rowFilter)));
+        Binder.boundReferences(table.schema().asStruct(), Collections.singletonList(rowFilter), true));
 
     // all of the projection columns are required
     requiredFieldIds.addAll(TypeUtil.getProjectedIds(table.schema().select(columns)));

--- a/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -68,7 +68,7 @@ public class ParquetDictionaryRowGroupFilter {
   public ParquetDictionaryRowGroupFilter(Schema schema, Expression unbound) {
     this.schema = schema;
     this.struct = schema.asStruct();
-    this.expr = Binder.bind(struct, rewriteNot(unbound));
+    this.expr = Binder.bind(struct, rewriteNot(unbound), true);
   }
 
   /**

--- a/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetFilters.java
@@ -161,7 +161,7 @@ class ParquetFilters {
     }
 
     protected Expression bind(UnboundPredicate<?> pred) {
-      return pred.bind(schema.asStruct());
+      return pred.bind(schema.asStruct(), true);
     }
 
     @Override
@@ -189,7 +189,7 @@ class ParquetFilters {
 
     protected Expression bind(UnboundPredicate<?> pred) {
       // instead of binding the predicate using the top-level schema, bind it to the partition data
-      return pred.bind(partitionStruct);
+      return pred.bind(partitionStruct, true);
     }
   }
 

--- a/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -57,7 +57,7 @@ public class ParquetMetricsRowGroupFilter {
   public ParquetMetricsRowGroupFilter(Schema schema, Expression unbound) {
     this.schema = schema;
     this.struct = schema.asStruct();
-    this.expr = Binder.bind(struct, rewriteNot(unbound));
+    this.expr = Binder.bind(struct, rewriteNot(unbound), true);
   }
 
   /**

--- a/spark/src/main/java/com/netflix/iceberg/spark/SparkExpressions.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/SparkExpressions.java
@@ -336,7 +336,7 @@ public class SparkExpressions {
 
   public static Expression convert(com.netflix.iceberg.expressions.Expression filter,
                                    Schema schema) {
-    return visit(Binder.bind(schema.asStruct(), filter), new ExpressionToSpark(schema));
+    return visit(Binder.bind(schema.asStruct(), filter, true), new ExpressionToSpark(schema));
   }
 
   private static class ExpressionToSpark extends ExpressionVisitors.

--- a/spark/src/main/java/com/netflix/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/SparkSchemaUtil.java
@@ -202,7 +202,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the Spark type does not match the Schema
    */
   public static Schema prune(Schema schema, StructType requestedType, List<Expression> filters) {
-    Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), filters);
+    Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), filters, true);
     return new Schema(visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
         .asNestedType()
         .asStructType()
@@ -225,7 +225,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the Spark type does not match the Schema
    */
   public static Schema prune(Schema schema, StructType requestedType, Expression filter) {
-    Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), Collections.singletonList(filter));
+    Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), Collections.singletonList(filter), true);
     return new Schema(visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
         .asNestedType()
         .asStructType()


### PR DESCRIPTION
Iceberg's current implementation has column case sensitivity, which hinders usability, as most sql users expect case insensitivity by default. While a query like the following will succeed in other Spark Readers, it will fail on Iceberg:

```sql
SELECT COUNT(*)
FROM iceTable
WHERE year = 2017
  AND MONTH = 11 -- Notice how MONTH has different casing than other predicates
  AND day = 01
```

This will fail with a stack trace similar to:
```
com.google.common.util.concurrent.UncheckedExecutionException: com.netflix.iceberg.exceptions.ValidationException: Cannot find field 'MONTH' in struct: struct<...>
...
```
In this PR, we solve this by making iceberg-api case-insensitive when binding expressions.


Some further notes:

- We could also solve this in iceberg-spark, however, that implies we would have to solve it in any other engine that supports iceberg ( presto, pig, etc ).

- Enabling case insensitivity implies that a table can not have columns were `LOWER(a) == LOWER(b)`. I have a `TODO` in the PR as maybe this change makes more sense under a feature flag.