### PR TITLE
[Refactor][Minor] Refactor ORCFileAppender  to be consistent with Avro/Parquet

### DIFF
--- a/orc/src/main/java/com/netflix/iceberg/orc/ORC.java
+++ b/orc/src/main/java/com/netflix/iceberg/orc/ORC.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.netflix.iceberg.Schema;
 import com.netflix.iceberg.hadoop.HadoopInputFile;
 import com.netflix.iceberg.hadoop.HadoopOutputFile;
+import com.netflix.iceberg.io.FileAppender;
 import com.netflix.iceberg.io.InputFile;
 import com.netflix.iceberg.io.OutputFile;
 import org.apache.hadoop.conf.Configuration;
@@ -30,11 +31,8 @@ import org.apache.orc.TypeDescription;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 public class ORC {
   private ORC() {
@@ -74,7 +72,7 @@ public class ORC {
       return this;
     }
 
-    public OrcFileAppender build() {
+    public FileAppender build() {
       OrcFile.WriterOptions options =
           OrcFile.writerOptions(conf);
       return new OrcFileAppender(schema, file, options, metadata);

--- a/orc/src/main/java/com/netflix/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/com/netflix/iceberg/orc/OrcFileAppender.java
@@ -34,7 +34,7 @@ import java.util.Map;
 /**
  * Create a file appender for ORC.
  */
-public class OrcFileAppender implements FileAppender<VectorizedRowBatch> {
+class OrcFileAppender implements FileAppender<VectorizedRowBatch> {
   private final Writer writer;
   private final TypeDescription orcSchema;
   private final ColumnIdMap columnIds = new ColumnIdMap();


### PR DESCRIPTION
* Make OrcFileAppender package private
* Remove unused imports from ORC
* ORC.WriteBuilder#build now returns FileAppender instead of OrcFileAppender