### PR TITLE
Register existing tables in Iceberg HiveCatalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -137,4 +137,13 @@ public interface Catalog {
    * @throws NoSuchTableException if the table does not exist
    */
   Table loadTable(TableIdentifier identifier);
+
+  /**
+   * Register a table.
+   *
+   * @param identifier a table identifier
+   * @param metadataFileLocation the location of a metadata file
+   * @return a Table instance
+   */
+  Table registerTable(TableIdentifier identifier, String metadataFileLocation);
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import com.google.common.collect.Maps;
 import java.util.Map;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -29,11 +28,6 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 
 public abstract class BaseMetastoreCatalog implements Catalog {
-  private final Configuration conf;
-
-  protected BaseMetastoreCatalog(Configuration conf) {
-    this.conf = conf;
-  }
 
   @Override
   public Table createTable(
@@ -42,7 +36,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       PartitionSpec spec,
       String location,
       Map<String, String> properties) {
-    TableOperations ops = newTableOps(conf, identifier);
+    TableOperations ops = newTableOps(identifier);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table already exists: " + identifier);
     }
@@ -51,7 +45,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     if (location != null) {
       baseLocation = location;
     } else {
-      baseLocation = defaultWarehouseLocation(conf, identifier);
+      baseLocation = defaultWarehouseLocation(identifier);
     }
 
     TableMetadata metadata = TableMetadata.newTableMetadata(
@@ -68,7 +62,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
   @Override
   public Table loadTable(TableIdentifier identifier) {
-    TableOperations ops = newTableOps(conf, identifier);
+    TableOperations ops = newTableOps(identifier);
     if (ops.current() == null) {
       throw new NoSuchTableException("Table does not exist: " + identifier);
     }
@@ -76,7 +70,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     return new BaseTable(ops, identifier.toString());
   }
 
-  protected abstract TableOperations newTableOps(Configuration newConf, TableIdentifier tableIdentifier);
+  protected abstract TableOperations newTableOps(TableIdentifier tableIdentifier);
 
-  protected abstract String defaultWarehouseLocation(Configuration hadoopConf, TableIdentifier tableIdentifier);
+  protected abstract String defaultWarehouseLocation(TableIdentifier tableIdentifier);
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -119,7 +119,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       return;
     }
 
-    String newMetadataLocation = writeNewMetadata(metadata, currentVersion() + 1);
+    String newMetadataLocation = metadata.file() == null ?
+        writeNewMetadata(metadata, currentVersion() + 1) :
+        metadata.file().location();
 
     boolean threw = true;
     Optional<Long> lockId = Optional.empty();


### PR DESCRIPTION
This PR allows us to register existing tables in Iceberg `HiveCatalog` and resolves #251.