### PR TITLE
Add appendManifest to AppendFiles API.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/AppendFiles.java
+++ b/api/src/main/java/org/apache/iceberg/AppendFiles.java
@@ -36,4 +36,15 @@ public interface AppendFiles extends SnapshotUpdate<AppendFiles> {
    * @return this for method chaining
    */
   AppendFiles appendFile(DataFile file);
+
+  /**
+   * Append the contents of a manifest to the table.
+   * <p>
+   * The manifest must contain only appended files. All files in the manifest will be appended to
+   * the table in the snapshot created by this update.
+   *
+   * @param file a manifest file
+   * @return this for method chaining
+   */
+  AppendFiles appendManifest(ManifestFile file);
 }

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
@@ -34,14 +35,18 @@ import org.apache.iceberg.io.OutputFile;
  * This implementation will attempt to commit 5 times before throwing {@link CommitFailedException}.
  */
 class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
+  private final TableOperations ops;
   private final PartitionSpec spec;
   private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
   private final List<DataFile> newFiles = Lists.newArrayList();
+  private final List<ManifestFile> appendManifests = Lists.newArrayList();
   private ManifestFile newManifest = null;
+  private final AtomicInteger manifestCount = new AtomicInteger(0);
   private boolean hasNewFiles = false;
 
   FastAppend(TableOperations ops) {
     super(ops);
+    this.ops = ops;
     this.spec = ops.current().spec();
   }
 
@@ -70,14 +75,33 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   }
 
   @Override
