### PR TITLE
Add SnapshotUpdate interface with set method.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/AppendFiles.java
+++ b/api/src/main/java/org/apache/iceberg/AppendFiles.java
@@ -28,7 +28,7 @@ package org.apache.iceberg;
  * When committing, these changes will be applied to the latest table snapshot. Commit conflicts
  * will be resolved by applying the changes to the new latest snapshot and reattempting the commit.
  */
-public interface AppendFiles extends PendingUpdate<Snapshot> {
+public interface AppendFiles extends SnapshotUpdate<AppendFiles> {
   /**
    * Append a {@link DataFile} to the table.
    *

--- a/api/src/main/java/org/apache/iceberg/DeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFiles.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.expressions.Projections;
  * When committing, these changes will be applied to the latest table snapshot. Commit conflicts
  * will be resolved by applying the changes to the new latest snapshot and reattempting the commit.
  */
-public interface DeleteFiles extends PendingUpdate<Snapshot> {
+public interface DeleteFiles extends SnapshotUpdate<DeleteFiles> {
   /**
    * Delete a file path from the underlying table.
    * <p>

--- a/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.expressions.Projections;
  * This has no requirements for the latest snapshot and will not fail based on other snapshot
  * changes.
  */
-public interface OverwriteFiles extends PendingUpdate<Snapshot> {
+public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
   /**
    * Delete files that match an {@link Expression} on data rows from the table.
    * <p>

--- a/api/src/main/java/org/apache/iceberg/ReplacePartitions.java
+++ b/api/src/main/java/org/apache/iceberg/ReplacePartitions.java
@@ -34,7 +34,7 @@ package org.apache.iceberg;
  * This has no requirements for the latest snapshot and will not fail based on other snapshot
  * changes.
  */
-public interface ReplacePartitions extends PendingUpdate<Snapshot> {
+public interface ReplacePartitions extends SnapshotUpdate<ReplacePartitions> {
   /**
    * Add a {@link DataFile} to the table.
    *

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.exceptions.ValidationException;
  * If any of the deleted files are no longer in the latest snapshot when reattempting, the commit
  * will throw a {@link ValidationException}.
  */
-public interface RewriteFiles extends PendingUpdate<Snapshot> {
+public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   /**
    * Add a rewrite that replaces one set of files with another set that contains the same data.
    *

--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -19,31 +19,20 @@
 
 package org.apache.iceberg;
 
-import org.apache.iceberg.exceptions.CommitFailedException;
-
 /**
- * Append implementation that produces a minimal number of manifest files.
- * <p>
- * This implementation will attempt to commit 5 times before throwing {@link CommitFailedException}.
+ * API for table changes that produce snapshots. This interface contains common methods for all
+ * updates that create a new table {@link Snapshot}.
+ *
+ * @param <THIS> the child Java API class, returned by method chaining.
  */
-class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements AppendFiles {
-  MergeAppend(TableOperations ops) {
-    super(ops);
-  }
+public interface SnapshotUpdate<THIS> extends PendingUpdate<Snapshot> {
+  /**
+   * Set a summary property in the snapshot produced by this update.
+   *
+   * @param property a String property name
+   * @param value a String property value
+   * @return this for method chaining
+   */
+  THIS set(String property, String value);
 
-  @Override
-  protected AppendFiles self() {
-    return this;
-  }
-
-  @Override
-  protected String operation() {
-    return DataOperations.APPEND;
-  }
-
-  @Override
-  public MergeAppend appendFile(DataFile file) {
-    add(file);
-    return this;
-  }
 }

--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -23,9 +23,9 @@ package org.apache.iceberg;
  * API for table changes that produce snapshots. This interface contains common methods for all
  * updates that create a new table {@link Snapshot}.
  *
- * @param <THIS> the child Java API class, returned by method chaining.
+ * @param <ThisT> the child Java API class, returned by method chaining.
  */
-public interface SnapshotUpdate<THIS> extends PendingUpdate<Snapshot> {
+public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
   /**
    * Set a summary property in the snapshot produced by this update.
    *
@@ -33,6 +33,6 @@ public interface SnapshotUpdate<THIS> extends PendingUpdate<Snapshot> {
    * @param value a String property value
    * @return this for method chaining
    */
-  THIS set(String property, String value);
+  ThisT set(String property, String value);
 
 }

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.io.OutputFile;
  * <p>
  * This implementation will attempt to commit 5 times before throwing {@link CommitFailedException}.
  */
-class FastAppend extends SnapshotUpdate implements AppendFiles {
+class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   private final PartitionSpec spec;
   private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
   private final List<DataFile> newFiles = Lists.newArrayList();
@@ -43,6 +43,12 @@ class FastAppend extends SnapshotUpdate implements AppendFiles {
   FastAppend(TableOperations ops) {
     super(ops);
     this.spec = ops.current().spec();
+  }
+
+  @Override
+  public AppendFiles set(String property, String value) {
+    summaryBuilder.set(property, value);
+    return this;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/OverwriteData.java
+++ b/core/src/main/java/org/apache/iceberg/OverwriteData.java
@@ -26,11 +26,16 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 
-public class OverwriteData extends MergingSnapshotUpdate implements OverwriteFiles {
+public class OverwriteData extends MergingSnapshotProducer<OverwriteFiles> implements OverwriteFiles {
   private boolean validateAddedFiles = false;
 
   protected OverwriteData(TableOperations ops) {
     super(ops);
+  }
+
+  @Override
+  protected OverwriteFiles self() {
+    return this;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ReplaceFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ReplaceFiles.java
@@ -22,12 +22,17 @@ package org.apache.iceberg;
 import com.google.common.base.Preconditions;
 import java.util.Set;
 
-class ReplaceFiles extends MergingSnapshotUpdate implements RewriteFiles {
+class ReplaceFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   ReplaceFiles(TableOperations ops) {
     super(ops);
 
     // replace files must fail if any of the deleted paths is missing and cannot be deleted
     failMissingDeletePaths();
+  }
+
+  @Override
+  protected RewriteFiles self() {
+    return this;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ReplacePartitionsOperation.java
+++ b/core/src/main/java/org/apache/iceberg/ReplacePartitionsOperation.java
@@ -23,9 +23,15 @@ import java.util.List;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 
-public class ReplacePartitionsOperation extends MergingSnapshotUpdate implements ReplacePartitions {
+public class ReplacePartitionsOperation
+    extends MergingSnapshotProducer<ReplacePartitions> implements ReplacePartitions {
   ReplacePartitionsOperation(TableOperations ops) {
     super(ops);
+  }
+
+  @Override
+  protected ReplacePartitions self() {
+    return this;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -52,8 +52,8 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 import static org.apache.iceberg.TableProperties.MANIFEST_LISTS_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_LISTS_ENABLED_DEFAULT;
 
-abstract class SnapshotUpdate implements PendingUpdate<Snapshot> {
-  private static final Logger LOG = LoggerFactory.getLogger(SnapshotUpdate.class);
+abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotProducer.class);
   static final Set<ManifestFile> EMPTY_SET = Sets.newHashSet();
 
   /**
@@ -68,7 +68,7 @@ abstract class SnapshotUpdate implements PendingUpdate<Snapshot> {
   private Long snapshotId = null;
   private TableMetadata base = null;
 
-  protected SnapshotUpdate(TableOperations ops) {
+  protected SnapshotProducer(TableOperations ops) {
     this.ops = ops;
     this.base = ops.current();
     this.manifestsWithMetadata = Caffeine

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Set;
@@ -49,6 +50,7 @@ public class SnapshotSummary {
     private long deletedDuplicateFiles = 0L;
     private long addedRecords = 0L;
     private long deletedRecords = 0L;
+    private Map<String, String> properties = Maps.newHashMap();
 
     public void clear() {
       changedPartitions.clear();
@@ -75,8 +77,15 @@ public class SnapshotSummary {
       this.addedRecords += file.recordCount();
     }
 
+    public void set(String property, String value) {
+      properties.put(property, value);
+    }
+
     public Map<String, String> build() {
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+      // copy custom summary properties
+      builder.putAll(properties);
 
       setIf(addedFiles > 0, builder, ADDED_FILES_PROP, addedFiles);
       setIf(deletedFiles > 0, builder, DELETED_FILES_PROP, deletedFiles);

--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -27,9 +27,14 @@ import org.apache.iceberg.expressions.Expression;
  * <p>
  * This implementation will attempt to commit 5 times before throwing {@link CommitFailedException}.
  */
-class StreamingDelete extends MergingSnapshotUpdate implements DeleteFiles {
+class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements DeleteFiles {
   StreamingDelete(TableOperations ops) {
     super(ops);
+  }
+
+  @Override
+  protected DeleteFiles self() {
+    return this;
   }
 
   @Override


### PR DESCRIPTION
This adds a `set` method to add custom properties to snapshot summaries. To add a method to all updates that produce snapshots, this adds a new public interface, `SnapshotUpdate`.

The new interface conflicts with a private class, which has been renamed to `SnapshotProducer`. Similarly, the subclass that implements merging and filter logic has been renamed to `MergingSnapshotProducer`.