### PR TITLE
[MINOR] Fix broken gradle build because of older shadow plugin version incompatible w/ gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     maven { url  "http://palantir.bintray.com/releases" }
   }
   dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.0'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
     classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.+'
     classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.5'
     classpath 'com.palantir.baseline:gradle-baseline-java:0.53.0'


### PR DESCRIPTION
This fixes issue w/ broken Gradle build due to quite older version of shadow plugin which is incompatible w/ Gradle 5 so that when we
```./gradlew clean build```

we get 

```
FAILURE: Build failed with an exception.
* What went wrong:
Method com/github/jengelman/gradle/plugins/shadow/internal/DependencyFileCollection.getBuildDependencies()Lorg/gradle/api/tasks/TaskDependency; is abstract
```