### PR TITLE
Ignore unsupported partition fields

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Expressions.java
@@ -117,8 +117,8 @@ public class Expressions {
     return new UnboundPredicate<>(op, ref(name));
   }
 
-  public static <T> UnboundPredicate<T> alwaysTrue(String name) {
-    return new UnboundPredicate<>(Expressions.alwaysTrue().op(), ref(name));
+  public static <T> UnboundPredicate<T> alwaysTrueUnboundPredicate() {
+    return new UnboundPredicate<>(Operation.TRUE, null);
   }
 
   public static True alwaysTrue() {

--- a/api/src/main/java/com/netflix/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Expressions.java
@@ -117,6 +117,10 @@ public class Expressions {
     return new UnboundPredicate<>(op, ref(name));
   }
 
+  public static <T> UnboundPredicate<T> alwaysTrue(String name) {
+    return new UnboundPredicate<>(Expressions.alwaysTrue().op(), ref(name));
+  }
+
   public static True alwaysTrue() {
     return True.INSTANCE;
   }

--- a/api/src/main/java/com/netflix/iceberg/transforms/Transform.java
+++ b/api/src/main/java/com/netflix/iceberg/transforms/Transform.java
@@ -43,7 +43,7 @@ public interface Transform<S, T> extends Serializable {
   T apply(S value);
 
   /**
-   * Checks whether this function can be applied to the give {@link Type}.
+   * Checks whether this function can be applied to the given {@link Type}.
    *
    * @param type a type
    * @return true if this transform can be applied to the type, false otherwise

--- a/api/src/main/java/com/netflix/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/com/netflix/iceberg/transforms/Transforms.java
@@ -73,7 +73,7 @@ public class Transforms {
   }
 
   private static Transform<?,?> match(Supplier<Transform> transformSupplier,
-      Supplier<Transform> defaultSupplier) {
+                                      Supplier<Transform> defaultSupplier) {
     try {
       return transformSupplier.get();
     } catch(IllegalArgumentException e) {

--- a/api/src/main/java/com/netflix/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/com/netflix/iceberg/transforms/UnknownTransform.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg.transforms;
+
+import com.netflix.iceberg.expressions.BoundPredicate;
+import com.netflix.iceberg.expressions.Expressions;
+import com.netflix.iceberg.expressions.UnboundPredicate;
+import com.netflix.iceberg.types.Type;
+
+class UnknownTransform<S, T> implements Transform<S, T> {
+
+  private final Type type;
+  private final String transform;
+
+  public UnknownTransform(Type type, String transform) {
+    this.type = type;
+    this.transform = transform;
+  }
+
+  @Override
+  public T apply(S value) {
+    throw new IllegalArgumentException(
+        "Unknown transform: " + transform + " for type: " + type.typeId().name());
+  }
+
+  @Override
+  public boolean canTransform(Type type) {
+    // Assuming the transform function can be applied for this type
+    return true;
+  }
+
+  @Override
+  public Type getResultType(Type sourceType) {
+    return type;
+  }
+
+  @Override
+  public UnboundPredicate<T> project(String name, BoundPredicate<S> predicate) {
+    // Assuming all partition values may contain matching data
+    return Expressions.alwaysTrue(name);
+  }
+
+  @Override
+  public UnboundPredicate<T> projectStrict(String name, BoundPredicate<S> predicate) {
+    // Can not provide guarantees of matching a predicate
+    return null;
+  }
+}

--- a/api/src/main/java/com/netflix/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/com/netflix/iceberg/transforms/UnknownTransform.java
@@ -24,7 +24,9 @@ import com.netflix.iceberg.expressions.Expressions;
 import com.netflix.iceberg.expressions.UnboundPredicate;
 import com.netflix.iceberg.types.Type;
 
-class UnknownTransform<S, T> implements Transform<S, T> {
+import java.util.Objects;
+
+public class UnknownTransform<S, T> implements Transform<S, T> {
 
   private final Type type;
   private final String transform;
@@ -42,7 +44,8 @@ class UnknownTransform<S, T> implements Transform<S, T> {
 
   @Override
   public boolean canTransform(Type type) {
-    // Assuming the transform function can be applied for this type
+    // Assuming the transform function can be applied for this type because unknown transform is only used when parsing
+    // a transform in an existing table (a previous Iceberg version has already validated this)
     return true;
   }
 
@@ -61,5 +64,25 @@ class UnknownTransform<S, T> implements Transform<S, T> {
   public UnboundPredicate<T> projectStrict(String name, BoundPredicate<S> predicate) {
     // Can not provide guarantees of matching a predicate
     return null;
+  }
+
+
+  @Override
+  public String toString() {
+    return String.format("unknown:%s:%s", type.toString(), transform);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    UnknownTransform<?, ?> that = (UnknownTransform<?, ?>) o;
+    return type.equals(that.type) &&
+            transform.equals(that.transform);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, transform);
   }
 }

--- a/api/src/main/java/com/netflix/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/com/netflix/iceberg/transforms/UnknownTransform.java
@@ -54,7 +54,7 @@ class UnknownTransform<S, T> implements Transform<S, T> {
   @Override
   public UnboundPredicate<T> project(String name, BoundPredicate<S> predicate) {
     // Assuming all partition values may contain matching data
-    return Expressions.alwaysTrue(name);
+    return Expressions.alwaysTrueUnboundPredicate();
   }
 
   @Override

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestProjection.java
@@ -21,6 +21,7 @@ package com.netflix.iceberg.transforms;
 
 import com.google.common.collect.Lists;
 import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.TestHelpers;
 import com.netflix.iceberg.expressions.BoundPredicate;
 import com.netflix.iceberg.expressions.Expression;
 import com.netflix.iceberg.expressions.Expressions;
@@ -168,53 +169,11 @@ public class TestProjection {
   }
 
   @Test
-  public void testUnknownTransformProjection() {
-    List<UnboundPredicate<?>> predicates = Lists.newArrayList(
-        Expressions.notNull("id"),
-        Expressions.isNull("id"),
-        Expressions.lessThan("id", 100),
-        Expressions.lessThanOrEqual("id", 101),
-        Expressions.greaterThan("id", 102),
-        Expressions.greaterThanOrEqual("id", 103),
-        Expressions.equal("id", 104),
-        Expressions.notEqual("id", 105)
-    );
-
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
-        .add(16, "id", "unknown")
-        .build();
-
-    for (UnboundPredicate<?> predicate : predicates) {
-      // get the projected predicate
-      Expression expr = Projections.inclusive(spec).project(predicate);
-      UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
-
-      Assert.assertEquals("Field name should match partition field",
-          "id", projected.ref().name());
-      Assert.assertEquals("Operation should match always true", Expressions.alwaysTrue().op(), projected.op());
-    }
-  }
-
-  @Test
   public void testUnknownTransformStrictProjection() {
-    List<UnboundPredicate<?>> predicates = Lists.newArrayList(
-        Expressions.notNull("id"),
-        Expressions.isNull("id"),
-        Expressions.lessThan("id", 100),
-        Expressions.lessThanOrEqual("id", 101),
-        Expressions.greaterThan("id", 102),
-        Expressions.greaterThanOrEqual("id", 103),
-        Expressions.equal("id", 104),
-        Expressions.notEqual("id", 105)
-    );
-
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
-        .add(16, "id", "unknown")
-        .build();
-
-    for (UnboundPredicate<?> predicate : predicates) {
-      Assert.assertEquals("Operation should match always false", Expressions.alwaysFalse(),
-          Projections.strict(spec).project(predicate));
-    }
+    TestHelpers.assertThrows("Should complain about unsupported transform",
+            IllegalArgumentException.class, "Transform not supported: unknown:long:unknown",
+            () -> PartitionSpec.builderFor(SCHEMA)
+                    .add(16, "id", "unknown")
+                    .build());
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestTransformSerialization.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestTransformSerialization.java
@@ -19,13 +19,9 @@
 
 package com.netflix.iceberg.transforms;
 
-import static com.netflix.iceberg.expressions.Expressions.lessThan;
-
 import com.netflix.iceberg.PartitionSpec;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.TestHelpers;
-import com.netflix.iceberg.exceptions.ValidationException;
-import com.netflix.iceberg.expressions.StrictMetricsEvaluator;
 import com.netflix.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -91,15 +87,11 @@ public class TestTransformSerialization {
     Schema schema = new Schema(
         Types.NestedField.required(1, "i", Types.IntegerType.get()));
 
-    // a spec with an unknown transform
-    PartitionSpec spec = PartitionSpec.builderFor(schema)
-        .add(1, "unknown", "unknown")
-        .build();
-
-    Transform transform = spec.getFieldBySourceId(1).transform();
-
+    // test a partition spec with an unknown transform
     TestHelpers.assertThrows("Should complain about missing column in expression",
-        IllegalArgumentException.class, "Unknown transform: unknown for type: INTEGER",
-        () -> transform.apply("someValue"));
+        IllegalArgumentException.class, "Transform not supported: unknown:int:unknown",
+        () -> PartitionSpec.builderFor(schema)
+                    .add(1, "unknown", "unknown")
+                    .build());
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestTransformSerialization.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestTransformSerialization.java
@@ -19,10 +19,13 @@
 
 package com.netflix.iceberg.transforms;
 
+import static com.netflix.iceberg.expressions.Expressions.lessThan;
 
 import com.netflix.iceberg.PartitionSpec;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.TestHelpers;
+import com.netflix.iceberg.exceptions.ValidationException;
+import com.netflix.iceberg.expressions.StrictMetricsEvaluator;
 import com.netflix.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -83,7 +86,7 @@ public class TestTransformSerialization {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testApplyUnknownTransform() {
     Schema schema = new Schema(
         Types.NestedField.required(1, "i", Types.IntegerType.get()));
@@ -94,6 +97,9 @@ public class TestTransformSerialization {
         .build();
 
     Transform transform = spec.getFieldBySourceId(1).transform();
-    transform.apply("someValue");
+
+    TestHelpers.assertThrows("Should complain about missing column in expression",
+        IllegalArgumentException.class, "Unknown transform: unknown for type: INTEGER",
+        () -> transform.apply("someValue"));
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestTransformSerialization.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestTransformSerialization.java
@@ -19,6 +19,7 @@
 
 package com.netflix.iceberg.transforms;
 
+
 import com.netflix.iceberg.PartitionSpec;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.TestHelpers;
@@ -79,5 +80,20 @@ public class TestTransformSerialization {
 
     Assert.assertEquals("Deserialization should produce equal partition spec",
         spec, TestHelpers.roundTripSerialize(spec));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test(expected = IllegalArgumentException.class)
+  public void testApplyUnknownTransform() {
+    Schema schema = new Schema(
+        Types.NestedField.required(1, "i", Types.IntegerType.get()));
+
+    // a spec with an unknown transform
+    PartitionSpec spec = PartitionSpec.builderFor(schema)
+        .add(1, "unknown", "unknown")
+        .build();
+
+    Transform transform = spec.getFieldBySourceId(1).transform();
+    transform.apply("someValue");
   }
 }

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestUnknownTransform.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestUnknownTransform.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg.transforms;
+
+import static com.netflix.iceberg.TestHelpers.assertAndUnwrapUnbound;
+import static com.netflix.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static com.netflix.iceberg.expressions.Expressions.lessThanOrEqual;
+import static com.netflix.iceberg.expressions.Expressions.or;
+import static com.netflix.iceberg.types.Types.NestedField.optional;
+import static com.netflix.iceberg.types.Types.NestedField.required;
+
+import com.netflix.iceberg.PartitionSpec;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.expressions.Expression;
+import com.netflix.iceberg.expressions.Expressions;
+import com.netflix.iceberg.expressions.Or;
+import com.netflix.iceberg.expressions.Projections;
+import com.netflix.iceberg.expressions.UnboundPredicate;
+import com.netflix.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUnknownTransform {
+
+  @Test
+  public void testUnknownTransform() {
+    Schema schema = new Schema(
+        required(1, "id", Types.LongType.get()),
+        optional(2, "before", Types.DateType.get()),
+        required(3, "after", Types.DateType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema)
+        .day("before")
+        .add(3, "after_unknown_transform", "unknown")
+        .build();
+
+    Expression filter = or(lessThanOrEqual("before", "2018-12-12"),
+        greaterThanOrEqual("after", "2017-01-01"));
+    Expression projection = Projections.inclusive(spec).project(filter);
+
+    Assert.assertTrue(projection instanceof Or);
+    Or or = (Or) projection;
+    UnboundPredicate<?> left = assertAndUnwrapUnbound(or.left());
+    Assert.assertEquals("Should be a before_day predicate", "before_day", left.ref().name());
+    Assert.assertEquals("Should be 429060", 17877, left.literal().value());
+    UnboundPredicate<?> right = assertAndUnwrapUnbound(or.right());
+    Assert.assertEquals("Should be a after_unknown_transform predicate", "after_unknown_transform", right.ref().name());
+    Assert.assertEquals("Should be always true", Expressions.alwaysTrue().op(), right.op());
+  }
+}

--- a/api/src/test/java/com/netflix/iceberg/transforms/TestUnknownTransform.java
+++ b/api/src/test/java/com/netflix/iceberg/transforms/TestUnknownTransform.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,49 +20,29 @@
 
 package com.netflix.iceberg.transforms;
 
-import static com.netflix.iceberg.TestHelpers.assertAndUnwrapUnbound;
-import static com.netflix.iceberg.expressions.Expressions.greaterThanOrEqual;
-import static com.netflix.iceberg.expressions.Expressions.lessThanOrEqual;
-import static com.netflix.iceberg.expressions.Expressions.or;
+import com.netflix.iceberg.PartitionSpec;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.TestHelpers;
+import com.netflix.iceberg.types.Types;
+import org.junit.Test;
+
 import static com.netflix.iceberg.types.Types.NestedField.optional;
 import static com.netflix.iceberg.types.Types.NestedField.required;
 
-import com.netflix.iceberg.PartitionSpec;
-import com.netflix.iceberg.Schema;
-import com.netflix.iceberg.expressions.Expression;
-import com.netflix.iceberg.expressions.Expressions;
-import com.netflix.iceberg.expressions.Or;
-import com.netflix.iceberg.expressions.Projections;
-import com.netflix.iceberg.expressions.UnboundPredicate;
-import com.netflix.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
-
 public class TestUnknownTransform {
 
-  @Test
-  public void testUnknownTransform() {
-    Schema schema = new Schema(
-        required(1, "id", Types.LongType.get()),
-        optional(2, "before", Types.DateType.get()),
-        required(3, "after", Types.DateType.get()));
+    @Test
+    public void testUnknownTransform() {
+        Schema schema = new Schema(
+                required(1, "id", Types.LongType.get()),
+                optional(2, "before", Types.DateType.get()),
+                required(3, "after", Types.DateType.get()));
 
-    PartitionSpec spec = PartitionSpec.builderFor(schema)
-        .day("before")
-        .add(3, "after_unknown_transform", "unknown")
-        .build();
-
-    Expression filter = or(lessThanOrEqual("before", "2018-12-12"),
-        greaterThanOrEqual("after", "2017-01-01"));
-    Expression projection = Projections.inclusive(spec).project(filter);
-
-    Assert.assertTrue(projection instanceof Or);
-    Or or = (Or) projection;
-    UnboundPredicate<?> left = assertAndUnwrapUnbound(or.left());
-    Assert.assertEquals("Should be a before_day predicate", "before_day", left.ref().name());
-    Assert.assertEquals("Should be 429060", 17877, left.literal().value());
-    UnboundPredicate<?> right = assertAndUnwrapUnbound(or.right());
-    Assert.assertEquals("Should be a after_unknown_transform predicate", "after_unknown_transform", right.ref().name());
-    Assert.assertEquals("Should be always true", Expressions.alwaysTrue().op(), right.op());
-  }
+        TestHelpers.assertThrows("Should complain about unknown transfer",
+                IllegalArgumentException.class, "Transform not supported: unknown:date:unknown_transform",
+                () -> PartitionSpec.builderFor(schema)
+                        .day("before")
+                        .add(3, "after_unknown_transform", "unknown_transform")
+                        .build());
+    }
 }


### PR DESCRIPTION
Thought I'd give it a try and help resolve the forward-compatible issue for new transforms to the partition spec detailed on [issue#32](https://github.com/apache/incubator-iceberg/issues/32) 