### PR TITLE
Collect lower/upper bounds for nested struct fields in ParquetMetrics

### DIFF
--- a/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/com/netflix/iceberg/parquet/ParquetMetrics.java
@@ -113,7 +113,9 @@ public class ParquetMetrics implements Serializable {
     Type currentType = schema.asStruct();
 
     while (pathIterator.hasNext()) {
-      if (currentType == null || !currentType.isStructType()) return false;
+      if (currentType == null || !currentType.isStructType()) {
+        return false;
+      }
       String fieldName = pathIterator.next();
       currentType = currentType.asStructType().fieldType(fieldName);
     }


### PR DESCRIPTION
This PR enables collection of lower/upper bounds for nested struct fields in `ParquetMetrics`.

The test is pretty simple as `TestParquetMetrics` already has a test for map/list elements as well as a test for all supported data types.

This resolves #78.