### PR TITLE
Remove uncessary precondition checks

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileAppender.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileAppender.java
@@ -43,7 +43,7 @@ public interface FileAppender<D> extends Closeable {
   Metrics metrics();
 
   /**
-   * @return the length of this file. Only valid after the file is closed.
+   * @return the length of this file.
    */
   long length();
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -62,8 +62,6 @@ class AvroFileAppender<D> implements FileAppender<D> {
 
   @Override
   public long length() {
-    Preconditions.checkState(writer == null,
-        "Cannot return length while appending to an open file.");
     if (stream != null) {
       try {
         return stream.getPos();

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.avro;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.Function;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
@@ -53,8 +53,6 @@ public class ParquetWriteAdapter<D> implements FileAppender<D> {
 
   @Override
   public long length() {
-    Preconditions.checkState(writer == null,
-        "Cannot return length while appending to an open file.");
     return writer.getDataSize();
   }
 


### PR DESCRIPTION
These checks unnecessarily prevent checking how much data has been written.