### PR TITLE
iceberg: don't bundle hdfs with iceberg runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
   apply plugin: 'nebula.source-jar'
   apply plugin: 'java'
   apply plugin: 'maven' // make pom files for deployment
-  apply plugin: 'nebula.maven-base-publish'
+  apply plugin: 'maven-publish' 
 
   compileJava {
     options.encoding = "UTF-8"
@@ -390,12 +390,12 @@ project(':iceberg-pig') {
 project(':iceberg-spark-runtime') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
-  tasks.build.dependsOn tasks.shadowJar
+  tasks.assemble.dependsOn tasks.shadowJar
   tasks.install.dependsOn tasks.shadowJar
   tasks.javadocJar.dependsOn tasks.shadowJar
 
   configurations {
-    compile {
+    compileOnly {
       // included in Spark
       exclude group: 'org.slf4j'
       exclude group: 'org.apache.commons'
@@ -431,7 +431,7 @@ project(':iceberg-spark-runtime') {
     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
 
-    archiveName = "iceberg-spark-runtime-${version}.${extension}"
+    archiveBaseName = "iceberg-spark-runtime"
   }
 }
 


### PR DESCRIPTION
Tries to fix #217
test plan:
first look at the dependency graph to understand what will be excluded
```

> Configure project :
org.ajoberstar.gradle.git.release.semver.SemVerStrategyState(scopeFromProp:null, stageFromProp:SNAPSHOT, currentHead:org.ajoberstar.grgit.Commit(0c6afe50def689ec1455a8e11ada45f922fb4bee, [b3d3ab9f69b8f32153068c40fe7460059ec519e4], org.ajoberstar.grgit.Person(Suren Nihalani, snihalani@linkedin.com), org.ajoberstar.grgit.Person(Suren Nihalani, snihalani@linkedin.com), 1561600963, iceberg: don't bundle hdfs with iceberg runtime

test plan:
./gradlew clean :iceberg-runtime:assemble
vim ./runtime/build/libs/iceberg-runtime-*
and then search for org.apache.hadoop in vim
, iceberg: don't bundle hdfs with iceberg runtime), currentBranch:org.ajoberstar.grgit.Branch(refs/heads/master, org.ajoberstar.grgit.Branch(refs/remotes/origin/master)), repoDirty:true, nearestVersion:org.ajoberstar.gradle.git.release.semver.NearestVersion(0.0.0, 0.0.0, 389, 389), inferredNormal:null, inferredPreRelease:null, inferredBuildMetadata:null)
org.ajoberstar.gradle.git.release.semver.SemVerStrategyState(scopeFromProp:null, stageFromProp:SNAPSHOT, currentHead:org.ajoberstar.grgit.Commit(0c6afe50def689ec1455a8e11ada45f922fb4bee, [b3d3ab9f69b8f32153068c40fe7460059ec519e4], org.ajoberstar.grgit.Person(Suren Nihalani, snihalani@linkedin.com), org.ajoberstar.grgit.Person(Suren Nihalani, snihalani@linkedin.com), 1561600963, iceberg: don't bundle hdfs with iceberg runtime

test plan:
./gradlew clean :iceberg-runtime:assemble
vim ./runtime/build/libs/iceberg-runtime-*
and then search for org.apache.hadoop in vim
, iceberg: don't bundle hdfs with iceberg runtime), currentBranch:org.ajoberstar.grgit.Branch(refs/heads/master, org.ajoberstar.grgit.Branch(refs/remotes/origin/master)), repoDirty:true, nearestVersion:org.ajoberstar.gradle.git.release.semver.NearestVersion(0.0.0, 0.0.0, 389, 389), inferredNormal:null, inferredPreRelease:null, inferredBuildMetadata:null)
Inferred project: iceberg, version: 0.1.0-SNAPSHOT
Publication nebula not found in project :.

> Task :iceberg-runtime:dependencies

------------------------------------------------------------
Project :iceberg-runtime
------------------------------------------------------------

compile - Dependencies for source set 'main' (deprecated, use 'implementation' instead).
+--- project :iceberg-api
+--- project :iceberg-common
+--- project :iceberg-core
|    +--- project :iceberg-api
|    +--- project :iceberg-common
|    +--- org.apache.avro:avro:1.8.2
|    |    +--- org.codehaus.jackson:jackson-core-asl:1.9.13
|    |    +--- org.codehaus.jackson:jackson-mapper-asl:1.9.13
|    |    |    \--- org.codehaus.jackson:jackson-core-asl:1.9.13
|    |    +--- com.thoughtworks.paranamer:paranamer:2.7
|    |    +--- org.xerial.snappy:snappy-java:1.1.1.3 -> 1.1.2.6
|    |    +--- org.apache.commons:commons-compress:1.8.1
|    |    +--- org.tukaani:xz:1.5
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.22
|    +--- com.fasterxml.jackson.core:jackson-databind:2.6.7
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.6.0
|    |    \--- com.fasterxml.jackson.core:jackson-core:2.6.7
|    +--- com.fasterxml.jackson.core:jackson-core:2.6.7
|    \--- com.github.ben-manes.caffeine:caffeine:2.7.0
|         +--- org.checkerframework:checker-qual:2.6.0
|         \--- com.google.errorprone:error_prone_annotations:2.3.3
+--- project :iceberg-parquet
|    +--- project :iceberg-api
|    +--- project :iceberg-core (*)
|    \--- org.apache.parquet:parquet-avro:1.10.0
|         +--- org.apache.parquet:parquet-column:1.10.0
|         |    +--- org.apache.parquet:parquet-common:1.10.0
|         |    |    +--- org.apache.parquet:parquet-format:2.4.0
|         |    |    |    \--- org.slf4j:slf4j-api:1.7.2 -> 1.7.22
|         |    |    \--- org.slf4j:slf4j-api:1.7.22
|         |    +--- org.apache.parquet:parquet-encoding:1.10.0
|         |    |    +--- org.apache.parquet:parquet-common:1.10.0 (*)
|         |    |    \--- commons-codec:commons-codec:1.10
|         |    \--- commons-codec:commons-codec:1.10
|         +--- org.apache.parquet:parquet-hadoop:1.10.0
|         |    +--- org.apache.parquet:parquet-column:1.10.0 (*)
|         |    +--- org.apache.parquet:parquet-format:2.4.0 (*)
|         |    +--- org.apache.parquet:parquet-jackson:1.10.0
|         |    +--- org.codehaus.jackson:jackson-mapper-asl:1.9.13 (*)
|         |    +--- org.codehaus.jackson:jackson-core-asl:1.9.13
|         |    +--- org.xerial.snappy:snappy-java:1.1.2.6
|         |    \--- commons-pool:commons-pool:1.6
|         +--- org.apache.parquet:parquet-format:2.4.0 (*)
|         +--- org.apache.avro:avro:1.8.2 (*)
|         \--- it.unimi.dsi:fastutil:7.0.13
+--- project :iceberg-spark
|    +--- project :iceberg-api
|    +--- project :iceberg-common
|    +--- project :iceberg-core (*)
|    +--- project :iceberg-orc
|    |    +--- project :iceberg-api
|    |    +--- project :iceberg-core (*)
|    |    \--- org.apache.orc:orc-core:1.5.5
|    |         +--- org.apache.orc:orc-shims:1.5.5
|    |         |    \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.22
|    |         +--- com.google.protobuf:protobuf-java:2.5.0
|    |         +--- commons-lang:commons-lang:2.6
|    |         +--- io.airlift:aircompressor:0.10
|    |         +--- javax.xml.bind:jaxb-api:2.2.11
|    |         +--- org.apache.hadoop:hadoop-hdfs:2.2.0
|    |         |    +--- com.google.guava:guava:11.0.2
|    |         |    +--- com.sun.jersey:jersey-core:1.9
|    |         |    +--- com.sun.jersey:jersey-server:1.9
|    |         |    |    +--- asm:asm:3.1
|    |         |    |    \--- com.sun.jersey:jersey-core:1.9
|    |         |    +--- commons-cli:commons-cli:1.2
|    |         |    +--- commons-codec:commons-codec:1.4 -> 1.10
|    |         |    +--- commons-io:commons-io:2.1
|    |         |    +--- commons-lang:commons-lang:2.5 -> 2.6
|    |         |    +--- commons-logging:commons-logging:1.1.1
|    |         |    +--- log4j:log4j:1.2.17
|    |         |    +--- com.google.protobuf:protobuf-java:2.5.0
|    |         |    +--- org.codehaus.jackson:jackson-core-asl:1.8.8 -> 1.9.13
|    |         |    +--- org.codehaus.jackson:jackson-mapper-asl:1.8.8 -> 1.9.13 (*)
|    |         |    \--- xmlenc:xmlenc:0.52
|    |         +--- org.apache.hive:hive-storage-api:2.6.0
|    |         |    +--- commons-lang:commons-lang:2.6
|    |         |    \--- org.slf4j:slf4j-api:1.7.10 -> 1.7.22
|    |         \--- org.slf4j:slf4j-api:1.7.5 -> 1.7.22
|    \--- project :iceberg-parquet (*)
+--- project :iceberg-pig
|    +--- project :iceberg-api
|    +--- project :iceberg-common
|    +--- project :iceberg-core (*)
|    \--- project :iceberg-parquet (*)
+--- project :iceberg-hive
|    \--- project :iceberg-core (*)
+--- org.apache.avro:avro:1.8.2 (*)
\--- org.apache.parquet:parquet-avro:1.10.0 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 0s
1 actionable task: 1 executed

```
./gradlew clean :iceberg-runtime:assemble
vim ./runtime/build/libs/iceberg-runtime-*
and then search for org.apache.hadoop in vim