### PR TITLE
Update Tasks to retry at least once, log timeouts.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -397,7 +397,10 @@ public class Tasks {
 
         } catch (Exception e) {
           long durationMs = System.currentTimeMillis() - start;
-          if (attempt >= maxAttempts || durationMs > maxDurationMs) {
+          if (attempt >= maxAttempts || (durationMs > maxDurationMs && attempt > 1)) {
+            if (durationMs > maxDurationMs) {
+              LOG.info("Stopping retries after {} ms", durationMs);
+            }
             throw e;
           }
 


### PR DESCRIPTION
This commit ensures that even if a commit times out, it is retried at least once so that long-running commits still make progress.