### PR TITLE
Apply Baseline plugin to iceberg-spark

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -53,11 +53,6 @@
             <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
             <property name="checkFormat" value="$1"/>
         </module>
-        <module name="AbbreviationAsWordInName"> <!-- Java Style Guide: Camel case : defined -->
-            <property name="ignoreFinal" value="false"/>
-            <property name="allowedAbbreviationLength" value="1"/>
-            <property name="allowedAbbreviations" value="ID,UUID,UTC,IO"/>
-        </module>
         <module name="AnnotationLocation"> <!-- Java Style Guide: Annotations -->
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
         </module>
@@ -90,7 +85,8 @@
                 org.apache.iceberg.types.Types.NestedField.*,
                 org.apache.iceberg.TableProperties.*,
                 org.apache.iceberg.types.Type.*,
-                org.junit.Assert.*"/>
+                org.junit.Assert.*,
+                org.apache.spark.sql.functions.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ task deploySite(type: Exec) {
 // We enable baseline-idea everywhere so that everyone can use IntelliJ to build code against the
 // Baseline style guide.
 def baselineProjects = [ project("iceberg-api"), project("iceberg-common"), project("iceberg-core"),
-                         project("iceberg-data"), project("iceberg-orc") ]
+                         project("iceberg-data"), project("iceberg-orc"), project("iceberg-spark") ]
 
 
 configure(subprojects - baselineProjects) {

--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -1,0 +1,145 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<scalastyle commentFilter="enabled">
+    <name>Iceberg Scalastyle configuration</name>
+    <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">true</parameter>
+            <parameter name="header">(?m)^/\*$\n^ \* Licensed to the Apache Software Foundation \(ASF\) under one$</parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[120]]></parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+        <parameters>
+            <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.WhileChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+        <parameters>
+            <parameter name="allowed"><![CDATA[2]]></parameter>
+            <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
+        </parameters>
+    </check>
+</scalastyle>

--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -142,4 +142,15 @@
             <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
         </parameters>
     </check>
+    <check level="error" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
+        <parameters>
+            <parameter name="groups">all</parameter>
+            <parameter name="group.all">.+</parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
+        <parameters>
+            <parameter name="tokens">COMMA</parameter>
+        </parameters>
+    </check>
 </scalastyle>

