### PR TITLE
Pick Largest Bin at Task Planning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -217,7 +217,7 @@ class BaseTableScan implements TableScan {
 
     return CloseableIterable.transform(
         CloseableIterable.wrap(splitFiles(splitSize), splits ->
-            new BinPacking.PackingIterable<>(splits, splitSize, lookback, weightFunc)),
+            new BinPacking.PackingIterable<>(splits, splitSize, lookback, weightFunc, true)),
         BaseCombinedScanTask::new);
   }
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotUpdate.java
@@ -436,7 +436,7 @@ abstract class MergingSnapshotUpdate extends SnapshotUpdate {
     // use a lookback of 1 to avoid reordering the manifests. using 1 also means this should pack
     // from the end so that the manifest that gets under-filled is the first one, which will be
     // merged the next time.
-    ListPacker<ManifestFile> packer = new ListPacker<>(manifestTargetSizeBytes, 1);
+    ListPacker<ManifestFile> packer = new ListPacker<>(manifestTargetSizeBytes, 1, false);
     List<List<ManifestFile>> bins = packer.packEnd(group, manifest -> manifest.length());
 
     // process bins in parallel, but put results in the order of the bins into an array to preserve

--- a/core/src/main/java/org/apache/iceberg/util/BinPacking.java
+++ b/core/src/main/java/org/apache/iceberg/util/BinPacking.java
@@ -23,6 +23,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -107,6 +109,8 @@ public class BinPacking {
           bins.addLast(bin);
 
           if (bins.size() > lookback) {
+            // sort by bin weight, descending
+            bins.sort(Comparator.comparing(Bin::getWeight).reversed());
             return ImmutableList.copyOf(bins.removeFirst().items());
           }
         }
@@ -143,6 +147,10 @@ public class BinPacking {
       public void add(T item, long weight) {
         this.binWeight += weight;
         items.add(item);
+      }
+
+      public long getWeight() {
+        return binWeight;
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/BinPacking.java
+++ b/core/src/main/java/org/apache/iceberg/util/BinPacking.java
@@ -115,7 +115,13 @@ public class BinPacking {
           bins.addLast(bin);
 
           if (bins.size() > lookback) {
-            return ImmutableList.copyOf((largestBinFirst ? getLargestBin() : bins.removeFirst()).items());
+            Bin binToRemove;
+            if (largestBinFirst) {
+              binToRemove = removeLargestBin(bins);
+            } else {
+              binToRemove = bins.removeFirst();
+            }
+            return ImmutableList.copyOf(binToRemove.items());
           }
         }
       }
@@ -127,7 +133,7 @@ public class BinPacking {
       return ImmutableList.copyOf(bins.removeFirst().items());
     }
 
-    private Bin getLargestBin() {
+    private Bin removeLargestBin(LinkedList<Bin> bins) {
       // Iterate through all bins looking for one with maximum weight, taking O(n) time.
       Bin maxBin = Collections.max(bins, Comparator.comparingLong(Bin::weight));
 

--- a/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
@@ -163,14 +163,17 @@ public class TestBinPacking {
     Assert.assertEquals("1 bin look-back: should merge ones with fives",
         l(l(5, 1), l(5, 1), l(5, 1)), pack(l(5, 1, 5, 1, 5, 1), 8, 1));
 
-    Assert.assertEquals("1 bin look-back: should merge until targetWeight and order them by weight descending",
-        l(l(32, 32, 32, 32), l(64, 64), l(128)),
-        pack(l(32, 32, 32, 32, 64, 64, 128), 128, 1));
+    Assert.assertEquals("2 bin look-back: should merge all ones with five when expensiveTaskFirst is enabled",
+        l(l(5, 1, 1, 1), l(5, 5)), pack(l(5, 1, 5, 1, 5, 1), 10, 2, true));
+
+    Assert.assertEquals("2 bin look-back: should merge until targetWeight by weight with expensiveTaskFirst is enabled",
+        l(l(36, 36, 36), l(128), l(36, 65), l(65)),
+        pack(l(36, 36, 36, 36, 65, 65, 128), 128, 2, true));
 
     Assert.assertEquals(
         "1 bin look-back: should order by weight descending and not order by number of items (at same weight)",
         l(l(128), l(64, 64), l(32, 32, 32, 32)),
-        pack(l(128, 64, 64, 32, 32, 32, 32), 128, 1));
+        pack(l(128, 64, 64, 32, 32, 32, 32), 128, 1, true));
   }
 
   private List<List<Integer>> pack(List<Integer> items, long targetWeight) {
@@ -178,7 +181,11 @@ public class TestBinPacking {
   }
 
   private List<List<Integer>> pack(List<Integer> items, long targetWeight, int lookback) {
-    ListPacker<Integer> packer = new ListPacker<>(targetWeight, lookback);
+    return pack(items, targetWeight, lookback, false);
+  }
+
+  private List<List<Integer>> pack(List<Integer> items, long targetWeight, int lookback, boolean expensiveTaskFirst) {
+    ListPacker<Integer> packer = new ListPacker<>(targetWeight, lookback, expensiveTaskFirst);
     return packer.pack(items, Integer::longValue);
   }
 
@@ -187,7 +194,7 @@ public class TestBinPacking {
   }
 
   private List<List<Integer>> packEnd(List<Integer> items, long targetWeight, int lookback) {
-    ListPacker<Integer> packer = new ListPacker<>(targetWeight, lookback);
+    ListPacker<Integer> packer = new ListPacker<>(targetWeight, lookback, false);
     return packer.packEnd(items, Integer::longValue);
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
@@ -166,7 +166,7 @@ public class TestBinPacking {
     Assert.assertEquals("2 bin look-back: should merge all ones with five when expensiveTaskFirst is enabled",
         l(l(5, 1, 1, 1), l(5, 5)), pack(l(5, 1, 5, 1, 5, 1), 10, 2, true));
 
-    Assert.assertEquals("2 bin look-back: should merge until targetWeight by weight with expensiveTaskFirst is enabled",
+    Assert.assertEquals("2 bin look-back: should merge until targetWeight when expensiveTaskFirst is enabled",
         l(l(36, 36, 36), l(128), l(36, 65), l(65)),
         pack(l(36, 36, 36, 36, 65, 65, 128), 128, 2, true));
 

--- a/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
@@ -162,6 +162,15 @@ public class TestBinPacking {
     // 6. [5, 1]
     Assert.assertEquals("1 bin look-back: should merge ones with fives",
         l(l(5, 1), l(5, 1), l(5, 1)), pack(l(5, 1, 5, 1, 5, 1), 8, 1));
+
+    Assert.assertEquals("1 bin look-back: should merge until targetWeight and order them by weight descending",
+        l(l(32, 32, 32, 32), l(64, 64), l(128)),
+        pack(l(32, 32, 32, 32, 64, 64, 128), 128, 1));
+
+    Assert.assertEquals(
+        "1 bin look-back: should order by weight descending and not order by number of items (at same weight)",
+        l(l(128), l(64, 64), l(32, 32, 32, 32)),
+        pack(l(128, 64, 64, 32, 32, 32, 32), 128, 1));
   }
 
   private List<List<Integer>> pack(List<Integer> items, long targetWeight) {

--- a/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
@@ -163,17 +163,14 @@ public class TestBinPacking {
     Assert.assertEquals("1 bin look-back: should merge ones with fives",
         l(l(5, 1), l(5, 1), l(5, 1)), pack(l(5, 1, 5, 1, 5, 1), 8, 1));
 
-    Assert.assertEquals("2 bin look-back: should merge all ones with five when expensiveTaskFirst is enabled",
-        l(l(5, 1, 1, 1), l(5, 5)), pack(l(5, 1, 5, 1, 5, 1), 10, 2, true));
-
-    Assert.assertEquals("2 bin look-back: should merge until targetWeight when expensiveTaskFirst is enabled",
+    Assert.assertEquals("2 bin look-back: should merge until targetWeight when largestBinFirst is enabled",
         l(l(36, 36, 36), l(128), l(36, 65), l(65)),
         pack(l(36, 36, 36, 36, 65, 65, 128), 128, 2, true));
 
     Assert.assertEquals(
-        "1 bin look-back: should order by weight descending and not order by number of items (at same weight)",
-        l(l(128), l(64, 64), l(32, 32, 32, 32)),
-        pack(l(128, 64, 64, 32, 32, 32, 32), 128, 1, true));
+        "1 bin look-back: should merge until targetWeight when largestBinFirst is enabled",
+        l(l(64, 64), l(128), l(32, 32, 32, 32)),
+        pack(l(64, 64, 128, 32, 32, 32, 32), 128, 1, true));
   }
 
   private List<List<Integer>> pack(List<Integer> items, long targetWeight) {
@@ -184,8 +181,8 @@ public class TestBinPacking {
     return pack(items, targetWeight, lookback, false);
   }
 
-  private List<List<Integer>> pack(List<Integer> items, long targetWeight, int lookback, boolean expensiveTaskFirst) {
-    ListPacker<Integer> packer = new ListPacker<>(targetWeight, lookback, expensiveTaskFirst);
+  private List<List<Integer>> pack(List<Integer> items, long targetWeight, int lookback, boolean largestBinFirst) {
+    ListPacker<Integer> packer = new ListPacker<>(targetWeight, lookback, largestBinFirst);
     return packer.pack(items, Integer::longValue);
   }
 


### PR DESCRIPTION
**Issue:** https://github.com/apache/incubator-iceberg/issues/114
**This PR:**
- Modifies PackingIterator to return the biggest bin instead of the first one when the number of bins exceeds `lookback`.