### PR TITLE
Fix FastAppends in BaseTransaction

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -135,6 +135,14 @@ class BaseTransaction implements Transaction {
   }
 
   @Override
+  public AppendFiles newFastAppend() {
+    checkLastOperationCommitted("AppendFiles");
+    AppendFiles append = new FastAppend(transactionOps);
+    updates.add(append);
+    return append;
+  }
+
+  @Override
   public RewriteFiles newRewrite() {
     checkLastOperationCommitted("RewriteFiles");
     RewriteFiles rewrite = new ReplaceFiles(transactionOps);
@@ -372,6 +380,11 @@ class BaseTransaction implements Transaction {
     @Override
     public AppendFiles newAppend() {
       return BaseTransaction.this.newAppend();
+    }
+
+    @Override
+    public AppendFiles newFastAppend() {
+      return BaseTransaction.this.newFastAppend();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes `newFastAppend` in `BaseTransaction`.