### PR TITLE
[MINOR] Fix unnecessary indentation in parameter list

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/expressions/Binder.java
+++ b/api/src/main/java/com/netflix/iceberg/expressions/Binder.java
@@ -86,7 +86,7 @@ public class Binder {
    * @throws IllegalStateException if any references are already bound
    */
   static Expression bind(StructType struct,
-                                   Expression expr) {
+                         Expression expr) {
     return Binder.bind(struct, expr, true);
   }
 


### PR DESCRIPTION
Remove unnecessary additional whitespace in parameters list.

Not sure if there's an official style guide, but saw this minor nit when reading through the code base and was hoping to offer a fix.