### PR TITLE
Fix Iceberg Parquet Reader scanning when filtering on nested types

### DIFF
--- a/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -28,6 +28,7 @@ import com.netflix.iceberg.expressions.Expression;
 import com.netflix.iceberg.expressions.ExpressionVisitors;
 import com.netflix.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
 import com.netflix.iceberg.expressions.Literal;
+import com.netflix.iceberg.types.Type;
 import com.netflix.iceberg.types.Types;
 import com.netflix.iceberg.types.Types.StructType;
 import org.apache.parquet.column.statistics.Statistics;
@@ -155,6 +156,13 @@ public class ParquetMetricsRowGroupFilter {
       Integer id = ref.fieldId();
       Preconditions.checkNotNull(struct.field(id),
           "Cannot filter by nested column: %s", schema.findField(id));
+
+      // When filtering nested types notNull() is implicit filter passed even
+      //   though complex filters aren't pushed down in Parquet. Leave all
+      //    nested column type filters to be evaluated post scan.
+      if(schema.findType(id) instanceof Type.NestedType) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {

--- a/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -157,10 +157,10 @@ public class ParquetMetricsRowGroupFilter {
       Preconditions.checkNotNull(struct.field(id),
           "Cannot filter by nested column: %s", schema.findField(id));
 
-      // When filtering nested types notNull() is implicit filter passed even
-      //   though complex filters aren't pushed down in Parquet. Leave all
-      //    nested column type filters to be evaluated post scan.
-      if(schema.findType(id) instanceof Type.NestedType) {
+      // When filtering nested types notNull() is implicit filter passed even though complex
+      // filters aren't pushed down in Parquet. Leave all nested column type filters to be
+      // evaluated post scan.
+      if (schema.findType(id) instanceof Type.NestedType) {
         return ROWS_MIGHT_MATCH;
       }
 
@@ -296,6 +296,13 @@ public class ParquetMetricsRowGroupFilter {
       Integer id = ref.fieldId();
       Types.NestedField field = struct.field(id);
       Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
+
+      // When filtering nested types notNull() is implicit filter passed even though complex
+      // filters aren't pushed down in Parquet. Leave all nested column type filters to be
+      // evaluated post scan.
+      if (schema.findType(id) instanceof Type.NestedType) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {


### PR DESCRIPTION
This PR fixes issue reported at https://github.com/apache/incubator-iceberg/issues/99


With this change filtering on complex predicates returns rows:
```
scala> spark.sql("select * from people_iceberg_complex where friends['Josh'] == 10").show()
19/02/22 14:42:30 WARN scheduler.TaskSetManager: Stage 16 contains a task of very large size (113 KB). The maximum recommended task size is 100 KB.
+---+----+--------------------+
|age|name|             friends|
+---+----+--------------------+
| 30|Andy|[Josh -> 10, Bisw...|
+---+----+--------------------+


scala> spark.sql("select * from people_iceberg_complex where friends['Josh'] == 10").explain()
== Physical Plan ==
*(1) Project [age#25, name#26, friends#27]
+- *(1) Filter ((friends#27[Josh] = 10) && isnotnull(friends#27))
   +- *(1) ScanV2 iceberg[age#25, name#26, friends#27] (Filters: [isnotnull(friends#27)], Options: [path=iceberg-people-complex,paths=[]])
```