### PR TITLE
Use Iceberg tables as sinks in Spark Structured Streaming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ subprojects {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.slf4j:slf4j-simple:1.7.5'
-    testCompile 'org.mockito:mockito-all:1.10.19'
+    testCompile 'org.mockito:mockito-core:1.10.19'
   }
 
   publishing {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter;
+import org.apache.spark.sql.streaming.OutputMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StreamingWriter extends Writer implements StreamWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StreamingWriter.class);
+  private static final String QUERY_ID_PROPERTY = "spark.sql.streaming.queryId";
+  private static final String EPOCH_ID_PROPERTY = "spark.sql.streaming.epochId";
+
+  private final String queryId;
+  private final OutputMode mode;
+
+  StreamingWriter(Table table, FileFormat format, String queryId, OutputMode mode) {
+    super(table, format);
+    this.queryId = queryId;
+    this.mode = mode;
+  }
+
+  @Override
+  public void commit(long epochId, WriterCommitMessage[] messages) {
+    LOG.info("Committing epoch {} for query {} in {} mode", epochId, queryId, mode);
+
+    table().refresh();
+    Long lastCommittedEpochId = getLastCommittedEpochId();
+    if (lastCommittedEpochId != null && epochId <= lastCommittedEpochId) {
+      LOG.info("Skipping epoch {} for query {} as it was already committed", epochId, queryId);
+      return;
+    }
+
+    if (mode == OutputMode.Complete()) {
+      OverwriteFiles overwriteFiles = table().newOverwrite();
+      overwriteFiles.overwriteByRowFilter(Expressions.alwaysTrue());
+      int numFiles = 0;
+      for (DataFile file : files(messages)) {
+        overwriteFiles.addFile(file);
+        numFiles++;
+      }
+      LOG.info("Overwriting files in {} with {} new files", table(), numFiles);
+      commit(overwriteFiles, epochId);
+    } else {
+      AppendFiles append = table().newFastAppend();
+      int numFiles = 0;
+      for (DataFile file : files(messages)) {
+        append.appendFile(file);
+        numFiles++;
+      }
+      LOG.info("Appending {} files to {}", numFiles, table());
+      commit(append, epochId);
+    }
+  }
+
+  private <T> void commit(SnapshotUpdate<T> snapshotUpdate, long epochId) {
+    snapshotUpdate.set(QUERY_ID_PROPERTY, queryId);
+    snapshotUpdate.set(EPOCH_ID_PROPERTY, Long.toString(epochId));
+    long start = System.currentTimeMillis();
+    snapshotUpdate.commit();
+    long duration = System.currentTimeMillis() - start;
+    LOG.info("Committed in {} ms", duration);
+  }
+
+  @Override
+  public void abort(long epochId, WriterCommitMessage[] messages) {
+    abort(messages);
+  }
+
+  private Long getLastCommittedEpochId() {
+    Snapshot snapshot = table().currentSnapshot();
+    Long lastCommittedEpochId = null;
+    while (snapshot != null) {
+      Map<String, String> summary = snapshot.summary();
+      String snapshotQueryId = summary.get(QUERY_ID_PROPERTY);
+      if (queryId.equals(snapshotQueryId)) {
+        lastCommittedEpochId = Long.valueOf(summary.get(EPOCH_ID_PROPERTY));
+        break;
+      }
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table().snapshot(parentSnapshotId) : null;
+    }
+    return lastCommittedEpochId;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -125,7 +125,11 @@ class Writer implements DataSourceWriter {
         });
   }
 
