### PR TITLE
Fix uncommitted file clean-up in transactions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg;
 
+import java.util.function.Consumer;
+
 /**
  * API for table changes that produce snapshots. This interface contains common methods for all
  * updates that create a new table {@link Snapshot}.
@@ -34,5 +36,13 @@ public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
    * @return this for method chaining
    */
   ThisT set(String property, String value);
+
+  /**
+   * Set a callback to delete files instead of the table's default.
+   *
+   * @param deleteFunc a String consumer used to delete locations.
+   * @return this for method chaining
+   */
+  ThisT deleteWith(Consumer<String> deleteFunc);
 
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -63,14 +63,12 @@ class BaseTransaction implements Transaction {
     return new BaseTransaction(ops, ops.refresh());
   }
 
-  // exposed for testing
   private final TableOperations ops;
   private final TransactionTable transactionTable;
   private final TableOperations transactionOps;
   private final List<PendingUpdate> updates;
   private final Set<Long> intermediateSnapshotIds;
-  // exposed for testing
-  final Set<String> deletedFiles = Sets.newHashSet(); // keep track of files deleted in the most recent commit
+  private final Set<String> deletedFiles = Sets.newHashSet(); // keep track of files deleted in the most recent commit
   private final Consumer<String> enqueueDelete = deletedFiles::add;
   private TransactionType type;
   private TableMetadata base;
@@ -448,5 +446,10 @@ class BaseTransaction implements Transaction {
   @VisibleForTesting
   TableOperations ops() {
     return ops;
+  }
+
+  @VisibleForTesting
+  Set<String> deletedFiles() {
+    return deletedFiles;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -51,6 +51,11 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   }
 
   @Override
+  protected AppendFiles self() {
+    return this;
+  }
+
+  @Override
   public AppendFiles set(String property, String value) {
     summaryBuilder.set(property, value);
     return this;

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -116,8 +116,6 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         .propertyAsInt(MANIFEST_MIN_MERGE_COUNT, MANIFEST_MIN_MERGE_COUNT_DEFAULT);
   }
 
-  protected abstract ThisT self();
-
   @Override
   public ThisT set(String property, String value) {
     summaryBuilder.set(property, value);

--- a/core/src/main/java/org/apache/iceberg/ReplaceManifests.java
+++ b/core/src/main/java/org/apache/iceberg/ReplaceManifests.java
@@ -74,6 +74,11 @@ public class ReplaceManifests extends SnapshotProducer<RewriteManifests> impleme
   }
 
   @Override
+  protected RewriteManifests self() {
+    return this;
+  }
+
+  @Override
   protected String operation() {
     return DataOperations.REPLACE;
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -31,9 +31,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
@@ -94,10 +94,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       });
   }
 
+  protected abstract ThisT self();
+
   @Override