--- a/spark/src/main/java/org/apache/iceberg/spark/FixupTypes.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/FixupTypes.java
@@ -55,7 +55,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type struct(Types.StructType struct, Iterable<Type> fieldTypes) {
-    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: " + sourceType);
+    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     List<Types.NestedField> fields = struct.fields();
     int length = fields.size();
@@ -89,7 +89,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type field(Types.NestedField field, Supplier<Type> future) {
-    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: " + sourceType);
+    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     Types.StructType sourceStruct = sourceType.asStructType();
     this.sourceType = sourceStruct.field(field.fieldId()).type();
@@ -102,7 +102,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type list(Types.ListType list, Supplier<Type> elementTypeFuture) {
-    Preconditions.checkArgument(sourceType.isListType(), "Not a list: " + sourceType);
+    Preconditions.checkArgument(sourceType.isListType(), "Not a list: %s", sourceType);
 
     Types.ListType sourceList = sourceType.asListType();
     this.sourceType = sourceList.elementType();
@@ -125,7 +125,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type map(Types.MapType map, Supplier<Type> keyTypeFuture, Supplier<Type> valueTypeFuture) {
-    Preconditions.checkArgument(sourceType.isMapType(), "Not a map: " + sourceType);
+    Preconditions.checkArgument(sourceType.isMapType(), "Not a map: %s", sourceType);
 
     Types.MapType sourceMap = sourceType.asMapType();
     try {

--- a/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
@@ -72,7 +72,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
   public Type struct(Types.StructType struct, Iterable<Type> fieldResults) {
     Preconditions.checkNotNull(struct, "Cannot prune null struct. Pruning must start with a schema.");
     Preconditions.checkArgument(current instanceof StructType, "Not a struct: %s", current);
-    StructType s = (StructType) current;
+    StructType requestedStruct = (StructType) current;
 
     List<Types.NestedField> fields = struct.fields();
     List<Type> types = Lists.newArrayList(fieldResults);
@@ -104,7 +104,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
 
     // Construct a new struct with the projected struct's order
     boolean reordered = false;
-    StructField[] requestedFields = s.fields();
+    StructField[] requestedFields = requestedStruct.fields();
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(requestedFields.length);
     for (int i = 0; i < requestedFields.length; i += 1) {
       // fields are resolved by name because Spark only sees the current table schema.
@@ -131,10 +131,10 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
   @Override
   public Type field(Types.NestedField field, Supplier<Type> fieldResult) {
     Preconditions.checkArgument(current instanceof StructType, "Not a struct: %s", current);
-    StructType struct = (StructType) current;
+    StructType requestedStruct = (StructType) current;
 
     // fields are resolved by name because Spark only sees the current table schema.
-    if (struct.getFieldIndex(field.name()).isEmpty()) {
+    if (requestedStruct.getFieldIndex(field.name()).isEmpty()) {
       // make sure that filter fields are projected even if they aren't in the requested schema.
       if (filterRefs.contains(field.fieldId())) {
         return field.type();
@@ -142,32 +142,32 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
       return null;
     }
 
-    int fieldIndex = struct.fieldIndex(field.name());
-    StructField f = struct.fields()[fieldIndex];
+    int fieldIndex = requestedStruct.fieldIndex(field.name());
+    StructField requestedField = requestedStruct.fields()[fieldIndex];
 
-    Preconditions.checkArgument(f.nullable() || field.isRequired(),
+    Preconditions.checkArgument(requestedField.nullable() || field.isRequired(),
         "Cannot project an optional field as non-null: %s", field.name());
 
-    this.current = f.dataType();
+    this.current = requestedField.dataType();
     try {
       return fieldResult.get();
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           "Invalid projection for field " + field.name() + ": " + e.getMessage(), e);
     } finally {
-      this.current = struct;
+      this.current = requestedStruct;
     }
   }
 
   @Override
   public Type list(Types.ListType list, Supplier<Type> elementResult) {
     Preconditions.checkArgument(current instanceof ArrayType, "Not an array: %s", current);
-    ArrayType array = (ArrayType) current;
+    ArrayType requestedArray = (ArrayType) current;
 
-    Preconditions.checkArgument(array.containsNull() || !list.isElementOptional(),
-        "Cannot project an array of optional elements as required elements: %s", array);
+    Preconditions.checkArgument(requestedArray.containsNull() || !list.isElementOptional(),
+        "Cannot project an array of optional elements as required elements: %s", requestedArray);
 
-    this.current = array.elementType();
+    this.current = requestedArray.elementType();
     try {
       Type elementType = elementResult.get();
       if (list.elementType() == elementType) {
@@ -181,21 +181,21 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
         return Types.ListType.ofRequired(list.elementId(), elementType);
       }
     } finally {
-      this.current = array;
+      this.current = requestedArray;
     }
   }
 
   @Override
   public Type map(Types.MapType map, Supplier<Type> keyResult, Supplier<Type> valueResult) {
     Preconditions.checkArgument(current instanceof MapType, "Not a map: %s", current);
-    MapType m = (MapType) current;
+    MapType requestedMap = (MapType) current;
 
-    Preconditions.checkArgument(m.valueContainsNull() || !map.isValueOptional(),
+    Preconditions.checkArgument(requestedMap.valueContainsNull() || !map.isValueOptional(),
         "Cannot project a map of optional values as required values: %s", map);
-    Preconditions.checkArgument(StringType.class.isInstance(m.keyType()),
-        "Invalid map key type (not string): %s", m.keyType());
+    Preconditions.checkArgument(StringType.class.isInstance(requestedMap.keyType()),
+        "Invalid map key type (not string): %s", requestedMap.keyType());
 
-    this.current = m.valueType();
+    this.current = requestedMap.valueType();
     try {
       Type valueType = valueResult.get();
       if (map.valueType() == valueType) {
@@ -208,7 +208,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
         return Types.MapType.ofRequired(map.keyId(), map.valueId(), map.keyType(), valueType);
       }
     } finally {
-      this.current = m;
+      this.current = requestedMap;
     }
   }
 
@@ -222,12 +222,12 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
     switch (primitive.typeId()) {
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
-        DecimalType d = (DecimalType) current;
-        Preconditions.checkArgument(d.scale() == decimal.scale(),
-            "Cannot project decimal with incompatible scale: %s != %s", d.scale(), decimal.scale());
-        Preconditions.checkArgument(d.precision() >= decimal.precision(),
+        DecimalType requestedDecimal = (DecimalType) current;
+        Preconditions.checkArgument(requestedDecimal.scale() == decimal.scale(),
+            "Cannot project decimal with incompatible scale: %s != %s", requestedDecimal.scale(), decimal.scale());
+        Preconditions.checkArgument(requestedDecimal.precision() >= decimal.precision(),
             "Cannot project decimal with incompatible precision: %s < %s",
-            d.precision(), decimal.precision());
+            requestedDecimal.precision(), decimal.precision());
         break;
       case TIMESTAMP:
         Types.TimestampType timestamp = (Types.TimestampType) primitive;

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -107,7 +107,7 @@ public class SparkFilters {
             EqualTo eq = (EqualTo) filter;
             // comparison with null in normal equality is always null. this is probably a mistake.
             Preconditions.checkNotNull(eq.value(),
-                "Expression is always false (eq is not null-safe): " + filter);
+                "Expression is always false (eq is not null-safe): %s", filter);
             return equal(eq.attribute(), convertLiteral(eq.value()));
           } else {
             EqualNullSafe eq = (EqualNullSafe) filter;

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -39,9 +39,6 @@ import org.apache.spark.sql.catalog.Column;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 
-import static org.apache.iceberg.spark.SparkTypeVisitor.visit;
-import static org.apache.iceberg.types.TypeUtil.visit;
-
 /**
  * Helper methods for working with Spark/Hive metadata.
  */
@@ -61,8 +58,7 @@ public class SparkSchemaUtil {
    */
   public static Schema schemaForTable(SparkSession spark, String name) {
     StructType sparkType = spark.table(name).schema();
-    Type converted = visit(sparkType,
-        new SparkTypeToType(sparkType));
+    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
     return new Schema(converted.asNestedType().asStructType().fields());
   }
 
@@ -95,7 +91,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the type cannot be converted to Spark
    */
   public static StructType convert(Schema schema) {
-    return (StructType) visit(schema, new TypeToSparkType());
+    return (StructType) TypeUtil.visit(schema, new TypeToSparkType());
   }
 
   /**
@@ -106,7 +102,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the type cannot be converted to Spark
    */
   public static DataType convert(Type type) {
-    return visit(type, new TypeToSparkType());
+    return TypeUtil.visit(type, new TypeToSparkType());
   }
 
   /**
@@ -124,7 +120,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the type cannot be converted
    */
   public static Schema convert(StructType sparkType) {
-    Type converted = visit(sparkType, new SparkTypeToType(sparkType));
+    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
     return new Schema(converted.asNestedType().asStructType().fields());
   }
 
@@ -143,7 +139,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the type cannot be converted
    */
   public static Type convert(DataType sparkType) {
-    return visit(sparkType, new SparkTypeToType());
+    return SparkTypeVisitor.visit(sparkType, new SparkTypeToType());
   }
 
   /**
@@ -161,7 +157,7 @@ public class SparkSchemaUtil {
    */
   public static Schema convert(Schema baseSchema, StructType sparkType) {
     // convert to a type with fresh ids
-    Types.StructType struct = visit(sparkType, new SparkTypeToType(sparkType)).asStructType();
+    Types.StructType struct = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType)).asStructType();
     // reassign ids to match the base schema
     Schema schema = TypeUtil.reassignIds(new Schema(struct.fields()), baseSchema);
     // fix types that can't be represented in Spark (UUID and Fixed)
@@ -180,7 +176,7 @@ public class SparkSchemaUtil {
    * @throws IllegalArgumentException if the Spark type does not match the Schema
    */
   public static Schema prune(Schema schema, StructType requestedType) {
-    return new Schema(visit(schema, new PruneColumnsWithoutReordering(requestedType, ImmutableSet.of()))
+    return new Schema(TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, ImmutableSet.of()))
         .asNestedType()
         .asStructType()
         .fields());
@@ -203,7 +199,7 @@ public class SparkSchemaUtil {
    */
   public static Schema prune(Schema schema, StructType requestedType, List<Expression> filters) {
     Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), filters, true);
-    return new Schema(visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
+    return new Schema(TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
         .asNestedType()
         .asStructType()
         .fields());
@@ -228,7 +224,7 @@ public class SparkSchemaUtil {
     Set<Integer> filterRefs =
         Binder.boundReferences(schema.asStruct(), Collections.singletonList(filter), caseSensitive);
 
-    return new Schema(visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
+    return new Schema(TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
         .asNestedType()
         .asStructType()
         .fields());

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -115,6 +115,7 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
     }
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   public Type atomic(DataType atomic) {
     if (atomic instanceof BooleanType) {

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTypeVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTypeVisitor.java
@@ -52,7 +52,7 @@ class SparkTypeVisitor<T> {
           (ArrayType) type,
           visit(((ArrayType) type).elementType(), visitor));
 
-    } else if (type instanceof UserDefinedType){
+    } else if (type instanceof UserDefinedType) {
       throw new UnsupportedOperationException(
           "User-defined types are not supported");
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -54,8 +54,8 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
   }
 
   @Override
-  public void setSchema(Schema fileSchema) {
-    this.fileSchema = Schema.applyAliases(fileSchema, readSchema);
+  public void setSchema(Schema newFileSchema) {
+    this.fileSchema = Schema.applyAliases(newFileSchema, readSchema);
   }
 
   @Override
@@ -108,7 +108,7 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
     public ValueReader<?> array(Schema array, ValueReader<?> elementReader) {
       LogicalType logical = array.getLogicalType();
       if (logical != null && "map".equals(logical.getName())) {
-        ValueReader<?>[] keyValueReaders = ((SparkValueReaders.StructReader) elementReader).readers;
+        ValueReader<?>[] keyValueReaders = ((SparkValueReaders.StructReader) elementReader).readers();
         return SparkValueReaders.arrayMap(keyValueReaders[0], keyValueReaders[1]);
       }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg.spark.data;
 
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.List;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.orc.ColumnIdMap;
 import org.apache.iceberg.orc.OrcValueReader;
@@ -46,10 +49,6 @@ import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.Platform;
 
-import java.math.BigDecimal;
-import java.sql.Timestamp;
-import java.util.List;
-
 /**
  * Converts the OrcInterator, which returns ORC's VectorizedRowBatch to a
  * set of Spark's UnsafeRows.
@@ -57,7 +56,7 @@ import java.util.List;
  * It minimizes allocations by reusing most of the objects in the implementation.
  */
 public class SparkOrcReader implements OrcValueReader<InternalRow> {
-  private final static int INITIAL_SIZE = 128 * 1024;
+  private static final int INITIAL_SIZE = 128 * 1024;
   private final int numFields;
   private final TypeDescription readSchema;
   private final Converter[] converters;
@@ -69,11 +68,11 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
   }
 
   private Converter[] buildConverters() {
-    final Converter[] converters = new Converter[numFields];
-    for(int c = 0; c < numFields; ++c) {
-      converters[c] = buildConverter(readSchema.getChildren().get(c));
+    final Converter[] newConverters = new Converter[numFields];
+    for (int c = 0; c < numFields; ++c) {
+      newConverters[c] = buildConverter(readSchema.getChildren().get(c));
     }
-    return converters;
+    return newConverters;
   }
 
   @Override
@@ -81,7 +80,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     final UnsafeRowWriter rowWriter = new UnsafeRowWriter(numFields, INITIAL_SIZE);
     rowWriter.reset();
     rowWriter.zeroOutNullBytes();
-    for(int c=0; c < batch.cols.length; ++c) {
+    for (int c = 0; c < batch.cols.length; ++c) {
       converters[c].convert(rowWriter, c, batch.cols[c], row);
     }
     return rowWriter.getRow();
@@ -91,7 +90,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     final List<TypeDescription> children = schema.getChildren();
     final StringBuilder rowBuilder = new StringBuilder("{");
 
-    for(int c = 0; c < children.size(); ++c) {
+    for (int c = 0; c < children.size(); ++c) {
       rowBuilder.append("\"");
       rowBuilder.append(schema.getFieldNames().get(c));
       rowBuilder.append("\": ");
@@ -135,12 +134,12 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
             if (i != 0) {
               binStr.append(", ");
             }
-            int v = bin[i] & 0xff;
-            if (v < 16) {
+            int value = bin[i] & 0xff;
+            if (value < 16) {
               binStr.append("0");
-              binStr.append(Integer.toHexString(v));
+              binStr.append(Integer.toHexString(value));
             } else {
-              binStr.append(Integer.toHexString(v));
+              binStr.append(Integer.toHexString(value));
             }
           }
           binStr.append("]");
@@ -159,7 +158,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
         TypeDescription child = schema.getChildren().get(0);
         final StringBuilder listStr = new StringBuilder("[");
         ArrayData list = row.getArray(ord);
-        for(int e=0; e < list.numElements(); ++e) {
+        for (int e = 0; e < list.numElements(); ++e) {
           if (e != 0) {
             listStr.append(", ");
           }
@@ -175,7 +174,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
         ArrayData keys = map.keyArray();
         ArrayData values = map.valueArray();
         StringBuilder mapStr = new StringBuilder("[");
-        for(int e=0; e < map.numElements(); ++e) {
+        for (int e = 0; e < map.numElements(); ++e) {
           if (e != 0) {
             mapStr.append(", ");
           }
@@ -222,26 +221,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
   private static class BooleanConverter implements Converter {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, ((LongColumnVector) vector).vector[row] != 0);
+        writer.write(column, ((LongColumnVector) vector).vector[rowIndex] != 0);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, ((LongColumnVector) vector).vector[row] != 0);
+        writer.write(element, ((LongColumnVector) vector).vector[rowIndex] != 0);
       }
     }
   }
@@ -250,26 +245,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, (byte) ((LongColumnVector) vector).vector[row]);
+        writer.write(column, (byte) ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, (byte) ((LongColumnVector) vector).vector[row]);
+        writer.write(element, (byte) ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
   }
@@ -278,26 +269,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, (short) ((LongColumnVector) vector).vector[row]);
+        writer.write(column, (short) ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, (short) ((LongColumnVector) vector).vector[row]);
+        writer.write(element, (short) ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
   }
@@ -306,26 +293,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, (int) ((LongColumnVector) vector).vector[row]);
+        writer.write(column, (int) ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, (int) ((LongColumnVector) vector).vector[row]);
+        writer.write(element, (int) ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
   }
@@ -334,26 +317,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, ((LongColumnVector) vector).vector[row]);
+        writer.write(column, ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, ((LongColumnVector) vector).vector[row]);
+        writer.write(element, ((LongColumnVector) vector).vector[rowIndex]);
       }
     }
   }
@@ -362,26 +341,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, (float) ((DoubleColumnVector) vector).vector[row]);
+        writer.write(column, (float) ((DoubleColumnVector) vector).vector[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, (float) ((DoubleColumnVector) vector).vector[row]);
+        writer.write(element, (float) ((DoubleColumnVector) vector).vector[rowIndex]);
       }
     }
   }
@@ -390,26 +365,22 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, ((DoubleColumnVector) vector).vector[row]);
+        writer.write(column, ((DoubleColumnVector) vector).vector[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, ((DoubleColumnVector) vector).vector[row]);
+        writer.write(element, ((DoubleColumnVector) vector).vector[rowIndex]);
       }
     }
   }
@@ -418,32 +389,28 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
 
     private long convert(TimestampColumnVector vector, int row) {
       // compute microseconds past 1970.
-      return (vector.time[row]/1000) * 1_000_000 + vector.nanos[row] / 1000;
+      return (vector.time[row] / 1000) * 1_000_000 + vector.nanos[row] / 1000;
     }
 
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        writer.write(column, convert((TimestampColumnVector) vector, row));
+        writer.write(column, convert((TimestampColumnVector) vector, rowIndex));
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        writer.write(element, convert((TimestampColumnVector) vector, row));
+        writer.write(element, convert((TimestampColumnVector) vector, rowIndex));
       }
     }
   }
@@ -452,34 +419,30 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
 
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        BytesColumnVector v = (BytesColumnVector) vector;
-        writer.write(column, v.vector[row], v.start[row], v.length[row]);
+        BytesColumnVector bytesVector = (BytesColumnVector) vector;
+        writer.write(column, bytesVector.vector[rowIndex], bytesVector.start[rowIndex], bytesVector.length[rowIndex]);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element, ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
         final BytesColumnVector v = (BytesColumnVector) vector;
-        writer.write(element, v.vector[row], v.start[row], v.length[row]);
+        writer.write(element, v.vector[rowIndex], v.start[rowIndex], v.length[rowIndex]);
       }
     }
   }
 
   private static class Decimal18Converter implements Converter {
-    final int precision;
-    final int scale;
+    private final int precision;
+    private final int scale;
 
     Decimal18Converter(int precision, int scale) {
       this.precision = precision;
@@ -489,15 +452,13 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        HiveDecimalWritable v = ((DecimalColumnVector) vector).vector[row];
+        HiveDecimalWritable value = ((DecimalColumnVector) vector).vector[rowIndex];
         writer.write(column,
-            new Decimal().set(v.serialize64(v.scale()), v.precision(), v.scale()),
+            new Decimal().set(value.serialize64(value.scale()), value.precision(), value.scale()),
             precision, scale);
       }
     }
@@ -505,23 +466,21 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        HiveDecimalWritable v = ((DecimalColumnVector) vector).vector[row];
+        HiveDecimalWritable value = ((DecimalColumnVector) vector).vector[rowIndex];
         writer.write(element,
-            new Decimal().set(v.serialize64(v.scale()), v.precision(), v.scale()),
+            new Decimal().set(value.serialize64(value.scale()), value.precision(), value.scale()),
             precision, scale);
       }
     }
   }
 
   private static class Decimal38Converter implements Converter {
-    final int precision;
-    final int scale;
+    private final int precision;
+    private final int scale;
 
     Decimal38Converter(int precision, int scale) {
       this.precision = precision;
@@ -531,16 +490,14 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        BigDecimal v = ((DecimalColumnVector) vector).vector[row]
+        BigDecimal value = ((DecimalColumnVector) vector).vector[rowIndex]
             .getHiveDecimal().bigDecimalValue();
         writer.write(column,
-            new Decimal().set(new scala.math.BigDecimal(v), precision, scale),
+            new Decimal().set(new scala.math.BigDecimal(value), precision, scale),
             precision, scale);
       }
     }
