### PR TITLE
Add case insensitive support to Parquet.

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -257,6 +257,7 @@ public class Parquet {
     private ReadSupport<?> readSupport = null;
     private Function<MessageType, ParquetValueReader<?>> readerFunc = null;
     private boolean filterRecords = true;
+    private boolean caseSensitive = true;
     private Map<String, String> properties = Maps.newHashMap();
     private boolean callInit = false;
     private boolean reuseContainers = false;
@@ -280,6 +281,15 @@ public class Parquet {
 
     public ReadBuilder project(Schema schema) {
       this.schema = schema;
+      return this;
+    }
+
+    public ReadBuilder caseInsensitive() {
+      return caseSensitive(false);
+    }
+
+    public ReadBuilder caseSensitive(boolean caseSensitive) {
+      this.caseSensitive = caseSensitive;
       return this;
     }
 
@@ -339,7 +349,7 @@ public class Parquet {
         ParquetReadOptions options = optionsBuilder.build();
 
         return new org.apache.iceberg.parquet.ParquetReader<>(
-            file, schema, options, readerFunc, filter, reuseContainers);
+            file, schema, options, readerFunc, filter, reuseContainers, caseSensitive);
       }
 
       ParquetReadBuilder<D> builder = new ParquetReadBuilder<>(ParquetIO.file(file));
@@ -374,7 +384,7 @@ public class Parquet {
         builder.useStatsFilter()
             .useDictionaryFilter()
             .useRecordFilter(filterRecords)
-            .withFilter(ParquetFilters.convert(fileSchema, filter));
+            .withFilter(ParquetFilters.convert(fileSchema, filter, caseSensitive));
       } else {
         // turn off filtering
         builder.useStatsFilter(false)

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -66,9 +66,13 @@ public class ParquetDictionaryRowGroupFilter {
   }
 
   public ParquetDictionaryRowGroupFilter(Schema schema, Expression unbound) {
+    this(schema, unbound, true);
+  }
+
+  public ParquetDictionaryRowGroupFilter(Schema schema, Expression unbound, boolean caseSensitive) {
     this.schema = schema;
     this.struct = schema.asStruct();
-    this.expr = Binder.bind(struct, rewriteNot(unbound), true);
+    this.expr = Binder.bind(struct, rewriteNot(unbound), caseSensitive);
   }
 
   /**

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.expressions.ExpressionVisitors.ExpressionVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.types.Types;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -40,19 +39,8 @@ import static org.apache.iceberg.expressions.ExpressionVisitors.visit;
 
 class ParquetFilters {
 
-  static FilterCompat.Filter convert(Schema schema, Expression expr) {
-    FilterPredicate pred = visit(expr, new ConvertFilterToParquet(schema));
-    // TODO: handle AlwaysFalse.INSTANCE
-    if (pred != null && pred != AlwaysTrue.INSTANCE) {
-      // FilterCompat will apply LogicalInverseRewriter
-      return FilterCompat.get(pred);
-    } else {
-      return FilterCompat.NOOP;
-    }
-  }
-
-  static FilterCompat.Filter convertColumnFilter(Schema schema, String column, Expression expr) {
-    FilterPredicate pred = visit(expr, new ConvertColumnFilterToParquet(schema, column));
+  static FilterCompat.Filter convert(Schema schema, Expression expr, boolean caseSensitive) {
+    FilterPredicate pred = visit(expr, new ConvertFilterToParquet(schema, caseSensitive));
     // TODO: handle AlwaysFalse.INSTANCE
     if (pred != null && pred != AlwaysTrue.INSTANCE) {
       // FilterCompat will apply LogicalInverseRewriter
@@ -64,9 +52,11 @@ class ParquetFilters {
 
   private static class ConvertFilterToParquet extends ExpressionVisitor<FilterPredicate> {
     private final Schema schema;
+    private final boolean caseSensitive;
 
-    private ConvertFilterToParquet(Schema schema) {
+    private ConvertFilterToParquet(Schema schema, boolean caseSensitive) {
       this.schema = schema;
+      this.caseSensitive = caseSensitive;
     }
 
     @Override
@@ -160,7 +150,7 @@ class ParquetFilters {
     }
 
     protected Expression bind(UnboundPredicate<?> pred) {
-      return pred.bind(schema.asStruct(), true);
+      return pred.bind(schema.asStruct(), caseSensitive);
     }
 
     @Override
@@ -175,21 +165,6 @@ class ParquetFilters {
         return AlwaysFalse.INSTANCE;
       }
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
-    }
-  }
-
-  private static class ConvertColumnFilterToParquet extends ConvertFilterToParquet {
-    private final Types.StructType partitionStruct;
-
-    private ConvertColumnFilterToParquet(Schema schema, String column) {
-      super(schema);
-      this.partitionStruct = schema.findField(column).type().asNestedType().asStructType();
-    }
-
-    @Override
-    protected Expression bind(UnboundPredicate<?> pred) {
-      // instead of binding the predicate using the top-level schema, bind it to the partition data
-      return pred.bind(partitionStruct, true);
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -56,9 +56,13 @@ public class ParquetMetricsRowGroupFilter {
   }
 
   public ParquetMetricsRowGroupFilter(Schema schema, Expression unbound) {
+    this(schema, unbound, true);
+  }
+
+  public ParquetMetricsRowGroupFilter(Schema schema, Expression unbound, boolean caseSensitive) {
     this.schema = schema;
     this.struct = schema.asStruct();
-    this.expr = Binder.bind(struct, rewriteNot(unbound), true);
+    this.expr = Binder.bind(struct, rewriteNot(unbound), caseSensitive);
   }
 
   /**

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -470,4 +470,10 @@ public class TestDictionaryRowGroupFilter {
     Assert.assertFalse("Should skip: contains only ''", shouldRead);
   }
 
+  @Test
+  public void testCaseInsensitive() {
+    boolean shouldRead = new ParquetDictionaryRowGroupFilter(SCHEMA, notEqual("no_Nulls", ""), false)
+        .shouldRead(PARQUET_SCHEMA, ROW_GROUP_METADATA, DICTIONARY_STORE);
+    Assert.assertFalse("Should skip: contains only ''", shouldRead);
+  }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestMetricsRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestMetricsRowGroupFilter.java
@@ -460,4 +460,11 @@ public class TestMetricsRowGroupFilter {
         .shouldRead(PARQUET_SCHEMA, ROW_GROUP_METADATA);
     Assert.assertTrue("Should read: id above upper bound", shouldRead);
   }
+
+  @Test
+  public void testCaseInsensitive() {
+    boolean shouldRead = new ParquetMetricsRowGroupFilter(SCHEMA, equal("ID", 5), false)
+        .shouldRead(PARQUET_SCHEMA, ROW_GROUP_METADATA);
+    Assert.assertFalse("Should not read: id below lower bound", shouldRead);
+  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -461,6 +461,7 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
           .split(task.start(), task.length())
           .createReaderFunc(fileSchema -> SparkParquetReaders.buildReader(readSchema, fileSchema))
           .filter(task.residual())
+          .caseSensitive(caseSensitive)
           .build();
     }
   }


### PR DESCRIPTION
#83 and #89 add case sensitivity flags, but filters pushed down to Parquet still do not support case sensitivity. This updates the Parquet row group filters to support a case sensitivity flag and updates Spark to pass the flag.

This also updates the old read path that uses `ReadSupport` when converting Iceberg expressions to Parquet filters.