### PR TITLE
Use the current schema in all partition specs in scan planning.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -158,7 +158,9 @@ class BaseSnapshot implements Snapshot {
     // accumulate adds and deletes from all manifests.
     // because manifests can be reused in newer snapshots, filter the changes by snapshot id.
     for (String manifest : Iterables.transform(manifests(), ManifestFile::path)) {
-      try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest))) {
+      try (ManifestReader reader = ManifestReader.read(
+          ops.io().newInputFile(manifest),
+          ops.current()::spec)) {
         for (ManifestEntry add : reader.addedFiles()) {
           if (add.snapshotId() == snapshotId) {
             adds.add(add.file().copy());

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -187,8 +187,6 @@ class BaseTableScan implements TableScan {
             String specString = PartitionSpecParser.toJson(spec);
             ResidualEvaluator residuals = new ResidualEvaluator(spec, rowFilter, caseSensitive);
             return Iterables.transform(
-                // TODO: the reader needs to be passed the row filter to filter by stats, but the
-                // reader needs to use the current schema and partition spec.
                 reader.filterRows(rowFilter).select(SNAPSHOT_COLUMNS),
                 file -> new BaseFileScanTask(file, schemaString, specString, residuals)
             );

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -157,16 +157,6 @@ class BaseTableScan implements TableScan {
         }
       });
 
-  private final LoadingCache<Integer, Expression> partitionExprCache = CacheBuilder
-      .newBuilder()
-      .build(new CacheLoader<Integer, Expression>() {
-        @Override
-        public Expression load(Integer specId) {
-          PartitionSpec spec = ops.current().spec(specId);
-          return Projections.inclusive(spec).project(rowFilter);
-        }
-      });
-
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
     Snapshot snapshot = snapshotId != null ?

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -48,7 +48,7 @@ class ManifestGroup {
   private final boolean ignoreDeleted;
   private final List<String> columns;
 
-  private final LoadingCache<Integer, InclusiveManifestEvaluator> EVAL_CACHE = CacheBuilder
+  private final LoadingCache<Integer, InclusiveManifestEvaluator> evalCache = CacheBuilder
       .newBuilder()
       .build(new CacheLoader<Integer, InclusiveManifestEvaluator>() {
         @Override
@@ -58,7 +58,7 @@ class ManifestGroup {
         }
       });
 
-  private final LoadingCache<Integer, Expression> PARTITION_EXPR_CACHE = CacheBuilder
+  private final LoadingCache<Integer, Expression> partitionExprCache = CacheBuilder
       .newBuilder()
       .build(new CacheLoader<Integer, Expression>() {
         @Override
@@ -120,7 +120,7 @@ class ManifestGroup {
     List<Closeable> toClose = Lists.newArrayList();
 
     Iterable<ManifestFile> matchingManifests = Iterables.filter(manifests,
-        manifest -> EVAL_CACHE.getUnchecked(manifest.partitionSpecId()).eval(manifest));
+        manifest -> evalCache.getUnchecked(manifest.partitionSpecId()).eval(manifest));
 
     if (ignoreDeleted) {
       // remove any manifests that don't have any existing or added files. if either the added or
@@ -135,7 +135,7 @@ class ManifestGroup {
         manifest -> {
           ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()));
           FilteredManifest filtered = reader
-              .filterPartitions(PARTITION_EXPR_CACHE.getUnchecked(manifest.partitionSpecId()))
+              .filterPartitions(partitionExprCache.getUnchecked(manifest.partitionSpecId()))
               .select(columns);
           toClose.add(reader);
           return Iterables.filter(

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -133,10 +133,10 @@ class ManifestGroup {
     Iterable<Iterable<ManifestEntry>> readers = Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()));
-          FilteredManifest filtered = reader
-              .filterPartitions(partitionExprCache.getUnchecked(manifest.partitionSpecId()))
-              .select(columns);
+          ManifestReader reader = ManifestReader.read(
+              ops.io().newInputFile(manifest.path()),
+              ops.current()::spec);
+          FilteredManifest filtered = reader.filterRows(dataFilter).select(columns);
           toClose.add(reader);
           return Iterables.filter(
               ignoreDeleted ? filtered.liveEntries() : filtered.allEntries(),

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -58,16 +58,6 @@ class ManifestGroup {
         }
       });
 
-  private final LoadingCache<Integer, Expression> partitionExprCache = CacheBuilder
-      .newBuilder()
-      .build(new CacheLoader<Integer, Expression>() {
-        @Override
-        public Expression load(Integer specId) {
-          PartitionSpec spec = ops.current().spec(specId);
-          return Projections.inclusive(spec).project(dataFilter);
-        }
-      });
-
   ManifestGroup(TableOperations ops, Iterable<ManifestFile> manifests) {
     this(ops, Sets.newHashSet(manifests), Expressions.alwaysTrue(), Expressions.alwaysTrue(),
         false, ImmutableList.of("*"));

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -45,7 +46,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 /**
  * Reader for manifest files.
  * <p>
- * Readers are created using the builder from {@link #read(InputFile)}.
+ * Readers are created using the builder from {@link #read(InputFile, Function)}.
  */
 public class ManifestReader extends CloseableGroup implements Filterable<FilteredManifest> {
   private static final Logger LOG = LoggerFactory.getLogger(ManifestReader.class);
@@ -54,25 +55,20 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
   private static final List<String> CHANGE_COLUNNS = Lists.newArrayList(
       "file_path", "file_format", "partition", "record_count", "file_size_in_bytes");
 
-  /**
-   * Returns a new {@link ManifestReader} for an {@link InputFile}.
-   *
-   * @param file an InputFile
-   * @return a manifest reader
-   */
-  public static ManifestReader read(InputFile file) {
-    return new ManifestReader(file, true);
+  // Visible for testing
+  static ManifestReader read(InputFile file) {
+    return new ManifestReader(file, null);
   }
 
   /**
    * Returns a new {@link ManifestReader} for an {@link InputFile}.
    *
    * @param file an InputFile
-   * @param caseSensitive whether column name matching should have case sensitivity
+   * @param specLookup a function to look up the manifest's partition spec by ID
    * @return a manifest reader
    */
-  public static ManifestReader read(InputFile file, boolean caseSensitive) {
-    return new ManifestReader(file, caseSensitive);
+  public static ManifestReader read(InputFile file, Function<Integer, PartitionSpec> specLookup) {
+    return new ManifestReader(file, specLookup);
   }
 
   private final InputFile file;
@@ -85,9 +81,8 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
   private List<ManifestEntry> adds = null;
   private List<ManifestEntry> deletes = null;
 
-  private ManifestReader(InputFile file, boolean caseSensitive) {
+  private ManifestReader(InputFile file, Function<Integer, PartitionSpec> specLookup) {
     this.file = file;
-    this.caseSensitive = caseSensitive;
 
     try {
       try (AvroIterable<ManifestEntry> headerReader = Avro.read(file)
@@ -98,13 +93,22 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
     } catch (IOException e) {
       throw new RuntimeIOException(e);
     }
-    this.schema = SchemaParser.fromJson(metadata.get("schema"));
+
     int specId = TableMetadata.INITIAL_SPEC_ID;
     String specProperty = metadata.get("partition-spec-id");
     if (specProperty != null) {
       specId = Integer.parseInt(specProperty);
     }
-    this.spec = PartitionSpecParser.fromJsonFields(schema, specId, metadata.get("partition-spec"));
+
+    if (specLookup != null) {
+      this.spec = specLookup.apply(specId);
+      this.schema = spec.schema();
+    } else {
+      this.schema = SchemaParser.fromJson(metadata.get("schema"));
+      this.spec = PartitionSpecParser.fromJsonFields(schema, specId, metadata.get("partition-spec"));
+    }
+
+    this.caseSensitive = true;
   }
 
   private ManifestReader(InputFile file, Map<String, String> metadata,

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotUpdate.java
@@ -334,7 +334,8 @@ abstract class MergingSnapshotUpdate extends SnapshotUpdate {
       return manifest;
     }
 
-    try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()))) {
+    try (ManifestReader reader = ManifestReader.read(
+        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
       Expression inclusiveExpr = Projections
           .inclusive(reader.spec())
           .project(deleteExpression);
@@ -487,7 +488,8 @@ abstract class MergingSnapshotUpdate extends SnapshotUpdate {
     try {
 
       for (ManifestFile manifest : bin) {
-        try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()))) {
+        try (ManifestReader reader = ManifestReader.read(
+            ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
           for (ManifestEntry entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {
               // suppress deletes from previous snapshots. only files deleted by this snapshot

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -174,7 +174,8 @@ class RemoveSnapshots implements ExpireSnapshots {
           }
 
           // the manifest has deletes, scan it to find files to delete
-          try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()))) {
+          try (ManifestReader reader = ManifestReader.read(
+              ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
             for (ManifestEntry entry : reader.entries()) {
               // if the snapshot ID of the DELETE entry is no longer valid, the data can be deleted
               if (entry.status() == ManifestEntry.Status.DELETED &&

--- a/core/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -280,7 +280,8 @@ abstract class SnapshotUpdate implements PendingUpdate<Snapshot> {
   }
 
   private static ManifestFile addMetadata(TableOperations ops, ManifestFile manifest) {
-    try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()))) {
+    try (ManifestReader reader = ManifestReader.read(
+        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
       PartitionSummary stats = new PartitionSummary(ops.current().spec(manifest.partitionSpecId()));
       int addedFiles = 0;
       int existingFiles = 0;

--- a/core/src/test/java/com/netflix/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/com/netflix/iceberg/TestScansAndSchemaEvolution.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netflix.iceberg;
+
+import com.google.common.collect.Lists;
+import com.netflix.iceberg.avro.Avro;
+import com.netflix.iceberg.avro.RandomAvroData;
+import com.netflix.iceberg.expressions.Expressions;
+import com.netflix.iceberg.io.FileAppender;
+import com.netflix.iceberg.types.Types;
+import org.apache.avro.generic.GenericData;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static com.netflix.iceberg.types.Types.NestedField.required;
+
+public class TestScansAndSchemaEvolution {
+  private static final Schema SCHEMA = new Schema(
+      required(1, "id", Types.LongType.get()),
+      required(2, "data", Types.StringType.get()),
+      required(3, "part", Types.StringType.get()));
+
+  private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA)
+      .identity("part")
+      .build();
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private DataFile createDataFile(File dataPath, String partValue) throws IOException {
+    List<GenericData.Record> expected = RandomAvroData.generate(SCHEMA, 100, 0L);
+
+    File dataFile = new File(dataPath, FileFormat.AVRO.addExtension(UUID.randomUUID().toString()));
+    try (FileAppender<GenericData.Record> writer = Avro.write(Files.localOutput(dataFile))
+        .schema(SCHEMA)
+        .named("test")
+        .build()) {
+      for (GenericData.Record rec : expected) {
+        rec.put("part", partValue); // create just one partition
+        writer.add(rec);
+      }
+    }
+
+    PartitionData partition = new PartitionData(SPEC.partitionType());
+    partition.set(0, partValue);
+    return DataFiles.builder(SPEC)
+        .withInputFile(Files.localInput(dataFile))
+        .withPartition(partition)
+        .withRecordCount(100)
+        .build();
+  }
+
+  @After
+  public void cleanupTables() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testPartitionSourceRename() throws IOException {
+    File location = temp.newFolder();
+    File dataLocation = new File(location, "data");
+    Assert.assertTrue(location.delete()); // should be created by table create
+
+    Table table = TestTables.create(location, "test", SCHEMA, SPEC);
+
+    DataFile fileOne = createDataFile(dataLocation, "one");
+    DataFile fileTwo = createDataFile(dataLocation, "two");
+
+    table.newAppend()
+        .appendFile(fileOne)
+        .appendFile(fileTwo)
+        .commit();
+
+    List<FileScanTask> tasks = Lists.newArrayList(
+        table.newScan().filter(Expressions.equal("part", "one")).planFiles());
+
+    Assert.assertEquals("Should produce 1 matching file task", 1, tasks.size());
+
+    table.updateSchema()
+        .renameColumn("part", "p")
+        .commit();
+
+    // plan the scan using the new name in a filter
+    tasks = Lists.newArrayList(
+        table.newScan().filter(Expressions.equal("p", "one")).planFiles());
+
+    Assert.assertEquals("Should produce 1 matching file task", 1, tasks.size());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -17,27 +17,26 @@
  * under the License.
  */
 
-package com.netflix.iceberg;
+package org.apache.iceberg;
 
 import com.google.common.collect.Lists;
-import com.netflix.iceberg.avro.Avro;
-import com.netflix.iceberg.avro.RandomAvroData;
-import com.netflix.iceberg.expressions.Expressions;
-import com.netflix.iceberg.io.FileAppender;
-import com.netflix.iceberg.types.Types;
 import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.avro.RandomAvroData;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
-import static com.netflix.iceberg.types.Types.NestedField.required;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestScansAndSchemaEvolution {
   private static final Schema SCHEMA = new Schema(


### PR DESCRIPTION
This fixes an issue reported to the dev list by Sudsport.

The problem is that expression operations were not using the latest version of the schema in some places, where the schema is taken from a partition spec. When the schema is updated, partition specs need to be rebuilt with the new schema so that expression binding always uses the current schema.