@@ -548,16 +505,14 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        BigDecimal v = ((DecimalColumnVector) vector).vector[row]
+        BigDecimal value = ((DecimalColumnVector) vector).vector[rowIndex]
             .getHiveDecimal().bigDecimalValue();
         writer.write(element,
-            new Decimal().set(new scala.math.BigDecimal(v), precision, scale),
+            new Decimal().set(new scala.math.BigDecimal(value), precision, scale),
             precision, scale);
       }
     }
@@ -568,7 +523,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
 
     StructConverter(final TypeDescription schema) {
       children = new Converter[schema.getChildren().size()];
-      for(int c=0; c < children.length; ++c) {
+      for (int c = 0; c < children.length; ++c) {
         children[c] = buildConverter(schema.getChildren().get(c));
       }
 
@@ -578,7 +533,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
       UnsafeRowWriter childWriter = new UnsafeRowWriter(parentWriter, children.length);
       int start = childWriter.cursor();
       childWriter.resetRowWriter();
-      for(int c=0; c < children.length; ++c) {
+      for (int c = 0; c < children.length; ++c) {
         children[c].convert(childWriter, c, vector.fields[c], row);
       }
       return start;
@@ -586,13 +541,11 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
 
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        int start = writeStruct(writer, (StructColumnVector) vector, row);
+        int start = writeStruct(writer, (StructColumnVector) vector, rowIndex);
         writer.setOffsetAndSizeFromPreviousCursor(column, start);
       }
     }
@@ -600,13 +553,11 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        int start = writeStruct(writer, (StructColumnVector) vector, row);
+        int start = writeStruct(writer, (StructColumnVector) vector, rowIndex);
         writer.setOffsetAndSizeFromPreviousCursor(element, start);
       }
     }
