### PR TITLE
Fix concurrent access to lazy PartitionSpec methods

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -55,10 +55,10 @@ public class PartitionSpec implements Serializable {
   // this is ordered so that DataFile has a consistent schema
   private final int specId;
   private final PartitionField[] fields;
-  private volatile transient ListMultimap<Integer, PartitionField> fieldsBySourceId = null;
-  private volatile transient Map<String, PartitionField> fieldsByName = null;
-  private volatile transient Class<?>[] lazyJavaClasses = null;
-  private volatile transient List<PartitionField> fieldList = null;
+  private transient volatile ListMultimap<Integer, PartitionField> fieldsBySourceId = null;
+  private transient volatile Map<String, PartitionField> fieldsByName = null;
+  private transient volatile Class<?>[] lazyJavaClasses = null;
+  private transient volatile List<PartitionField> fieldList = null;
 
   private PartitionSpec(Schema schema, int specId, List<PartitionField> fields) {
     this.schema = schema;

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -55,10 +55,10 @@ public class PartitionSpec implements Serializable {
   // this is ordered so that DataFile has a consistent schema
   private final int specId;
   private final PartitionField[] fields;
-  private transient ListMultimap<Integer, PartitionField> fieldsBySourceId = null;
-  private transient Map<String, PartitionField> fieldsByName = null;
-  private transient Class<?>[] lazyJavaClasses = null;
-  private transient List<PartitionField> fieldList = null;
+  private volatile transient ListMultimap<Integer, PartitionField> fieldsBySourceId = null;
+  private volatile transient Map<String, PartitionField> fieldsByName = null;
+  private volatile transient Class<?>[] lazyJavaClasses = null;
+  private volatile transient List<PartitionField> fieldList = null;
 
   private PartitionSpec(Schema schema, int specId, List<PartitionField> fields) {
     this.schema = schema;


### PR DESCRIPTION
This was causing `NullPointerException` in `PartitionData.get`. When two Spark tasks started at the same time on an executor, both would load the same partition spec instance because of the spec parser's cache. One thread would create `lazyJavaClasses` and another would access it before it was fully initialized, causing Spark's converter to partition to cache null classes for some partitions, leading to the NPE from `PartitionData.get`.