### PR TITLE
Add option to load column stats with data files.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -142,9 +142,9 @@ public interface DataFile {
    * Copies this {@link DataFile data file} without file stats. Manifest readers can reuse data file instances; use
    * this method to copy data without stats when collecting files.
    *
-   * @return a copy of this data file
+   * @return a copy of this data file, without lower bounds, upper bounds, value counts, or null value counts
    */
-  DataFile slimCopy();
+  DataFile copyWithoutStats();
 
   /**
    * @return List of recommended split locations, if applicable, null otherwise.

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -139,6 +139,14 @@ public interface DataFile {
   DataFile copy();
 
   /**
+   * Copies this {@link DataFile data file} without file stats. Manifest readers can reuse data file instances; use
+   * this method to copy data without stats when collecting files.
+   *
+   * @return a copy of this data file
+   */
+  DataFile slimCopy();
+
+  /**
    * @return List of recommended split locations, if applicable, null otherwise.
    * When available, this information is used for planning scan tasks whose boundaries
    * are determined by these offsets. The returned list must be sorted in ascending order.

--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -76,6 +76,15 @@ public interface TableScan {
   TableScan caseSensitive(boolean caseSensitive);
 
   /**
+   * Create a new {@link TableScan} from this that loads the column stats with each data file.
+   * <p>
+   * Column stats include: value count, null value count, lower bounds, and upper bounds.
+   *
+   * @return a new scan based on this that loads column stats.
+   */
+  TableScan includeColumnStats();
+
+  /**
    * Create a new {@link TableScan} from this that will read the given data columns. This produces
    * an expected schema that includes all fields that are either selected or used by this scan's
    * filter expression.

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -378,6 +378,11 @@ public class TestHelpers {
     }
 
     @Override
+    public DataFile slimCopy() {
+      return this;
+    }
+
+    @Override
     public List<Long> splitOffsets() {
       return null;
     }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -378,7 +378,7 @@ public class TestHelpers {
     }
 
     @Override
-    public DataFile slimCopy() {
+    public DataFile copyWithoutStats() {
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -163,12 +163,12 @@ class BaseSnapshot implements Snapshot {
           ops.current()::spec)) {
         for (ManifestEntry add : reader.addedFiles()) {
           if (add.snapshotId() == snapshotId) {
-            adds.add(add.file().copy());
+            adds.add(add.file().slimCopy());
           }
         }
         for (ManifestEntry delete : reader.deletedFiles()) {
           if (delete.snapshotId() == snapshotId) {
-            deletes.add(delete.file().copy());
+            deletes.add(delete.file().slimCopy());
           }
         }
       } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -163,12 +163,12 @@ class BaseSnapshot implements Snapshot {
           ops.current()::spec)) {
         for (ManifestEntry add : reader.addedFiles()) {
           if (add.snapshotId() == snapshotId) {
-            adds.add(add.file().slimCopy());
+            adds.add(add.file().copyWithoutStats());
           }
         }
         for (ManifestEntry delete : reader.deletedFiles()) {
           if (delete.snapshotId() == snapshotId) {
-            deletes.add(delete.file().slimCopy());
+            deletes.add(delete.file().copyWithoutStats());
           }
         }
       } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -61,11 +61,10 @@ class BaseTableScan implements TableScan {
       "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
       "file_size_in_bytes", "record_count", "partition"
   );
-  private static final List<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.of(
-      "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
-      "file_size_in_bytes", "record_count", "partition", "value_counts", "null_value_counts",
-      "lower_bounds", "upper_bounds"
-  );
+  private static final List<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.<String>builder()
+      .addAll(SCAN_COLUMNS)
+      .add("value_counts", "null_value_counts", "lower_bounds", "upper_bounds")
+      .build();
   private static final boolean PLAN_SCANS_WITH_WORKER_POOL =
       SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);
 

--- a/core/src/main/java/org/apache/iceberg/FilteredManifest.java
+++ b/core/src/main/java/org/apache/iceberg/FilteredManifest.java
@@ -129,15 +129,15 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
       List<String> projectColumns = Lists.newArrayList(columns);
       projectColumns.addAll(STATS_COLUMNS); // order doesn't matter
 
-      // if no stats columns were projected, drop them by using slimCopy
-      boolean useSlimCopy = Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS).isEmpty();
+      // if no stats columns were projected, drop them
+      boolean dropStats = Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS).isEmpty();
 
       return Iterators.transform(
           Iterators.filter(reader.iterator(partFilter, projectColumns),
               input -> input != null &&
                   evaluator.eval(input.partition()) &&
                   metricsEvaluator.eval(input)),
-          useSlimCopy ? DataFile::slimCopy : DataFile::copy);
+          dropStats ? DataFile::copyWithoutStats : DataFile::copy);
 
     } else {
       return Iterators.transform(reader.iterator(partFilter, columns), DataFile::copy);

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -27,7 +27,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.nio.file.CopyOption;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.IndexedRecord;

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -165,7 +165,7 @@ class GenericDataFile
    *
    * @param toCopy a generic data file to copy.
    */
-  private GenericDataFile(GenericDataFile toCopy) {
+  private GenericDataFile(GenericDataFile toCopy, boolean fullCopy) {
     this.filePath = toCopy.filePath;
     this.format = toCopy.format;
     this.partitionData = toCopy.partitionData.copy();
@@ -174,12 +174,20 @@ class GenericDataFile
     this.fileSizeInBytes = toCopy.fileSizeInBytes;
     this.fileOrdinal = toCopy.fileOrdinal;
     this.sortColumns = copy(toCopy.sortColumns);
-    // TODO: support lazy conversion to/from map
-    this.columnSizes = copy(toCopy.columnSizes);
-    this.valueCounts = copy(toCopy.valueCounts);
-    this.nullValueCounts = copy(toCopy.nullValueCounts);
-    this.lowerBounds = SerializableByteBufferMap.wrap(copy(toCopy.lowerBounds));
-    this.upperBounds = SerializableByteBufferMap.wrap(copy(toCopy.upperBounds));
+    if (fullCopy) {
+      // TODO: support lazy conversion to/from map
+      this.columnSizes = copy(toCopy.columnSizes);
+      this.valueCounts = copy(toCopy.valueCounts);
+      this.nullValueCounts = copy(toCopy.nullValueCounts);
+      this.lowerBounds = SerializableByteBufferMap.wrap(copy(toCopy.lowerBounds));
+      this.upperBounds = SerializableByteBufferMap.wrap(copy(toCopy.upperBounds));
+    } else {
+      this.columnSizes = null;
+      this.valueCounts = null;
+      this.nullValueCounts = null;
+      this.lowerBounds = null;
+      this.upperBounds = null;
+    }
     this.fromProjectionPos = toCopy.fromProjectionPos;
     this.keyMetadata = toCopy.keyMetadata == null ? null : ByteBuffers.copy(toCopy.keyMetadata);
     this.splitOffsets = copy(toCopy.splitOffsets);
@@ -414,8 +422,13 @@ class GenericDataFile
   }
 
   @Override
+  public DataFile slimCopy() {
+    return new GenericDataFile(this, false /* slim copy */);
+  }
+
+  @Override
   public DataFile copy() {
-    return new GenericDataFile(this);
+    return new GenericDataFile(this, true /* full copy */);
   }
 
   private static <K, V> Map<K, V> copy(Map<K, V> map) {

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -27,6 +27,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.nio.file.CopyOption;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.IndexedRecord;
@@ -422,8 +423,8 @@ class GenericDataFile
   }
 
   @Override
-  public DataFile slimCopy() {
-    return new GenericDataFile(this, false /* slim copy */);
+  public DataFile copyWithoutStats() {
+    return new GenericDataFile(this, false /* drop stats */);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -165,6 +165,7 @@ class GenericDataFile
    * Copy constructor.
    *
    * @param toCopy a generic data file to copy.
+   * @param fullCopy whether to copy all fields or to drop column-level stats
    */
   private GenericDataFile(GenericDataFile toCopy, boolean fullCopy) {
     this.filePath = toCopy.filePath;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -60,11 +60,15 @@ class ManifestEntry implements IndexedRecord, SpecificData.SchemaConstructable {
     this.schema = AvroSchemaUtil.convert(getSchema(partitionType), "manifest_entry");
   }
 
-  private ManifestEntry(ManifestEntry toCopy) {
+  private ManifestEntry(ManifestEntry toCopy, boolean fullCopy) {
     this.schema = toCopy.schema;
     this.status = toCopy.status;
     this.snapshotId = toCopy.snapshotId;
-    this.file = toCopy.file().copy();
+    if (fullCopy) {
+      this.file = toCopy.file().copy();
+    } else {
+      this.file = toCopy.file().slimCopy();
+    }
   }
 
   ManifestEntry wrapExisting(long newSnapshotId, DataFile newFile) {
@@ -110,7 +114,11 @@ class ManifestEntry implements IndexedRecord, SpecificData.SchemaConstructable {
   }
 
   public ManifestEntry copy() {
-    return new ManifestEntry(this);
+    return new ManifestEntry(this, true /* full copy */);
+  }
+
+  public ManifestEntry slimCopy() {
+    return new ManifestEntry(this, false /* slim copy */);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -67,7 +67,7 @@ class ManifestEntry implements IndexedRecord, SpecificData.SchemaConstructable {
     if (fullCopy) {
       this.file = toCopy.file().copy();
     } else {
-      this.file = toCopy.file().slimCopy();
+      this.file = toCopy.file().copyWithoutStats();
     }
   }
 
@@ -117,8 +117,8 @@ class ManifestEntry implements IndexedRecord, SpecificData.SchemaConstructable {
     return new ManifestEntry(this, true /* full copy */);
   }
 
-  public ManifestEntry slimCopy() {
-    return new ManifestEntry(this, false /* slim copy */);
+  public ManifestEntry copyWithoutStats() {
+    return new ManifestEntry(this, false /* drop stats */);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -183,10 +183,10 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
     for (ManifestEntry entry : entries(CHANGE_COLUNNS)) {
       switch (entry.status()) {
         case ADDED:
-          adds.add(entry.slimCopy());
+          adds.add(entry.copyWithoutStats());
           break;
         case DELETED:
-          deletes.add(entry.slimCopy());
+          deletes.add(entry.copyWithoutStats());
           break;
         default:
       }

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -183,10 +183,10 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
     for (ManifestEntry entry : entries(CHANGE_COLUNNS)) {
       switch (entry.status()) {
         case ADDED:
-          adds.add(entry.copy());
+          adds.add(entry.slimCopy());
           break;
         case DELETED:
-          deletes.add(entry.copy());
+          deletes.add(entry.slimCopy());
           break;
         default:
       }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -434,7 +434,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             } else {
               // only add the file to deletes if it is a new delete
               // this keeps the snapshot summary accurate for non-duplicate data
-              deletedFiles.add(entry.file().copy());
+              deletedFiles.add(entry.file().slimCopy());
             }
             deletedPaths.add(wrapper);
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -434,7 +434,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             } else {
               // only add the file to deletes if it is a new delete
               // this keeps the snapshot summary accurate for non-duplicate data
-              deletedFiles.add(entry.file().slimCopy());
+              deletedFiles.add(entry.file().copyWithoutStats());
             }
             deletedPaths.add(wrapper);
 

--- a/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
@@ -20,7 +20,10 @@
 package org.apache.iceberg;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.types.Types;
@@ -29,11 +32,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.List;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;

--- a/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestScanDataFileColumns {
+  private static final Schema SCHEMA = new Schema(
+      required(1, "id", Types.LongType.get()),
+      optional(2, "data", Types.StringType.get()));
+
+  private static final Configuration CONF = new Configuration();
+  private static final Tables TABLES = new HadoopTables(CONF);
+
+  @Rule
+  public final TemporaryFolder temp = new TemporaryFolder();
+
+  private String tableLocation = null;
+  private Table table = null;
+
+  @Before
+  public void createTables() throws IOException {
+    File location = temp.newFolder("shared");
+    Assert.assertTrue(location.delete());
+    this.tableLocation = location.toString();
+    this.table = TABLES.create(
+        SCHEMA, PartitionSpec.unpartitioned(),
+        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, FileFormat.PARQUET.name()),
+        tableLocation);
+
+    // commit the test data
+    table.newAppend()
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("file1.parquet")
+            .withFileSizeInBytes(100)
+            .withMetrics(new Metrics(3L,
+                null, // no column sizes
+                ImmutableMap.of(1, 3L), // value count
+                ImmutableMap.of(1, 0L), // null count
+                ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
+                ImmutableMap.of(1, longToBuffer(2L)))) // upper bounds)
+            .build())
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("file2.parquet")
+            .withFileSizeInBytes(100)
+            .withMetrics(new Metrics(3L,
+                null, // no column sizes
+                ImmutableMap.of(1, 3L), // value count
+                ImmutableMap.of(1, 0L), // null count
+                ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
+                ImmutableMap.of(1, longToBuffer(12L)))) // upper bounds)
+            .build())
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("file3.parquet")
+            .withFileSizeInBytes(100)
+            .withMetrics(new Metrics(3L,
+                null, // no column sizes
+                ImmutableMap.of(1, 3L), // value count
+                ImmutableMap.of(1, 0L), // null count
+                ImmutableMap.of(1, longToBuffer(20L)), // lower bounds
+                ImmutableMap.of(1, longToBuffer(22L)))) // upper bounds)
+            .build())
+        .commit();
+  }
+
+  @Test
+  public void testColumnStatsIgnored() {
+    // stats columns should be suppressed by default
+    for (FileScanTask fileTask : table.newScan().planFiles()) {
+      Assert.assertNull(fileTask.file().valueCounts());
+      Assert.assertNull(fileTask.file().nullValueCounts());
+      Assert.assertNull(fileTask.file().lowerBounds());
+      Assert.assertNull(fileTask.file().upperBounds());
+    }
+  }
+
+  @Test
+  public void testColumnStatsLoading() {
+    // stats columns should be suppressed by default
+    for (FileScanTask fileTask : table.newScan().includeColumnStats().planFiles()) {
+      Assert.assertNotNull(fileTask.file().valueCounts());
+      Assert.assertNotNull(fileTask.file().nullValueCounts());
+      Assert.assertNotNull(fileTask.file().lowerBounds());
+      Assert.assertNotNull(fileTask.file().upperBounds());
+    }
+  }
+
+  private static ByteBuffer longToBuffer(long value) {
+    return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
+  }
+}


### PR DESCRIPTION
This adds an option to `BaseTableScan` to load column-level stats. Many clients do not need column-level stats when scanning Iceberg tables and removing them before copying data files speeds up query planning.

When filtering files listed in a manifest, stats columns are now always loaded for the `InclusiveMetricsEvaluator`. When a data file is selected, its contents are either copied using a full copy or a "slim" copy that discards the large maps of column stats.