-  private Iterable<DataFile> files(WriterCommitMessage[] messages) {
+  protected Table table() {
+    return table;
+  }
+
+  protected Iterable<DataFile> files(WriterCommitMessage[] messages) {
     if (messages.length > 0) {
       return concat(transform(Arrays.asList(messages), message -> message != null
           ? ImmutableList.copyOf(((TaskCommit) message).files())

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.streaming.MemoryStream;
+import org.apache.spark.sql.streaming.DataStreamWriter;
+import org.apache.spark.sql.streaming.StreamingQuery;
+import org.apache.spark.sql.streaming.StreamingQueryException;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import scala.collection.JavaConversions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestStructuredStreaming {
+
+  private static final Configuration CONF = new Configuration();
+  private static final Schema SCHEMA = new Schema(
+      optional(1, "id", Types.IntegerType.get()),
+      optional(2, "data", Types.StringType.get())
+  );
+  private static SparkSession spark = null;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @BeforeClass
+  public static void startSpark() {
+    TestStructuredStreaming.spark = SparkSession.builder()
+        .master("local[2]")
+        .config("spark.sql.shuffle.partitions", 4)
+        .getOrCreate();
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestStructuredStreaming.spark;
+    TestStructuredStreaming.spark = null;
+    currentSpark.stop();
+  }
+
+  @Test
+  public void testStreamingWriteAppendMode() throws IOException {
+    File parent = temp.newFolder("parquet");
+    File location = new File(parent, "test-table");
+    File checkpoint = new File(parent, "checkpoint");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+
+    List<SimpleRecord> expected = Lists.newArrayList(
+        new SimpleRecord(1, "1"),
+        new SimpleRecord(2, "2"),
+        new SimpleRecord(3, "3"),
+        new SimpleRecord(4, "4")
+    );
+
+    MemoryStream<Integer> inputStream = new MemoryStream<>(1, spark.sqlContext(), Encoders.INT());
+    DataStreamWriter<Row> streamWriter = inputStream.toDF()
+        .selectExpr("value AS id", "CAST (value AS STRING) AS data")
+        .writeStream()
+        .outputMode("append")
+        .format("iceberg")
+        .option("checkpointLocation", checkpoint.toString())
+        .option("path", location.toString());
+
+    try {
+      // start the original query with checkpointing
+      StreamingQuery query = streamWriter.start();
+      List<Integer> batch1 = Lists.newArrayList(1, 2);
+      inputStream.addData(JavaConversions.asScalaBuffer(batch1));
+      query.processAllAvailable();
+      List<Integer> batch2 = Lists.newArrayList(3, 4);
+      inputStream.addData(JavaConversions.asScalaBuffer(batch2));
+      query.processAllAvailable();
+      query.stop();
+
+      // remove the last commit to force Spark to reprocess batch #1
+      File lastCommitFile = new File(checkpoint.toString() + "/commits/1");
+      Assert.assertTrue("The commit file must be deleted", lastCommitFile.delete());
+
+      // restart the query from the checkpoint
+      StreamingQuery restartedQuery = streamWriter.start();
+      restartedQuery.processAllAvailable();
+
+      // ensure the write was idempotent
+      Dataset<Row> result = spark.read()
+          .format("iceberg")
+          .load(location.toString());
+      List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+      Assert.assertEquals("Result rows should match", expected, actual);
+      Assert.assertEquals("Number of snapshots should match", 2, Iterables.size(table.snapshots()));
+    } finally {
+      for (StreamingQuery query : spark.streams().active()) {
+        query.stop();
+      }
+    }
+  }
+
+  @Test
+  public void testStreamingWriteCompleteMode() throws IOException {
+    File parent = temp.newFolder("parquet");
+    File location = new File(parent, "test-table");
+    File checkpoint = new File(parent, "checkpoint");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+
+    List<SimpleRecord> expected = Lists.newArrayList(
+        new SimpleRecord(2, "1"),
+        new SimpleRecord(3, "2"),
+        new SimpleRecord(1, "3")
+    );
+
+    MemoryStream<Integer> inputStream = new MemoryStream<>(1, spark.sqlContext(), Encoders.INT());
+    DataStreamWriter<Row> streamWriter = inputStream.toDF()
+        .groupBy("value")
+        .count()
+        .selectExpr("CAST(count AS INT) AS id", "CAST (value AS STRING) AS data")
+        .writeStream()
+        .outputMode("complete")
+        .format("iceberg")
+        .option("checkpointLocation", checkpoint.toString())
+        .option("path", location.toString());
+
+    try {
+      // start the original query with checkpointing
+      StreamingQuery query = streamWriter.start();
+      List<Integer> batch1 = Lists.newArrayList(1, 2);
+      inputStream.addData(JavaConversions.asScalaBuffer(batch1));
+      query.processAllAvailable();
+      List<Integer> batch2 = Lists.newArrayList(1, 2, 2, 3);
+      inputStream.addData(JavaConversions.asScalaBuffer(batch2));
+      query.processAllAvailable();
+      query.stop();
+
+      // remove the last commit to force Spark to reprocess batch #1
+      File lastCommitFile = new File(checkpoint.toString() + "/commits/1");
+      Assert.assertTrue("The commit file must be deleted", lastCommitFile.delete());
+
+      // restart the query from the checkpoint
+      StreamingQuery restartedQuery = streamWriter.start();
+      restartedQuery.processAllAvailable();
+
+      // ensure the write was idempotent
+      Dataset<Row> result = spark.read()
+          .format("iceberg")
+          .load(location.toString());
+      List<SimpleRecord> actual = result.orderBy("data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+      Assert.assertEquals("Result rows should match", expected, actual);
+      Assert.assertEquals("Number of snapshots should match", 2, Iterables.size(table.snapshots()));
+    } finally {
+      for (StreamingQuery query : spark.streams().active()) {
+        query.stop();
+      }
+    }
+  }
+
+  @Test
+  public void testStreamingWriteUpdateMode() throws IOException {
+    exceptionRule.expect(StreamingQueryException.class);
+    exceptionRule.expectMessage("Output mode Update is not supported");
+
+    File parent = temp.newFolder("parquet");
+    File location = new File(parent, "test-table");
+    File checkpoint = new File(parent, "checkpoint");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    tables.create(SCHEMA, spec, location.toString());
+
+    MemoryStream<Integer> inputStream = new MemoryStream<>(1, spark.sqlContext(), Encoders.INT());
+    DataStreamWriter<Row> streamWriter = inputStream.toDF()
+        .selectExpr("value AS id", "CAST (value AS STRING) AS data")
+        .writeStream()
+        .outputMode("update")
+        .format("iceberg")
+        .option("checkpointLocation", checkpoint.toString())
+        .option("path", location.toString());
+
+    try {
+      StreamingQuery query = streamWriter.start();
+      List<Integer> batch1 = Lists.newArrayList(1, 2);
+      inputStream.addData(JavaConversions.asScalaBuffer(batch1));
+      query.processAllAvailable();
+    } finally {
+      for (StreamingQuery query : spark.streams().active()) {
+        query.stop();
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR allows us to use Iceberg tables as sinks in Spark Structured Streaming and resolves #178.

Only `Complete` and `Append` modes are supported.