+  public FastAppend appendManifest(ManifestFile manifest) {
+    // the manifest must be rewritten with this update's snapshot ID
+    try (ManifestReader reader = ManifestReader.read(
+        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+      OutputFile newManifestPath = manifestPath(manifestCount.getAndIncrement());
+      appendManifests.add(ManifestWriter.copyAppendManifest(reader, newManifestPath, snapshotId(), summaryBuilder));
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
+    }
+
+    return this;
+  }
+
+  @Override
   public List<ManifestFile> apply(TableMetadata base) {
     List<ManifestFile> newManifests = Lists.newArrayList();
 
     try {
-      newManifests.add(writeManifest());
+      ManifestFile manifest = writeManifest();
+      if (manifest != null) {
+        newManifests.add(manifest);
+      }
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write manifest");
     }
+
+    newManifests.addAll(appendManifests);
 
     if (base.currentSnapshot() != null) {
       newManifests.addAll(base.currentSnapshot().manifests());
@@ -88,8 +112,14 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
 
   @Override
   protected void cleanUncommitted(Set<ManifestFile> committed) {
-    if (!committed.contains(newManifest)) {
+    if (newManifest != null && !committed.contains(newManifest)) {
       deleteFile(newManifest.path());
+    }
+
+    for (ManifestFile manifest : appendManifests) {
+      if (!committed.contains(manifest)) {
+        deleteFile(manifest.path());
+      }
     }
   }
 
@@ -99,8 +129,8 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
       newManifest = null;
     }
 
-    if (newManifest == null) {
-      OutputFile out = manifestPath(0);
+    if (newManifest == null && newFiles.size() > 0) {
+      OutputFile out = manifestPath(manifestCount.getAndIncrement());
 
       ManifestWriter writer = new ManifestWriter(spec, out, snapshotId());
       try {

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -31,8 +31,49 @@ import org.slf4j.LoggerFactory;
 /**
  * Writer for manifest files.
  */
-class ManifestWriter implements FileAppender<DataFile> {
+public class ManifestWriter implements FileAppender<DataFile> {
   private static final Logger LOG = LoggerFactory.getLogger(ManifestWriter.class);
+
+  static ManifestFile copyAppendManifest(ManifestReader reader, OutputFile outputFile, long snapshotId,
+                                         SnapshotSummary.Builder summaryBuilder) {
+    ManifestWriter writer = new ManifestWriter(reader.spec(), outputFile, snapshotId);
+    boolean threw = true;
+    try {
+      for (ManifestEntry entry : reader.entries()) {
+        Preconditions.checkArgument(entry.status() == ManifestEntry.Status.ADDED,
+            "Cannot append manifest: contains existing files");
+        summaryBuilder.addedFile(reader.spec(), entry.file());
+        writer.add(entry);
+      }
+
+      threw = false;
+
+    } finally {
+      try {
+        writer.close();
+      } catch (IOException e) {
+        if (!threw) {
+          throw new RuntimeIOException(e, "Failed to close manifest: %s", outputFile);
+        }
+      }
+    }
+
+    return writer.toManifestFile();
+  }
+
+  /**
+   * Create a new {@link ManifestWriter}.
+   * <p>
+   * Manifests created by this writer are not part of a snapshot and have all entry snapshot IDs
+   * set to -1.
+   *
+   * @param spec {@link PartitionSpec} used to produce {@link DataFile} partition tuples
+   * @param outputFile the destination file location
+   * @return a manifest writer
+   */
+  public static ManifestWriter write(PartitionSpec spec, OutputFile outputFile) {
+    return new ManifestWriter(spec, outputFile, -1);
+  }
 
   private final OutputFile file;
   private final int specId;
@@ -55,33 +96,7 @@ class ManifestWriter implements FileAppender<DataFile> {
     this.stats = new PartitionSummary(spec);
   }
 
-  public void addExisting(Iterable<ManifestEntry> entries) {
-    for (ManifestEntry entry : entries) {
-      if (entry.status() != ManifestEntry.Status.DELETED) {
-        addExisting(entry);
-      }
-    }
-  }
-
-  public void addExisting(ManifestEntry entry) {
-    add(reused.wrapExisting(entry.snapshotId(), entry.file()));
-  }
-
-  public void addExisting(long newSnapshotId, DataFile newFile) {
-    add(reused.wrapExisting(newSnapshotId, newFile));
-  }
-
-  public void delete(ManifestEntry entry) {
-    // Use the current Snapshot ID for the delete. It is safe to delete the data file from disk
-    // when this Snapshot has been removed or when there are no Snapshots older than this one.
-    add(reused.wrapDelete(snapshotId, entry.file()));
-  }
-
-  public void delete(DataFile deletedFile) {
-    add(reused.wrapDelete(snapshotId, deletedFile));
-  }
-
-  public void add(ManifestEntry entry) {
+  void addEntry(ManifestEntry entry) {
     switch (entry.status()) {
       case ADDED:
         addedFiles += 1;
@@ -97,11 +112,53 @@ class ManifestWriter implements FileAppender<DataFile> {
     writer.add(entry);
   }
 
+  /**
+   * Add an added entry for a data file.
+   * <p>
+   * The entry's snapshot ID will be this manifest's snapshot ID.
+   *
+   * @param addedFile a data file
+   */
   @Override
   public void add(DataFile addedFile) {
     // TODO: this assumes that file is a GenericDataFile that can be written directly to Avro
     // Eventually, this should check in case there are other DataFile implementations.
-    add(reused.wrapAppend(snapshotId, addedFile));
+    addEntry(reused.wrapAppend(snapshotId, addedFile));
+  }
+
+  public void add(ManifestEntry entry) {
+    addEntry(reused.wrapAppend(snapshotId, entry.file()));
+  }
+
+  /**
+   * Add an existing entry for a data file.
+   *
+   * @param existingFile a data file
+   * @param fileSnapshotId snapshot ID when the data file was added to the table
+   */
+  public void existing(DataFile existingFile, long fileSnapshotId) {
+    addEntry(reused.wrapExisting(fileSnapshotId, existingFile));
+  }
+
+  void existing(ManifestEntry entry) {
+    addEntry(reused.wrapExisting(entry.snapshotId(), entry.file()));
+  }
+
+  /**
+   * Add a delete entry for a data file.
+   * <p>
+   * The entry's snapshot ID will be this manifest's snapshot ID.
+   *
+   * @param deletedFile a data file
+   */
+  public void delete(DataFile deletedFile) {
+    addEntry(reused.wrapDelete(snapshotId, deletedFile));
+  }
+
+  void delete(ManifestEntry entry) {
+    // Use the current Snapshot ID for the delete. It is safe to delete the data file from disk
+    // when this Snapshot has been removed or when there are no Snapshots older than this one.
+    addEntry(reused.wrapDelete(snapshotId, entry.file()));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/MergeAppend.java
+++ b/core/src/main/java/org/apache/iceberg/MergeAppend.java
@@ -46,4 +46,10 @@ class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements Append
     add(file);
     return this;
   }
+
+  @Override
+  public AppendFiles appendManifest(ManifestFile manifest) {
+    add(manifest);
+    return this;
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/ReplaceManifests.java
+++ b/core/src/main/java/org/apache/iceberg/ReplaceManifests.java
@@ -236,7 +236,7 @@ public class ReplaceManifests extends SnapshotProducer<RewriteManifests> impleme
         writer = newWriter();
       }
 
-      writer.addExisting(entry);
+      writer.existing(entry);
       estimatedSize += len;
     }
 


### PR DESCRIPTION
This is intended for writers that need to checkpoint state or to help parallelize conversion. Writers that checkpoint should be able to create manifest files and append the contents of those manifests to a table, instead of checkpointing individual data files. Similarly, when copying table state to convert to Iceberg, tasks should be able to create manifests in parallel and commit a small list of manifests to a table instead of collecting all data files into a single commit.

Manifests that will be appended must be rewritten in the final commit to correctly set the snapshot ID of all new data files.

This also makes `ManifestWriter` public and cleans up its public API.