### PR TITLE
Add Table.metadataAsTable

### DIFF
--- a/api/src/main/java/com/netflix/iceberg/Table.java
+++ b/api/src/main/java/com/netflix/iceberg/Table.java
@@ -43,6 +43,13 @@ public interface Table {
   TableScan newScan();
 
   /**
+   * Create a new {@link Table} of the file metadata for this table.
+   *
+   * @return a table of the metadata for this table
+   */
+  Table metadataAsTable();
+
+  /**
    * Return the {@link Schema schema} for this table.
    *
    * @return this table's schema

--- a/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseMetastoreTables.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static com.netflix.iceberg.TableMetadata.newTableMetadata;
 
 public abstract class BaseMetastoreTables implements Tables {
-  private static final String FILES_SUFFIX = "$files";
+  private static final String ENTRIES_SUFFIX = "$entries";
 
   private final Configuration conf;
 
@@ -43,8 +43,8 @@ public abstract class BaseMetastoreTables implements Tables {
   public Table load(String database, String table) {
     String tableName = table;
     boolean metadataTable = false;
-    if (table.endsWith(FILES_SUFFIX)) {
-      tableName = table.substring(0, table.length() - FILES_SUFFIX.length());
+    if (table.endsWith(ENTRIES_SUFFIX)) {
+      tableName = table.substring(0, table.length() - ENTRIES_SUFFIX.length());
       metadataTable = true;
     }
 

--- a/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
+++ b/core/src/main/java/com/netflix/iceberg/BaseTransaction.java
@@ -310,6 +310,11 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public Table metadataAsTable() {
+      throw new UnsupportedOperationException("Transaction tables do not support metadata scans");
+    }
+
+    @Override
     public Schema schema() {
       return current.schema();
     }

--- a/core/src/main/java/com/netflix/iceberg/DataFiles.java
+++ b/core/src/main/java/com/netflix/iceberg/DataFiles.java
@@ -161,6 +161,18 @@ public class DataFiles {
         location, format, partition, stat.getLen(), stat.getBlockSize(), metrics);
   }
 
+  public static DataFile fromManifest(ManifestFile manifest) {
+    Preconditions.checkArgument(
+        manifest.addedFilesCount() != null && manifest.existingFilesCount() != null,
+        "Cannot create data file from manifest: data file counts are missing.");
+
+    return new GenericDataFile(manifest.path(),
+        FileFormat.AVRO,
+        manifest.addedFilesCount() + manifest.existingFilesCount(),
+        manifest.length(),
+        DEFAULT_BLOCK_SIZE);
+  }
+
   public static Builder builder(PartitionSpec spec) {
     return new Builder(spec);
   }

--- a/core/src/main/java/com/netflix/iceberg/DataTableScan.java
+++ b/core/src/main/java/com/netflix/iceberg/DataTableScan.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.netflix.iceberg.expressions.Expression;
+import com.netflix.iceberg.expressions.InclusiveManifestEvaluator;
+import com.netflix.iceberg.expressions.ResidualEvaluator;
+import com.netflix.iceberg.io.CloseableIterable;
+import com.netflix.iceberg.util.ParallelIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static com.netflix.iceberg.util.ThreadPools.getWorkerPool;
+
+public class DataTableScan extends BaseTableScan {
+  private static final Logger LOG = LoggerFactory.getLogger(DataTableScan.class);
+
+  private static final List<String> SNAPSHOT_COLUMNS = ImmutableList.of(
+      "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
+      "file_size_in_bytes", "record_count", "partition", "value_counts", "null_value_counts",
+      "lower_bounds", "upper_bounds"
+  );
+  private static final boolean PLAN_SCANS_WITH_WORKER_POOL =
+      SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);
+
+  public DataTableScan(TableOperations ops, Table table) {
+    super(ops, table, table.schema());
+  }
+
+  protected DataTableScan(TableOperations ops, Table table, Long snapshotId, Schema schema,
+                          Expression rowFilter) {
+    super(ops, table, snapshotId, schema, rowFilter);
+  }
+
+  protected TableScan newRefinedScan(TableOperations ops, Table table, Long snapshotId,
+                                     Schema schema, Expression rowFilter) {
+    return new DataTableScan(ops, table, snapshotId, schema, rowFilter);
+  }
+
+  public CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot,
+                                                   Expression rowFilter) {
+    LoadingCache<Integer, InclusiveManifestEvaluator> evalCache = CacheBuilder
+        .newBuilder()
+        .build(new CacheLoader<Integer, InclusiveManifestEvaluator>() {
+          @Override
+          public InclusiveManifestEvaluator load(Integer specId) {
+            PartitionSpec spec = ops.current().spec(specId);
+            return new InclusiveManifestEvaluator(spec, rowFilter);
+          }
+        });
+
+    Iterable<ManifestFile> matchingManifests = Iterables.filter(snapshot.manifests(),
+        manifest -> evalCache.getUnchecked(manifest.partitionSpecId()).eval(manifest));
+
+    ConcurrentLinkedQueue<Closeable> toClose = new ConcurrentLinkedQueue<>();
+    Iterable<Iterable<FileScanTask>> readers = Iterables.transform(
+        matchingManifests,
+        manifest -> {
+          ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()));
+          toClose.add(reader);
+          String schemaString = SchemaParser.toJson(reader.spec().schema());
+          String specString = PartitionSpecParser.toJson(reader.spec());
+          ResidualEvaluator residuals = ResidualEvaluator.of(reader.spec(), rowFilter);
+          return Iterables.transform(
+              reader.filterRows(rowFilter).select(SNAPSHOT_COLUMNS),
+              file -> new BaseFileScanTask(file, schemaString, specString, residuals)
+          );
+        });
+
+    if (PLAN_SCANS_WITH_WORKER_POOL && snapshot.manifests().size() > 1) {
+      return CloseableIterable.combine(
+          new ParallelIterable<>(readers, getWorkerPool()),
+          toClose);
+    } else {
+      return CloseableIterable.combine(Iterables.concat(readers), toClose);
+    }
+  }
+
+  protected long targetSplitSize(TableOperations ops) {
+    return ops.current().propertyAsLong(
+        TableProperties.SPLIT_SIZE, TableProperties.SPLIT_SIZE_DEFAULT);
+  }
+}

--- a/core/src/main/java/com/netflix/iceberg/MetadataTable.java
+++ b/core/src/main/java/com/netflix/iceberg/MetadataTable.java
@@ -19,146 +19,115 @@
 
 package com.netflix.iceberg;
 
-import com.netflix.iceberg.io.FileIO;
-import com.netflix.iceberg.io.LocationProvider;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-/**
- * Base {@link Table} implementation.
- * <p>
- * This can be extended by providing a {@link TableOperations} to the constructor.
- */
-public class BaseTable implements Table, HasTableOperations {
+public class MetadataTable implements Table {
   private final TableOperations ops;
-  private final String name;
+  private final Table table;
 
-  public BaseTable(TableOperations ops, String name) {
+  public MetadataTable(TableOperations ops, Table table) {
     this.ops = ops;
-    this.name = name;
-  }
-
-  @Override
-  public TableOperations operations() {
-    return ops;
+    this.table = table;
   }
 
   @Override
   public void refresh() {
-    ops.refresh();
+    table.refresh();
   }
 
   @Override
   public TableScan newScan() {
-    return new DataTableScan(ops, this);
+    return new MetadataTableScan(ops, table);
   }
 
   @Override
   public Table metadataAsTable() {
-    return new MetadataTable(ops, this);
+    throw new UnsupportedOperationException("Cannot scan metadata of a metadata table");
   }
 
   @Override
   public Schema schema() {
-    return ops.current().schema();
+    return ManifestEntry.getSchema(table.spec().partitionType());
   }
 
   @Override
   public PartitionSpec spec() {
-    return ops.current().spec();
+    return PartitionSpec.unpartitioned();
   }
 
   @Override
   public Map<String, String> properties() {
-    return ops.current().properties();
+    return ImmutableMap.of();
   }
 
   @Override
   public String location() {
-    return ops.current().location();
+    return table.currentSnapshot().manifestListLocation();
   }
 
   @Override
   public Snapshot currentSnapshot() {
-    return ops.current().currentSnapshot();
+    return table.currentSnapshot();
   }
 
   @Override
   public Iterable<Snapshot> snapshots() {
-    return ops.current().snapshots();
+    return table.snapshots();
   }
 
   @Override
   public UpdateSchema updateSchema() {
-    return new SchemaUpdate(ops);
+    throw new UnsupportedOperationException("Cannot update the schema of a metadata table");
   }
 
   @Override
   public UpdateProperties updateProperties() {
-    return new PropertiesUpdate(ops);
+    throw new UnsupportedOperationException("Cannot update the properties of a metadata table");
   }
 
   @Override
   public UpdateLocation updateLocation() {
-    return new SetLocation(ops);
+    throw new UnsupportedOperationException("Cannot update the location of a metadata table");
   }
 
   @Override
   public AppendFiles newAppend() {
-    return new MergeAppend(ops);
-  }
-
-  @Override
-  public AppendFiles newFastAppend() {
-    return new FastAppend(ops);
+    throw new UnsupportedOperationException("Cannot append to a metadata table");
   }
 
   @Override
   public RewriteFiles newRewrite() {
-    return new ReplaceFiles(ops);
+    throw new UnsupportedOperationException("Cannot rewrite in a metadata table");
   }
 
   @Override
   public OverwriteFiles newOverwrite() {
-    return new OverwriteData(ops);
+    throw new UnsupportedOperationException("Cannot overwrite in a metadata table");
   }
 
   @Override
   public ReplacePartitions newReplacePartitions() {
-    return new ReplacePartitionsOperation(ops);
+    throw new UnsupportedOperationException("Cannot replace partitions in a metadata table");
   }
 
   @Override
   public DeleteFiles newDelete() {
-    return new StreamingDelete(ops);
+    throw new UnsupportedOperationException("Cannot delete from a metadata table");
   }
 
   @Override
   public ExpireSnapshots expireSnapshots() {
-    return new RemoveSnapshots(ops);
+    throw new UnsupportedOperationException("Cannot expire snapshots from a metadata table");
   }
 
   @Override
   public Rollback rollback() {
-    return new RollbackToSnapshot(ops);
+    throw new UnsupportedOperationException("Cannot roll back a metadata table");
   }
 
   @Override
   public Transaction newTransaction() {
-    return BaseTransaction.newTransaction(ops);
-  }
-
-  @Override
-  public FileIO io() {
-    return operations().io();
-  }
-
-  @Override
-  public LocationProvider locationProvider() {
-    return operations().locationProvider();
-  }
-
-  @Override
-  public String toString() {
-    return name;
+    throw new UnsupportedOperationException("Cannot create transactions for a metadata table");
   }
 }

--- a/core/src/main/java/com/netflix/iceberg/MetadataTable.java
+++ b/core/src/main/java/com/netflix/iceberg/MetadataTable.java
@@ -20,6 +20,8 @@
 package com.netflix.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import com.netflix.iceberg.io.FileIO;
+import com.netflix.iceberg.io.LocationProvider;
 import java.util.Map;
 
 public class MetadataTable implements Table {
@@ -129,5 +131,15 @@ public class MetadataTable implements Table {
   @Override
   public Transaction newTransaction() {
     throw new UnsupportedOperationException("Cannot create transactions for a metadata table");
+  }
+
+  @Override
+  public FileIO io() {
+    return table.io();
+  }
+
+  @Override
+  public LocationProvider locationProvider() {
+    return table.locationProvider();
   }
 }

--- a/core/src/main/java/com/netflix/iceberg/MetadataTableScan.java
+++ b/core/src/main/java/com/netflix/iceberg/MetadataTableScan.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.google.common.collect.Iterables;
+import com.netflix.iceberg.avro.Avro;
+import com.netflix.iceberg.expressions.Expression;
+import com.netflix.iceberg.io.CloseableIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.netflix.iceberg.expressions.ResidualEvaluator.unpartitioned;
+
+public class MetadataTableScan extends BaseTableScan {
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataTableScan.class);
+  private static final long TARGET_SPLIT_SIZE = 32 * 1024 * 1024; // 32 MB
+
+  protected MetadataTableScan(TableOperations ops, Table table) {
+    super(ops, table, ManifestEntry.getSchema(table.spec().partitionType()));
+  }
+
+  protected MetadataTableScan(TableOperations ops, Table table, Long snapshotId, Schema schema,
+                              Expression rowFilter) {
+    super(ops, table, snapshotId, schema, rowFilter);
+  }
+
+  @Override
+  protected TableScan newRefinedScan(TableOperations ops, Table table, Long snapshotId,
+                                     Schema schema, Expression rowFilter) {
+    return new MetadataTableScan(ops, table, snapshotId, schema, rowFilter);
+  }
+
+  @Override
+  protected long targetSplitSize(TableOperations ops) {
+    return TARGET_SPLIT_SIZE;
+  }
+
+  @Override
+  protected CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot,
+                                                      Expression rowFilter) {
+    CloseableIterable<ManifestFile> manifests;
+    if (snapshot.manifestListLocation() != null) {
+      manifests = Avro
+          .read(ops.io().newInputFile(snapshot.manifestListLocation()))
+          .rename("manifest_file", GenericManifestFile.class.getName())
+          .rename("partitions", GenericPartitionFieldSummary.class.getName())
+          .rename("r508", GenericPartitionFieldSummary.class.getName())
+          .project(ManifestFile.schema())
+          .reuseContainers(false)
+          .build();
+    } else {
+      manifests = CloseableIterable.withNoopClose(snapshot.manifests());
+    }
+
+    String schemaString = SchemaParser.toJson(schema());
+    String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
+
+    return CloseableIterable.wrap(manifests, files -> Iterables.transform(files,
+        manifest -> new BaseFileScanTask(
+            DataFiles.fromManifest(manifest), schemaString, specString, unpartitioned(rowFilter))));
+  }
+}

--- a/spark/src/main/java/com/netflix/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/source/IcebergSource.java
@@ -47,8 +47,6 @@ import static com.netflix.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 
 public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, DataSourceRegister {
 
-  private static final String FILES_SUFFIX = "$files";
-
   private SparkSession lazySpark = null;
   private Configuration lazyConf = null;
 
@@ -97,20 +95,13 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
   }
 
   protected Table findTable(DataSourceOptions options, Configuration conf) {
-    Optional<String> maybeLocation = options.get("path");
-    Preconditions.checkArgument(maybeLocation.isPresent(),
+    Optional<String> location = options.get("path");
+    Preconditions.checkArgument(location.isPresent(),
         "Cannot open table without a location: path is not set");
 
     HadoopTables tables = new HadoopTables(conf);
 
-    String location = maybeLocation.get();
-    if (location.endsWith(FILES_SUFFIX)) {
-      return tables
-          .load(location.substring(0, location.length() - FILES_SUFFIX.length()))
-          .metadataAsTable();
-    } else {
-      return tables.load(location);
-    }
+    return tables.load(location.get());
   }
 
   private SparkSession lazySparkSession() {

--- a/spark/src/main/java/com/netflix/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/com/netflix/iceberg/spark/source/IcebergSource.java
@@ -47,6 +47,8 @@ import static com.netflix.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 
 public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, DataSourceRegister {
 
+  private static final String FILES_SUFFIX = "$files";
+
   private SparkSession lazySpark = null;
   private Configuration lazyConf = null;
 
@@ -95,13 +97,20 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
   }
 
   protected Table findTable(DataSourceOptions options, Configuration conf) {
-    Optional<String> location = options.get("path");
-    Preconditions.checkArgument(location.isPresent(),
+    Optional<String> maybeLocation = options.get("path");
+    Preconditions.checkArgument(maybeLocation.isPresent(),
         "Cannot open table without a location: path is not set");
 
     HadoopTables tables = new HadoopTables(conf);
 
-    return tables.load(location.get());
+    String location = maybeLocation.get();
+    if (location.endsWith(FILES_SUFFIX)) {
+      return tables
+          .load(location.substring(0, location.length() - FILES_SUFFIX.length()))
+          .metadataAsTable();
+    } else {
+      return tables.load(location);
+    }
   }
 
   private SparkSession lazySparkSession() {


### PR DESCRIPTION
This adds a new method to the public API, `Table.metadataAsTable` that returns the table's manifest entries as a table. This provides access to file-level metadata in query engines that can read manifest files as data files.

This also exposes metadata tables through BaseMetastoreTableOperations under a special table name ending with `$entries`.