### PR TITLE
Extend Table API to get snapshots by id

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -79,6 +79,14 @@ public interface Table {
   Snapshot currentSnapshot();
 
   /**
+   * Get the {@link Snapshot snapshot} of this table with the given id, or null if there is no
+   * matching snapshot.
+   *
+   * @return the {@link Snapshot} with the given id.
+   */
+  Snapshot snapshot(long snapshotId);
+
+  /**
    * Get the {@link Snapshot snapshots} of this table.
    *
    * @return an Iterable of snapshots of this table.

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -79,6 +79,11 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public Snapshot snapshot(long snapshotId) {
+    return ops.current().snapshot(snapshotId);
+  }
+
+  @Override
   public Iterable<Snapshot> snapshots() {
     return ops.current().snapshots();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -350,6 +350,11 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public Snapshot snapshot(long snapshotId) {
+      return current.snapshot(snapshotId);
+    }
+
+    @Override
     public Iterable<Snapshot> snapshots() {
       return current.snapshots();
     }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.Iterables;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSnapshotSelection extends TableTestBase {
+
+  @Test
+  public void testSnapshotSelectionById() {
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .commit();
+    Snapshot firstSnapshot = table.currentSnapshot();
+
+    table.newFastAppend()
+        .appendFile(FILE_B)
+        .commit();
+    Snapshot secondSnapshot = table.currentSnapshot();
+
+    Assert.assertEquals("Table should have two snapshots", 2, Iterables.size(table.snapshots()));
+    validateSnapshot(null, table.snapshot(firstSnapshot.snapshotId()), FILE_A);
+    validateSnapshot(firstSnapshot, table.snapshot(secondSnapshot.snapshotId()), FILE_B);
+  }
+}


### PR DESCRIPTION
This PR introduces a way to get a snapshot by id via the `Table` API.

This change is needed to efficiently support Iceberg tables as sinks in Spark Structured Streaming. In particular, this change allows us to efficiently retrieve the parent snapshot by id.