@@ -621,15 +572,15 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
       childConverter = buildConverter(child);
     }
 
-    int writeList(UnsafeWriter parentWriter, ListColumnVector v, int row) {
-      int offset = (int) v.offsets[row];
-      int length = (int) v.lengths[row];
+    int writeList(UnsafeWriter parentWriter, ListColumnVector vector, int row) {
+      int offset = (int) vector.offsets[row];
+      int length = (int) vector.lengths[row];
 
       UnsafeArrayWriter childWriter = new UnsafeArrayWriter(parentWriter, getArrayElementSize(child));
       int start = childWriter.cursor();
       childWriter.initialize(length);
-      for(int c = 0; c < length; ++c) {
-        childConverter.convert(childWriter, c, v.child, offset + c);
+      for (int c = 0; c < length; ++c) {
+        childConverter.convert(childWriter, c, vector.child, offset + c);
       }
       return start;
     }
@@ -637,13 +588,11 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector,
                         int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        int start = writeList(writer, (ListColumnVector) vector, row);
+        int start = writeList(writer, (ListColumnVector) vector, rowIndex);
         writer.setOffsetAndSizeFromPreviousCursor(column, start);
       }
     }
@@ -651,26 +600,24 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
     @Override
     public void convert(UnsafeArrayWriter writer, int element,
                         ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        int start = writeList(writer, (ListColumnVector) vector, row);
+        int start = writeList(writer, (ListColumnVector) vector, rowIndex);
         writer.setOffsetAndSizeFromPreviousCursor(element, start);
       }
     }
   }
 
   private static class MapConverter implements Converter {
+    private static final int KEY_SIZE_BYTES = 8;
+
     private final Converter keyConvert;
     private final Converter valueConvert;
 
     private final int keySize;
     private final int valueSize;
-
-    private final int KEY_SIZE_BYTES = 8;
 
     MapConverter(TypeDescription schema) {
       final TypeDescription keyType = schema.getChildren().get(0);
@@ -682,9 +629,9 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
       valueSize = getArrayElementSize(valueType);
     }
 
-    int writeMap(UnsafeWriter parentWriter, MapColumnVector v, int row) {
-      final int offset = (int) v.offsets[row];
-      final int length = (int) v.lengths[row];
+    int writeMap(UnsafeWriter parentWriter, MapColumnVector vector, int row) {
+      final int offset = (int) vector.offsets[row];
+      final int length = (int) vector.lengths[row];
 
       UnsafeArrayWriter keyWriter = new UnsafeArrayWriter(parentWriter, keySize);
       final int start = keyWriter.cursor();
@@ -694,8 +641,8 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
 
       // serialize the keys
       keyWriter.initialize(length);
-      for(int c = 0; c < length; ++c) {
-        keyConvert.convert(keyWriter, c, v.keys, offset + c);
+      for (int c = 0; c < length; ++c) {
+        keyConvert.convert(keyWriter, c, vector.keys, offset + c);
       }
       // store the serialized size of the keys
       Platform.putLong(keyWriter.getBuffer(), start,
@@ -704,34 +651,30 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
       // serialize the values
       UnsafeArrayWriter valueWriter = new UnsafeArrayWriter(parentWriter, valueSize);
       valueWriter.initialize(length);
-      for(int c = 0; c < length; ++c) {
-        valueConvert.convert(valueWriter, c, v.values, offset + c);
+      for (int c = 0; c < length; ++c) {
+        valueConvert.convert(valueWriter, c, vector.values, offset + c);
       }
       return start;
     }
 
     @Override
     public void convert(UnsafeRowWriter writer, int column, ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNullAt(column);
       } else {
-        int start = writeMap(writer, (MapColumnVector) vector, row);
+        int start = writeMap(writer, (MapColumnVector) vector, rowIndex);
         writer.setOffsetAndSizeFromPreviousCursor(column, start);
       }
     }
 
     @Override
     public void convert(UnsafeArrayWriter writer, int element, ColumnVector vector, int row) {
-      if (vector.isRepeating) {
-        row = 0;
-      }
-      if (!vector.noNulls && vector.isNull[row]) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
         writer.setNull(element);
       } else {
-        int start = writeMap(writer, (MapColumnVector) vector, row);
+        int start = writeMap(writer, (MapColumnVector) vector, rowIndex);
         writer.setOffsetAndSizeFromPreviousCursor(element, start);
       }
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -41,6 +41,9 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class SparkValueReaders {
+
+  private SparkValueReaders() {}
+
   static ValueReader<UTF8String> strings() {
     return StringReader.INSTANCE;
   }
@@ -71,7 +74,7 @@ public class SparkValueReaders {
   }
 
   private static class StringReader implements ValueReader<UTF8String> {
-    private static StringReader INSTANCE = new StringReader();
+    private static final StringReader INSTANCE = new StringReader();
 
     private StringReader() {
     }
@@ -100,7 +103,7 @@ public class SparkValueReaders {
       return buffer;
     });
 
-    private static UUIDReader INSTANCE = new UUIDReader();
+    private static final UUIDReader INSTANCE = new UUIDReader();
 
     private UUIDReader() {
     }
@@ -229,13 +232,17 @@ public class SparkValueReaders {
   }
 
   static class StructReader implements ValueReader<InternalRow> {
-    final ValueReader<?>[] readers;
+    private final ValueReader<?>[] readers;
 
     private StructReader(List<ValueReader<?>> readers) {
       this.readers = new ValueReader[readers.size()];
       for (int i = 0; i < this.readers.length; i += 1) {
         this.readers[i] = readers.get(i);
       }
+    }
+
+    ValueReader<?>[] readers() {
+      return readers;
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
@@ -39,6 +39,9 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class SparkValueWriters {
+
+  private SparkValueWriters() {}
+
   static ValueWriter<UTF8String> strings() {
     return StringWriter.INSTANCE;
   }
@@ -56,7 +59,7 @@ public class SparkValueWriters {
   }
 
   static <K, V> ValueWriter<MapData> arrayMap(
-    ValueWriter<K> keyWriter, DataType keyType, ValueWriter<V> valueWriter, DataType valueType) {
+      ValueWriter<K> keyWriter, DataType keyType, ValueWriter<V> valueWriter, DataType valueType) {
     return new ArrayMapWriter<>(keyWriter, keyType, valueWriter, valueType);
   }
 
@@ -70,7 +73,7 @@ public class SparkValueWriters {
   }
 
   private static class StringWriter implements ValueWriter<UTF8String> {
-    private static StringWriter INSTANCE = new StringWriter();
+    private static final StringWriter INSTANCE = new StringWriter();
 
     private StringWriter() {
     }
@@ -91,7 +94,7 @@ public class SparkValueWriters {
       return buffer;
     });
 
-    private static UUIDWriter INSTANCE = new UUIDWriter();
+    private static final UUIDWriter INSTANCE = new UUIDWriter();
 
     private UUIDWriter() {
     }
@@ -233,7 +236,7 @@ public class SparkValueWriters {
   }
 
   static class StructWriter implements ValueWriter<InternalRow> {
-    final ValueWriter<?>[] writers;
+    private final ValueWriter<?>[] writers;
     private final DataType[] types;
 
     @SuppressWarnings("unchecked")
@@ -244,6 +247,10 @@ public class SparkValueWriters {
         this.writers[i] = writers.get(i);
         this.types[i] = types.get(i);
       }
+    }
+
+    ValueWriter<?>[] writers() {
+      return writers;
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/hacks/Hive.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/hacks/Hive.java
@@ -30,6 +30,9 @@ import scala.Option;
 import scala.collection.Seq;
 
 public class Hive {
+
+  private Hive() {}
+
   public static Seq<CatalogTablePartition> partitions(SparkSession spark, String name) {
     List<String> parts = Lists.newArrayList(Splitter.on('.').limit(2).split(name));
     String db = parts.size() == 1 ? "default" : parts.get(0);

--- a/spark/src/main/java/org/apache/iceberg/spark/source/PartitionKey.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/PartitionKey.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -37,8 +38,6 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
-
-import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
 
 class PartitionKey implements StructLike {
 
@@ -59,10 +58,10 @@ class PartitionKey implements StructLike {
     this.accessors = (Accessor<InternalRow>[]) Array.newInstance(Accessor.class, size);
 
     Schema schema = spec.schema();
-    Map<Integer, Accessor<InternalRow>> accessors = buildAccessors(schema);
+    Map<Integer, Accessor<InternalRow>> newAccessors = buildAccessors(schema);
     for (int i = 0; i < size; i += 1) {
       PartitionField field = fields.get(i);
-      Accessor<InternalRow> accessor = accessors.get(field.sourceId());
+      Accessor<InternalRow> accessor = newAccessors.get(field.sourceId());
       if (accessor == null) {
         throw new RuntimeException(
             "Cannot build accessor for field: " + schema.findField(field.sourceId()));
@@ -165,31 +164,31 @@ class PartitionKey implements StructLike {
     return TypeUtil.visit(schema, new BuildPositionAccessors());
   }
 
-  private static Accessor<InternalRow> newAccessor(int p, Type type) {
+  private static Accessor<InternalRow> newAccessor(int position, Type type) {
     switch (type.typeId()) {
       case STRING:
-        return new StringAccessor(p, convert(type));
+        return new StringAccessor(position, SparkSchemaUtil.convert(type));
       case DECIMAL:
-        return new DecimalAccessor(p, convert(type));
+        return new DecimalAccessor(position, SparkSchemaUtil.convert(type));
       case BINARY:
-        return new BytesAccessor(p, convert(type));
+        return new BytesAccessor(position, SparkSchemaUtil.convert(type));
       default:
-        return new PositionAccessor(p, convert(type));
+        return new PositionAccessor(position, SparkSchemaUtil.convert(type));
     }
   }
 
-  private static Accessor<InternalRow> newAccessor(int p, boolean isOptional, Types.StructType type,
+  private static Accessor<InternalRow> newAccessor(int position, boolean isOptional, Types.StructType type,
                                                    Accessor<InternalRow> accessor) {
     int size = type.fields().size();
     if (isOptional) {
       // the wrapped position handles null layers
-      return new WrappedPositionAccessor(p, size, accessor);
+      return new WrappedPositionAccessor(position, size, accessor);
     } else if (accessor instanceof PositionAccessor) {
-      return new Position2Accessor(p, size, (PositionAccessor) accessor);
+      return new Position2Accessor(position, size, (PositionAccessor) accessor);
     } else if (accessor instanceof Position2Accessor) {
-      return new Position3Accessor(p, size, (Position2Accessor) accessor);
+      return new Position3Accessor(position, size, (Position2Accessor) accessor);
     } else {
-      return new WrappedPositionAccessor(p, size, accessor);
+      return new WrappedPositionAccessor(position, size, accessor);
     }
   }
 
@@ -234,62 +233,70 @@ class PartitionKey implements StructLike {
   }
 
   private static class PositionAccessor implements Accessor<InternalRow> {
-    protected final DataType type;
-    protected int p;
+    private final DataType type;
+    private int position;
 
-    private PositionAccessor(int p, DataType type) {
-      this.p = p;
+    private PositionAccessor(int position, DataType type) {
+      this.position = position;
       this.type = type;
     }
 
     @Override
     public Object get(InternalRow row) {
-      if (row.isNullAt(p)) {
+      if (row.isNullAt(position)) {
         return null;
       }
-      return row.get(p, type);
+      return row.get(position, type);
+    }
+
+    DataType type() {
+      return type;
+    }
+
+    int position() {
+      return position;
     }
   }
 
   private static class StringAccessor extends PositionAccessor {
-    private StringAccessor(int p, DataType type) {
-      super(p, type);
+    private StringAccessor(int position, DataType type) {
+      super(position, type);
     }
 
     @Override
     public Object get(InternalRow row) {
-      if (row.isNullAt(p)) {
+      if (row.isNullAt(position())) {
         return null;
       }
-      return row.get(p, type).toString();
+      return row.get(position(), type()).toString();
     }
   }
 
   private static class DecimalAccessor extends PositionAccessor {
-    private DecimalAccessor(int p, DataType type) {
-      super(p, type);
+    private DecimalAccessor(int position, DataType type) {
+      super(position, type);
     }
 
     @Override
     public Object get(InternalRow row) {
-      if (row.isNullAt(p)) {
+      if (row.isNullAt(position())) {
         return null;
       }
-      return ((Decimal) row.get(p, type)).toJavaBigDecimal();
+      return ((Decimal) row.get(position(), type())).toJavaBigDecimal();
     }
   }
 
   private static class BytesAccessor extends PositionAccessor {
-    private BytesAccessor(int p, DataType type) {
-      super(p, type);
+    private BytesAccessor(int position, DataType type) {
+      super(position, type);
     }
 
     @Override
     public Object get(InternalRow row) {
-      if (row.isNullAt(p)) {
+      if (row.isNullAt(position())) {
         return null;
       }
-      return ByteBuffer.wrap((byte[]) row.get(p, type));
+      return ByteBuffer.wrap((byte[]) row.get(position(), type()));
     }
   }
 
@@ -299,10 +306,10 @@ class PartitionKey implements StructLike {
     private final int p1;
     private final DataType type;
 
-    private Position2Accessor(int p, int size, PositionAccessor wrapped) {
-      this.p0 = p;
+    private Position2Accessor(int position, int size, PositionAccessor wrapped) {
+      this.p0 = position;
       this.size0 = size;
-      this.p1 = wrapped.p;
+      this.p1 = wrapped.position;
       this.type = wrapped.type;
     }
 
@@ -320,8 +327,8 @@ class PartitionKey implements StructLike {
     private final int p2;
     private final DataType type;
 
-    private Position3Accessor(int p, int size, Position2Accessor wrapped) {
-      this.p0 = p;
+    private Position3Accessor(int position, int size, Position2Accessor wrapped) {
+      this.p0 = position;
       this.size0 = size;
       this.p1 = wrapped.p0;
       this.size1 = wrapped.size0;
@@ -336,19 +343,19 @@ class PartitionKey implements StructLike {
   }
 
   private static class WrappedPositionAccessor implements Accessor<InternalRow> {
-    private final int p;
+    private final int position;
     private final int size;
     private final Accessor<InternalRow> accessor;
 
-    private WrappedPositionAccessor(int p, int size, Accessor<InternalRow> accessor) {
-      this.p = p;
+    private WrappedPositionAccessor(int position, int size, Accessor<InternalRow> accessor) {
+      this.position = position;
       this.size = size;
       this.accessor = accessor;
     }
 
     @Override
     public Object get(InternalRow row) {
-      InternalRow inner = row.getStruct(p, size);
+      InternalRow inner = row.getStruct(position, size);
       if (inner != null) {
         return accessor.get(inner);
       }

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -19,21 +19,20 @@
 
 package org.apache.iceberg.spark
 
+import com.google.common.collect.Maps
 import java.nio.ByteBuffer
 import java.util
-import com.google.common.collect.Maps
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, PathFilter}
-import org.apache.iceberg.parquet.ParquetUtil
 import org.apache.iceberg.{DataFile, DataFiles, Metrics, PartitionSpec}
+import org.apache.iceberg.hadoop.HadoopInputFile
+import org.apache.iceberg.orc.OrcMetrics
+import org.apache.iceberg.parquet.ParquetUtil
 import org.apache.iceberg.spark.hacks.Hive
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition
 import scala.collection.JavaConverters._
-
-import org.apache.iceberg.hadoop.HadoopInputFile
-import org.apache.iceberg.orc.OrcMetrics
 
 object SparkTableUtil {
   /**

--- a/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -48,6 +48,9 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class RandomData {
+
+  private RandomData() {}
+
   public static List<Record> generateList(Schema schema, int numRecords, long seed) {
     RandomDataGenerator generator = new RandomDataGenerator(schema, seed);
     List<Record> records = Lists.newArrayListWithExpectedSize(numRecords);
@@ -289,6 +292,7 @@ public class RandomData {
     }
   }
 
+  @SuppressWarnings("RandomModInteger")
   private static Object generatePrimitive(Type.PrimitiveType primitive,
                                          Random random) {
     int choice = random.nextInt(20);
@@ -424,6 +428,7 @@ public class RandomData {
   }
 
   private static final String DIGITS = "0123456789";
+
   private static BigInteger randomUnscaled(int precision, Random random) {
     int length = random.nextInt(precision);
     if (length == 0) {

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -47,12 +47,12 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.Assert;
 import scala.collection.Seq;
@@ -61,7 +61,10 @@ import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
 import static scala.collection.JavaConverters.mapAsJavaMapConverter;
 import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
+@SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
 public class TestHelpers {
+
+  private TestHelpers() {}
 
   public static void assertEqualsSafe(Types.StructType struct, Record rec, Row row) {
     List<Types.NestedField> fields = struct.fields();
@@ -127,8 +130,8 @@ public class TestHelpers {
       case DATE:
         Assert.assertTrue("Should be an int", expected instanceof Integer);
         Assert.assertTrue("Should be a Date", actual instanceof Date);
-        int daysFrom1970_01_01 = (Integer) expected;
-        LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFrom1970_01_01);
+        int daysFromEpoch = (Integer) expected;
+        LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFromEpoch);
         Assert.assertEquals("ISO-8601 date should be equal", date.toString(), actual.toString());
         break;
       case TIMESTAMP:

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.spark.data;
 
+import java.io.File;
+import java.io.IOException;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
@@ -29,8 +31,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import java.io.File;
-import java.io.IOException;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -93,9 +93,9 @@ public class TestParquetAvroReader {
     long sum = 0;
     long sumSq = 0;
     int warmups = 2;
-    int n = 10;
+    int trials = 10;
 
-    for (int i = 0; i < warmups + n; i += 1) {
+    for (int i = 0; i < warmups + trials; i += 1) {
       // clean up as much memory as possible to avoid a large GC during the timed run
       System.gc();
 
@@ -120,16 +120,16 @@ public class TestParquetAvroReader {
 
         if (i >= warmups) {
           sum += duration;
-          sumSq += (duration * duration);
+          sumSq += duration * duration;
         }
       }
     }
 
-    double mean = ((double) sum) / n;
-    double stddev = Math.sqrt((((double) sumSq) / n) - (mean * mean));
+    double mean = ((double) sum) / trials;
+    double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
     System.err.println(String.format(
-        "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", n, mean, stddev));
+        "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
   }
 
   @Ignore
@@ -206,24 +206,24 @@ public class TestParquetAvroReader {
             fileSchema -> ParquetAvroValueReaders.buildReader(COMPLEX_SCHEMA, readSchema))
         .reuseContainers()
         .build()) {
-      int i = 0;
+      int recordNum = 0;
       Iterator<Record> iter = records.iterator();
       for (Record actual : reader) {
         Record expected = iter.next();
-        Assert.assertEquals("Record " + i + " should match expected", expected, actual);
-        i += 1;
+        Assert.assertEquals("Record " + recordNum + " should match expected", expected, actual);
+        recordNum += 1;
       }
     }
   }
 
-  private File writeTestData(Schema schema, int n, int seed) throws IOException {
+  private File writeTestData(Schema schema, int numRecords, int seed) throws IOException {
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
 
     try (FileAppender<Record> writer = Parquet.write(Files.localOutput(testFile))
         .schema(schema)
         .build()) {
-      writer.addAll(RandomData.generate(schema, n, seed));
+      writer.addAll(RandomData.generate(schema, numRecords, seed));
     }
 
     return testFile;

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
@@ -94,12 +94,12 @@ public class TestParquetAvroWriter {
         .createReaderFunc(
             fileSchema -> ParquetAvroValueReaders.buildReader(COMPLEX_SCHEMA, readSchema))
         .build()) {
-      int i = 0;
+      int recordNum = 0;
       Iterator<Record> iter = records.iterator();
       for (Record actual : reader) {
         Record expected = iter.next();
-        Assert.assertEquals("Record " + i + " should match expected", expected, actual);
-        i += 1;
+        Assert.assertEquals("Record " + recordNum + " should match expected", expected, actual);
+        recordNum += 1;
       }
     }
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -19,8 +19,6 @@
 
 package org.apache.iceberg.spark.data;
 
-import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
@@ -31,6 +29,8 @@ import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.orc.ORC;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.junit.Assert;
+
+import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
 
 public class TestSparkOrcReader extends AvroDataTest {
   @Override

--- a/spark/src/test/java/org/apache/iceberg/spark/source/SimpleRecord.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/SimpleRecord.java
@@ -1,17 +1,20 @@
 /*
- * Copyright 2018 Hortonworks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark.source;
@@ -48,10 +51,10 @@ public class SimpleRecord {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o){
+    if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()){
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
@@ -63,9 +63,9 @@ public class TestAvroScan extends AvroDataTest {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestAvroScan.spark;
+    SparkSession currentSpark = TestAvroScan.spark;
     TestAvroScan.spark = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Override

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -85,10 +85,10 @@ public class TestDataFrameWrites extends AvroDataTest {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestDataFrameWrites.spark;
+    SparkSession currentSpark = TestDataFrameWrites.spark;
     TestDataFrameWrites.spark = null;
     TestDataFrameWrites.sc = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Override

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -122,9 +122,9 @@ public class TestFilteredScan {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestFilteredScan.spark;
+    SparkSession currentSpark = TestFilteredScan.spark;
     TestFilteredScan.spark = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Rule
@@ -261,7 +261,7 @@ public class TestFilteredScan {
     List<InputPartition<InternalRow>> tasks = reader.planInputPartitions();
     Assert.assertEquals("Should only create one task for a small file", 1, tasks.size());
 
-    assertEqualsSafe(SCHEMA.asStruct(), expected(5,6,7,8,9),
+    assertEqualsSafe(SCHEMA.asStruct(), expected(5, 6, 7, 8, 9),
         read(unpartitioned.toString(), "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
   }
 
@@ -293,6 +293,7 @@ public class TestFilteredScan {
     }
   }
 
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
   @Test
   public void testDayPartitionedTimestampFilters() {
     File location = buildPartitionedTable("partitioned_by_day", PARTITION_BY_DAY, "ts_day", "ts");
@@ -334,6 +335,7 @@ public class TestFilteredScan {
     }
   }
 
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
   @Test
   public void testHourPartitionedTimestampFilters() {
     File location = buildPartitionedTable("partitioned_by_hour", PARTITION_BY_HOUR, "ts_hour", "ts");
@@ -375,12 +377,13 @@ public class TestFilteredScan {
     }
   }
 
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
   @Test
   public void testFilterByNonProjectedColumn() {
     {
       Schema actualProjection = SCHEMA.select("id", "data");
       List<Record> expected = Lists.newArrayList();
-      for (Record rec : expected(5, 6 ,7, 8, 9)) {
+      for (Record rec : expected(5, 6, 7, 8, 9)) {
         expected.add(projectFlat(actualProjection, rec));
       }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
@@ -68,9 +68,9 @@ public class TestParquetScan extends AvroDataTest {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestParquetScan.spark;
+    SparkSession currentSpark = TestParquetScan.spark;
     TestParquetScan.spark = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Override

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
@@ -65,9 +65,9 @@ public class TestParquetWrite {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestParquetWrite.spark;
+    SparkSession currentSpark = TestParquetWrite.spark;
     TestParquetWrite.spark = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Test
@@ -105,7 +105,7 @@ public class TestParquetWrite {
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
       for (DataFile file : ManifestReader.read(localInput(manifest.path()), null)) {
         Assert.assertNotNull("Split offsets not present", file.splitOffsets());
-        Assert.assertEquals("Should have reported record count as 1" , 1, file.recordCount());
+        Assert.assertEquals("Should have reported record count as 1", 1, file.recordCount());
         Assert.assertNotNull("Column sizes metric not present", file.columnSizes());
         Assert.assertNotNull("Counts metric not present", file.valueCounts());
         Assert.assertNotNull("Null value counts metric not present", file.nullValueCounts());

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
-import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
@@ -96,9 +95,9 @@ public class TestPartitionValues {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestPartitionValues.spark;
+    SparkSession currentSpark = TestPartitionValues.spark;
     TestPartitionValues.spark = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Rule

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -568,9 +568,9 @@ public abstract class TestReadProjection {
 
   private static org.apache.avro.Schema fromOption(org.apache.avro.Schema schema) {
     Preconditions.checkArgument(schema.getType() == UNION,
-        "Expected union schema but was passed: {}", schema);
+        "Expected union schema but was passed: %s", schema);
     Preconditions.checkArgument(schema.getTypes().size() == 2,
-        "Expected optional schema, but was passed: {}", schema);
+        "Expected optional schema, but was passed: %s", schema);
     if (schema.getTypes().get(0).getType() == org.apache.avro.Schema.Type.NULL) {
       return schema.getTypes().get(1);
     } else {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -19,21 +19,21 @@
 
 package org.apache.iceberg.spark.source;
 
-import java.io.IOException;
-import java.util.List;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Encoders;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -63,9 +63,9 @@ public class TestSnapshotSelection {
 
   @AfterClass
   public static void stopSpark() {
-    SparkSession spark = TestSnapshotSelection.spark;
+    SparkSession currentSpark = TestSnapshotSelection.spark;
     TestSnapshotSelection.spark = null;
-    spark.stop();
+    currentSpark.stop();
   }
 
   @Test

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -182,7 +182,7 @@ class TestTables {
       return nextSnapshotId;
     }
   }
-  
+
   static class LocalFileIO implements FileIO {
 
     @Override


### PR DESCRIPTION
This PR applies Baseline to iceberg-spark and resolves #161. 

**Open Questions**

I’ve picked the default Scala formatting from Baseline. Here are a few points I want to bring attention to:
  - Baseline applies `FileLengthChecker` with 800 as `maxFileLength`. Is it ok for us?
  - Baseline applies `CyclomaticComplexityChecker` with 10 as the max value. Shall we make it 12 as in Java?
  - Baseline applies `MethodLengthChecker` with 50 as `maxLength`. Shall we make it 150 as in Java?
  - Baseline applies `ReturnChecker`. Is it ok for us?

The description of rules can be found [here](http://www.scalastyle.org/rules-dev.html).
 