-  public THIS deleteWith(Consumer<String> deleteFunc) {
+  public ThisT deleteWith(Consumer<String> deleteCallback) {
     Preconditions.checkArgument(this.deleteFunc == defaultDelete, "Cannot set delete callback more than once");
-    this.deleteFunc = deleteFunc;
+    this.deleteFunc = deleteCallback;
     return self();
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -19,11 +19,14 @@
 
 package org.apache.iceberg;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.io.OutputFile;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -457,5 +460,89 @@ public class TestTransaction extends TableTestBase {
         previousManifests.contains(table.currentSnapshot().manifests().get(0)));
 
     Assert.assertFalse("Append manifest should be deleted", new File(appendManifest.path()).exists());
+  }
+
+  @Test
+  public void testTransactionRetryAndAppendManifests() throws Exception {
+    // use only one retry and aggressively merge manifests
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "1")
+        .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "0")
+        .commit();
+
+    Assert.assertEquals("Table should be on version 1", 1, (int) version());
+
+    table.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertEquals("Table should be on version 2 after append", 2, (int) version());
+    Assert.assertEquals("Append should create one manifest", 1, table.currentSnapshot().manifests().size());
+    ManifestFile v1manifest = table.currentSnapshot().manifests().get(0);
+
+    TableMetadata base = readMetadata();
+
+    // create a manifest append
+    OutputFile manifestLocation = Files.localOutput("/tmp/" + UUID.randomUUID().toString() + ".avro");
+    ManifestWriter writer = ManifestWriter.write(table.spec(), manifestLocation);
+    try {
+      writer.add(FILE_D);
+    } finally {
+      writer.close();
+    }
+
+    Transaction t = table.newTransaction();
+
+    t.newAppend()
+        .appendManifest(writer.toManifestFile())
+        .commit();
+
+    Assert.assertSame("Base metadata should not change when commit is created", base, readMetadata());
+    Assert.assertEquals("Table should be on version 2 after txn create", 2, (int) version());
+
+    Assert.assertEquals("Append should have one merged manifest", 1, t.table().currentSnapshot().manifests().size());
+    ManifestFile mergedManifest = t.table().currentSnapshot().manifests().get(0);
+
+    // find the initial copy of the appended manifest
+    String copiedAppendManifest = Iterables.getOnlyElement(Iterables.filter(
+        Iterables.transform(listManifestFiles(), File::getPath),
+        path -> !v1manifest.path().contains(path) && !mergedManifest.path().contains(path)));
+
+    Assert.assertTrue("Transaction should hijack the delete of the original copied manifest",
+        ((BaseTransaction) t).deletedFiles.contains(copiedAppendManifest));
+    Assert.assertTrue("Copied append manifest should not be deleted yet", new File(copiedAppendManifest).exists());
+
+    // cause the transaction commit to fail and retry
+    table.newAppend()
+        .appendFile(FILE_C)
+        .commit();
+
+    Assert.assertEquals("Table should be on version 3 after real append", 3, (int) version());
+
+    t.commitTransaction();
+
+    Assert.assertEquals("Table should be on version 4 after commit", 4, (int) version());
+
+    Assert.assertTrue("Transaction should hijack the delete of the original copied manifest",
+        ((BaseTransaction) t).deletedFiles.contains(copiedAppendManifest));
+    Assert.assertFalse("Append manifest should be deleted", new File(copiedAppendManifest).exists());
+    Assert.assertTrue("Transaction should hijack the delete of the first merged manifest",
+        ((BaseTransaction) t).deletedFiles.contains(mergedManifest.path()));
+    Assert.assertFalse("Append manifest should be deleted", new File(mergedManifest.path()).exists());
+
+    Assert.assertEquals("Should merge all commit manifests into a single manifest",
+        1, table.currentSnapshot().manifests().size());
+  }
+
+  @Test
+  public void testTransactionNoCustomDeleteFunc() {
+    AssertHelpers.assertThrows("Should fail setting a custom delete function with a transaction",
+        IllegalArgumentException.class, "Cannot set delete callback more than once",
+        () -> table.newTransaction()
+            .newAppend()
+            .appendFile(FILE_A)
+            .appendFile(FILE_B)
+            .deleteWith(file -> {}));
   }
 }


### PR DESCRIPTION
This adds a callback for deleting files to `SnapshotProducer` and uses that callback in `Transaction`
to track deletes instead of running them. When a transaction is committed, the last set of deletes are run so that the actual deletes are for the last commit of each operation in the transaction.

This ensures that unused metadata files are not deleted when operations are committed to the transaction. The set of files that needs to be deleted may change, so only the last set of deletes in a transaction should be run.

This was discovered when appending a manifest file using #201. A manifest was copied, merged with existing manifests, and deleted when committing a change to the transaction. When the transaction committed, it conflicted and re-ran the manifest file append. Manifests from the conflicting commit were merged into existing manifests instead of the copy of the appended manifest, so the copy that had already been deleted was used in table metadata.