### PR TITLE
Fix row group dictionary filter handling of null values.

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -90,6 +90,7 @@ public class ParquetDictionaryRowGroupFilter {
     private DictionaryPageReadStore dictionaries = null;
     private Map<Integer, Set<?>> dictCache = null;
     private Map<Integer, Boolean> isFallback = null;
+    private Map<Integer, Boolean> mayContainNulls = null;
     private Map<Integer, ColumnDescriptor> cols = null;
     private Map<Integer, Function<Object, Object>> conversions = null;
 
@@ -98,6 +99,7 @@ public class ParquetDictionaryRowGroupFilter {
       this.dictionaries = dictionaries;
       this.dictCache = Maps.newHashMap();
       this.isFallback = Maps.newHashMap();
+      this.mayContainNulls = Maps.newHashMap();
       this.cols = Maps.newHashMap();
       this.conversions = Maps.newHashMap();
 
@@ -115,6 +117,7 @@ public class ParquetDictionaryRowGroupFilter {
         if (colType.getId() != null) {
           int id = colType.getId().intValue();
           isFallback.put(id, hasNonDictionaryPages(meta));
+          mayContainNulls.put(id, mayContainNull(meta));
         }
       }
 
@@ -282,7 +285,7 @@ public class ParquetDictionaryRowGroupFilter {
       }
 
       Set<T> dictionary = dict(id, lit.comparator());
-      if (dictionary.size() > 1) {
+      if (dictionary.size() > 1 || mayContainNulls.get(id)) {
         return ROWS_MIGHT_MATCH;
       }
 
@@ -346,6 +349,10 @@ public class ParquetDictionaryRowGroupFilter {
 
       return dictSet;
     }
+  }
+
+  private static boolean mayContainNull(ColumnChunkMetaData meta) {
+    return meta.getStatistics() == null || meta.getStatistics().getNumNulls() != 0;
   }
 
   @SuppressWarnings("deprecation")

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -135,6 +135,35 @@ public class TestDictionaryRowGroupFilter {
   }
 
   @Test
+  public void testAssumptions() {
+    // this case validates that other cases don't need to test expressions with null literals.
+    TestHelpers.assertThrows("Should reject null literal in equal expression",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> equal("col", null));
+    TestHelpers.assertThrows("Should reject null literal in notEqual expression",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> notEqual("col", null));
+    TestHelpers.assertThrows("Should reject null literal in lessThan expression",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> lessThan("col", null));
+    TestHelpers.assertThrows("Should reject null literal in lessThanOrEqual expression",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> lessThanOrEqual("col", null));
+    TestHelpers.assertThrows("Should reject null literal in greaterThan expression",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> greaterThan("col", null));
+    TestHelpers.assertThrows("Should reject null literal in greaterThanOrEqual expression",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> greaterThanOrEqual("col", null));
+  }
+
+  @Test
   public void testAllNulls() {
     boolean shouldRead = new ParquetDictionaryRowGroupFilter(SCHEMA, notNull("all_nulls"))
         .shouldRead(PARQUET_SCHEMA, ROW_GROUP_METADATA, DICTIONARY_STORE);
@@ -434,7 +463,11 @@ public class TestDictionaryRowGroupFilter {
   public void testStringNotEq() {
     boolean shouldRead = new ParquetDictionaryRowGroupFilter(SCHEMA, notEqual("some_nulls", "some"))
         .shouldRead(PARQUET_SCHEMA, ROW_GROUP_METADATA, DICTIONARY_STORE);
-    Assert.assertFalse("Should skip: all values are 'some'", shouldRead);
+    Assert.assertTrue("Should read: contains null != 'some'", shouldRead);
+
+    shouldRead = new ParquetDictionaryRowGroupFilter(SCHEMA, notEqual("no_nulls", ""))
+        .shouldRead(PARQUET_SCHEMA, ROW_GROUP_METADATA, DICTIONARY_STORE);
+    Assert.assertFalse("Should skip: contains only ''", shouldRead);
   }
 
 }


### PR DESCRIPTION
This is a fix for PARQUET-1510 ported to Iceberg's implementation of dictionary filtering.