### PR TITLE
Close open manifests during scan planning.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Filterable.java
+++ b/api/src/main/java/org/apache/iceberg/Filterable.java
@@ -22,13 +22,14 @@ package org.apache.iceberg;
 import com.google.common.collect.Lists;
 import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
 
 /**
  * Methods to filter files in a snapshot or manifest when reading.
  *
  * @param <T> Java class returned by filter methods, also filterable
  */
-public interface Filterable<T extends Filterable<T>> extends Iterable<DataFile> {
+public interface Filterable<T extends Filterable<T>> extends CloseableIterable<DataFile> {
   /**
    * Selects the columns of a file manifest to read.
    * <p>

--- a/api/src/main/java/org/apache/iceberg/io/CloseableGroup.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableGroup.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Deque;
-import java.util.Iterator;
 
 public abstract class CloseableGroup implements Closeable {
   private final Deque<Closeable> closeables = Lists.newLinkedList();
@@ -39,25 +38,6 @@ public abstract class CloseableGroup implements Closeable {
       if (toClose != null) {
         toClose.close();
       }
-    }
-  }
-
-  static class ClosingIterable<T> extends CloseableGroup implements CloseableIterable<T> {
-    private final Iterable<T> iterable;
-
-    ClosingIterable(Iterable<T> iterable, Iterable<Closeable> closeables) {
-      this.iterable = iterable;
-      if (iterable instanceof Closeable) {
-        addCloseable((Closeable) iterable);
-      }
-      for (Closeable closeable : closeables) {
-        addCloseable(closeable);
-      }
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-      return iterable.iterator();
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -42,16 +42,7 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
   }
 
   static <E> CloseableIterable<E> empty() {
-    return new CloseableIterable<E>() {
-      @Override
-      public void close() {
-      }
-
-      @Override
-      public Iterator<E> iterator() {
-        return Collections.emptyIterator();
-      }
-    };
+    return withNoopClose(Collections.emptyList());
   }
 
   static <E> CloseableIterable<E> combine(Iterable<E> iterable, Closeable closeable) {
@@ -64,22 +55,6 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
       @Override
       public Iterator<E> iterator() {
         return iterable.iterator();
-      }
-    };
-  }
-
-  static <I, O> CloseableIterable<O> wrap(CloseableIterable<I> iterable, Function<Iterable<I>, Iterable<O>> wrap) {
-    Iterable<O> wrappedIterable = wrap.apply(iterable);
-
-    return new CloseableIterable<O>() {
-      @Override
-      public void close() throws IOException {
-        iterable.close();
-      }
-
-      @Override
-      public Iterator<O> iterator() {
-        return wrappedIterable.iterator();
       }
     };
   }

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.io;
 
 import com.google.common.base.Preconditions;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
@@ -53,8 +54,18 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
     };
   }
 
-  static <E> CloseableIterable<E> combine(Iterable<E> iterable, Iterable<Closeable> closeables) {
-    return new CloseableGroup.ClosingIterable<>(iterable, closeables);
+  static <E> CloseableIterable<E> combine(Iterable<E> iterable, Closeable closeable) {
+    return new CloseableIterable<E>() {
+      @Override
+      public void close() throws IOException {
+        closeable.close();
+      }
+
+      @Override
+      public Iterator<E> iterator() {
+        return iterable.iterator();
+      }
+    };
   }
 
   static <I, O> CloseableIterable<O> wrap(CloseableIterable<I> iterable, Function<Iterable<I>, Iterable<O>> wrap) {
@@ -100,4 +111,95 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
       }
     };
   }
+
+  static <E> CloseableIterable<E> concat(Iterable<CloseableIterable<E>> iterable) {
+    Iterator<CloseableIterable<E>> iterables = iterable.iterator();
+    if (!iterables.hasNext()) {
+      return empty();
+    } else {
+      return new ConcatCloseableIterable<>(iterable);
+    }
+  }
+
+  class ConcatCloseableIterable<E> extends CloseableGroup implements CloseableIterable<E> {
+    private final Iterable<CloseableIterable<E>> inputs;
+
+    ConcatCloseableIterable(Iterable<CloseableIterable<E>> inputs) {
+      this.inputs = inputs;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      ConcatCloseableIterator<E> iter = new ConcatCloseableIterator<>(inputs);
+      addCloseable(iter);
+      return iter;
+    }
+
+    private static class ConcatCloseableIterator<E> implements Iterator<E>, Closeable {
+      private final Iterator<CloseableIterable<E>> iterables;
+      private CloseableIterable<E> currentIterable = null;
+      private Iterator<E> currentIterator = null;
+      private boolean closed = false;
+
+      private ConcatCloseableIterator(Iterable<CloseableIterable<E>> inputs) {
+        this.iterables = inputs.iterator();
+        this.currentIterable = iterables.next();
+        this.currentIterator = currentIterable.iterator();
+      }
+
+      @Override
+      public boolean hasNext() {
+        if (closed) {
+          return false;
+        }
+
+        if (currentIterator.hasNext()) {
+          return true;
+        }
+
+        while (iterables.hasNext()) {
+          try {
+            currentIterable.close();
+          } catch (IOException e) {
+            throw new RuntimeIOException(e, "Failed to close iterable");
+          }
+
+          this.currentIterable = iterables.next();
+          this.currentIterator = currentIterable.iterator();
+
+          if (currentIterator.hasNext()) {
+            return true;
+          }
+        }
+
+        try {
+          currentIterable.close();
+        } catch (IOException e) {
+          throw new RuntimeIOException(e, "Failed to close iterable");
+        }
+
+        this.closed = true;
+        this.currentIterator = null;
+        this.currentIterable = null;
+
+        return false;
+      }
+
+      @Override
+      public void close() throws IOException {
+        if (!closed) {
+          currentIterable.close();
+          this.closed = true;
+          this.currentIterator = null;
+          this.currentIterable = null;
+        }
+      }
+
+      @Override
+      public E next() {
+        return currentIterator.next();
+      }
+    }
+  }
+
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -28,14 +28,12 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import java.io.Closeable;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import org.apache.iceberg.TableMetadata.SnapshotLogEntry;
 import org.apache.iceberg.events.Listeners;
@@ -175,30 +173,26 @@ class BaseTableScan implements TableScan {
       Iterable<ManifestFile> matchingManifests = Iterables.filter(snapshot.manifests(),
           manifest -> evalCache.getUnchecked(manifest.partitionSpecId()).eval(manifest));
 
-      ConcurrentLinkedQueue<Closeable> toClose = new ConcurrentLinkedQueue<>();
-      Iterable<Iterable<FileScanTask>> readers = Iterables.transform(
+      Iterable<CloseableIterable<FileScanTask>> readers = Iterables.transform(
           matchingManifests,
           manifest -> {
               ManifestReader reader = ManifestReader
                   .read(ops.io().newInputFile(manifest.path()), ops.current()::spec)
                   .caseSensitive(caseSensitive);
             PartitionSpec spec = ops.current().spec(manifest.partitionSpecId());
-            toClose.add(reader);
             String schemaString = SchemaParser.toJson(spec.schema());
             String specString = PartitionSpecParser.toJson(spec);
             ResidualEvaluator residuals = new ResidualEvaluator(spec, rowFilter, caseSensitive);
-            return Iterables.transform(
+            return CloseableIterable.transform(
                 reader.filterRows(rowFilter).select(SNAPSHOT_COLUMNS),
                 file -> new BaseFileScanTask(file, schemaString, specString, residuals)
             );
           });
 
       if (PLAN_SCANS_WITH_WORKER_POOL && snapshot.manifests().size() > 1) {
-        return CloseableIterable.combine(
-            new ParallelIterable<>(readers, getWorkerPool()),
-            toClose);
+        return new ParallelIterable<>(readers, getWorkerPool());
       } else {
-        return CloseableIterable.combine(Iterables.concat(readers), toClose);
+        return CloseableIterable.concat(readers);
       }
 
     } else {
@@ -255,7 +249,7 @@ class BaseTableScan implements TableScan {
         .from(fileScanTasks)
         .transformAndConcat(input -> input.split(splitSize));
     // Capture manifests which can be closed after scan planning
-    return CloseableIterable.combine(splitTasks, ImmutableList.of(fileScanTasks));
+    return CloseableIterable.combine(splitTasks, fileScanTasks);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -212,9 +212,11 @@ class BaseTableScan implements TableScan {
 
     Function<FileScanTask, Long> weightFunc = file -> Math.max(file.length(), openFileCost);
 
+    CloseableIterable<FileScanTask> splitFiles = splitFiles(splitSize);
     return CloseableIterable.transform(
-        CloseableIterable.wrap(splitFiles(splitSize), splits ->
-            new BinPacking.PackingIterable<>(splits, splitSize, lookback, weightFunc, true)),
+        CloseableIterable.combine(
+            new BinPacking.PackingIterable<>(splitFiles, splitSize, lookback, weightFunc, true),
+            splitFiles),
         BaseCombinedScanTask::new);
   }
 

--- a/core/src/main/java/org/apache/iceberg/FilteredManifest.java
+++ b/core/src/main/java/org/apache/iceberg/FilteredManifest.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import org.apache.iceberg.ManifestEntry.Status;
@@ -127,6 +128,11 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
     } else {
       return Iterators.transform(reader.iterator(partFilter, columns), DataFile::copy);
     }
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
   }
 
   private Evaluator evaluator() {

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -107,7 +107,6 @@ class ManifestGroup {
    */
   public CloseableIterable<ManifestEntry> entries() {
     Evaluator evaluator = new Evaluator(DataFile.getType(EMPTY_STRUCT), fileFilter);
-    List<Closeable> toClose = Lists.newArrayList();
 
     Iterable<ManifestFile> matchingManifests = Iterables.filter(manifests,
         manifest -> evalCache.getUnchecked(manifest.partitionSpecId()).eval(manifest));
@@ -127,7 +126,6 @@ class ManifestGroup {
               ops.io().newInputFile(manifest.path()),
               ops.current()::spec);
           FilteredManifest filtered = reader.filterRows(dataFilter).select(columns);
-          toClose.add(reader);
           return CloseableIterable.combine(
               Iterables.filter(
                   ignoreDeleted ? filtered.liveEntries() : filtered.allEntries(),

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.IOException;


### PR DESCRIPTION
This fixes the single manifest case for #104 and also closes manifest files more quickly for both parallel and single-threaded scans.