### PR TITLE
Store split offsets for ORC files

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -92,9 +92,8 @@ public class ORC {
 
     public <D> FileAppender<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
-      OrcFile.WriterOptions options = OrcFile.writerOptions(conf);
       return new OrcFileAppender<>(TypeConversion.toOrc(schema, new ColumnIdMap()),
-          this.file, createWriterFunc, options, metadata,
+          this.file, createWriterFunc, conf, metadata,
           conf.getInt(VECTOR_ROW_BATCH_SIZE, DEFAULT_SIZE));
     }
   }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -125,6 +125,7 @@ class OrcFileAppender<D> implements FileAppender<D> {
 
   @Override
   public List<Long> splitOffsets() {
+    Preconditions.checkState(isClosed, "File is not yet closed");
     Reader reader;
     try {
       reader = OrcFile.createReader(path, new OrcFile.ReaderOptions(conf));

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iceberg.spark.data;
 
 import org.apache.iceberg.Files;
@@ -26,10 +45,10 @@ public class TestOrcWrite {
 
   @Test
   public void splitOffsets() throws IOException {
-    Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
 
+    Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);
     FileAppender<InternalRow> writer = ORC.write(Files.localOutput(testFile))
         .createWriterFunc(SparkOrcWriter::new)
         .schema(SCHEMA)

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -1,0 +1,42 @@
+package org.apache.iceberg.spark.data;
+
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestOrcWrite {
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private static final Schema SCHEMA = new Schema(
+      optional(1, "id", Types.IntegerType.get()),
+      optional(2, "data", Types.StringType.get())
+  );
+
+  @Test
+  public void splitOffsets() throws IOException {
+    Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    FileAppender<InternalRow> writer = ORC.write(Files.localOutput(testFile))
+        .createWriterFunc(SparkOrcWriter::new)
+        .schema(SCHEMA)
+        .build();
+
+    writer.addAll(rows);
+    writer.close();
+    Assert.assertNotNull("Split offsets not present", writer.splitOffsets());
+  }
+}


### PR DESCRIPTION
I had to reopen the file with an ORC reader to get the stripe offsets. Stripe information is cached in the writer but it is not made public AFAICT.  If folks are OK with the approach, I will try to add tests for this, similar to #186 

cc: @edgarRd 