### PR TITLE
Remove usage of deprecated Schema.Field constructor

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -156,7 +156,7 @@ public class AvroSchemaUtil {
                           int valueId, Schema valueSchema) {
     String keyValueName = "k" + keyId + "_v" + valueId;
 
-    Schema.Field keyField = new Schema.Field("key", keySchema, null, null);
+    Schema.Field keyField = new Schema.Field("key", keySchema, null, (Object) null);
     keyField.addProp(FIELD_ID_PROP, keyId);
 
     Schema.Field valueField = new Schema.Field("value", valueSchema, null,
@@ -172,7 +172,7 @@ public class AvroSchemaUtil {
                           int valueId, String valueName, Schema valueSchema) {
     String keyValueName = "k" + keyId + "_v" + valueId;
 
-    Schema.Field keyField = new Schema.Field("key", keySchema, null, null);
+    Schema.Field keyField = new Schema.Field("key", keySchema, null, (Object) null);
     if (!"key".equals(keyName)) {
       keyField.addAlias(keyName);
     }

--- a/core/src/main/java/org/apache/iceberg/util/Pair.java
+++ b/core/src/main/java/org/apache/iceberg/util/Pair.java
@@ -44,8 +44,8 @@ public class Pair<X, Y> implements IndexedRecord, SpecificData.SchemaConstructab
           Schema xSchema = ReflectData.get().getSchema(key.first);
           Schema ySchema = ReflectData.get().getSchema(key.second);
           return Schema.createRecord("pair", null, null, false, Lists.newArrayList(
-              new Schema.Field("x", xSchema, null, null),
-              new Schema.Field("y", ySchema, null, null)
+              new Schema.Field("x", xSchema, null, (Object) null),
+              new Schema.Field("y", ySchema, null, (Object) null)
           ));
         }
       });


### PR DESCRIPTION
Without the cast, the deprecated variant that takes JsonNode is
chosen by Java's overload resolution because it is "more specific".