### PR TITLE
Fix row group skipping in ParquetReader.

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -245,6 +245,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
       }
 
       nextRowGroupStart += pages.getRowCount();
+      nextRowGroup += 1;
 
       model.setPageSource(pages);
     }


### PR DESCRIPTION
By only updating the next row group index when a row group was skipped, `ParquetReader` was skipping initial row groups, then processing row groups after that without skipping because the index was not updated.