### PR TITLE
Make metrics collection configurable via table properties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import org.apache.iceberg.MetricsModes.MetricsMode;
+
+import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE;
+import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT;
+
+public class MetricsConfig {
+
+  private static final String COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
+
+  private Map<String, MetricsMode> columnModes = Maps.newHashMap();
+  private MetricsMode defaultMode;
+
+  private MetricsConfig() {}
+
+  public static MetricsConfig getDefault() {
+    MetricsConfig spec = new MetricsConfig();
+    spec.defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+    return spec;
+  }
+
+  public static MetricsConfig fromProperties(Map<String, String> props) {
+    MetricsConfig spec = new MetricsConfig();
+    props.keySet().stream()
+        .filter(key -> key.startsWith(COLUMN_CONF_PREFIX))
+        .forEach(key -> {
+          MetricsMode mode = MetricsModes.fromString(props.get(key));
+          String columnAlias = key.replaceFirst(COLUMN_CONF_PREFIX, "");
+          spec.columnModes.put(columnAlias, mode);
+        });
+    String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+    spec.defaultMode = MetricsModes.fromString(defaultModeAsString);
+    return spec;
+  }
+
+  public MetricsMode columnMode(String columnAlias) {
+    return columnModes.getOrDefault(columnAlias, defaultMode);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.base.Preconditions;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class defines different metrics modes, which allow users to control the collection of
+ * value_counts, null_value_counts, lower_bounds, upper_bounds for different columns in metadata.
+ */
+public class MetricsModes {
+
+  private static final Pattern TRUNCATE = Pattern.compile("truncate\\((\\d+)\\)");
+
+  private MetricsModes() {}
+
+  public static MetricsMode fromString(String mode) {
+    if ("none".equalsIgnoreCase(mode)) {
+      return None.get();
+    } else if ("counts".equalsIgnoreCase(mode)) {
+      return Counts.get();
+    } else if ("full".equalsIgnoreCase(mode)) {
+      return Full.get();
+    }
+
+    Matcher truncateMatcher = TRUNCATE.matcher(mode.toLowerCase(Locale.ENGLISH));
+    if (truncateMatcher.matches()) {
+      int length = Integer.parseInt(truncateMatcher.group(1));
+      return Truncate.withLength(length);
+    }
+
+    throw new IllegalArgumentException("Invalid metrics mode: " + mode);
+  }
+
+  public interface MetricsMode {}
+
+  /**
+   * Under this mode, value_counts, null_value_counts, lower_bounds, upper_bounds are not persisted.
+   */
+  public static class None implements MetricsMode {
+    private static final None INSTANCE = new None();
+
+    public static None get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+      return "none";
+    }
+  }
+
+  /**
+   * Under this mode, only value_counts, null_value_counts are persisted.
+   */
+  public static class Counts implements MetricsMode {
+    private static final Counts INSTANCE = new Counts();
+
+    public static Counts get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+      return "counts";
+    }
+  }
+
+  /**
+   * Under this mode, value_counts, null_value_counts and truncated lower_bounds, upper_bounds are persisted.
+   */
+  public static class Truncate implements MetricsMode {
+    private final int length;
+
+    private Truncate(int length) {
+      this.length = length;
+    }
+
+    public static Truncate withLength(int length) {
+      Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+      return new Truncate(length);
+    }
+
+    public int length() {
+      return length;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("truncate(%d)", length);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      Truncate truncate = (Truncate) obj;
+      return length == truncate.length;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(length);
+    }
+  }
+
+  /**
+   * Under this mode, value_counts, null_value_counts and full lower_bounds, upper_bounds are persisted.
+   */
+  public static class Full implements MetricsMode {
+    private static final Full INSTANCE = new Full();
+
+    public static Full get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+      return "full";
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -89,6 +89,6 @@ public class TableProperties {
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "none";
 
-  public static final String WRITE_METADATA_TRUNCATE_BYTES = "write.metadata.truncate-length";
-  public static final int WRITE_METADATA_TRUNCATE_BYTES_DEFAULT = 16;
+  public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
+  public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.MetricsModes.Counts;
+import org.apache.iceberg.MetricsModes.Full;
+import org.apache.iceberg.MetricsModes.None;
+import org.apache.iceberg.MetricsModes.Truncate;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestMetricsModes {
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void testMetricsModeParsing() {
+    Assert.assertEquals(None.get(), MetricsModes.fromString("none"));
+    Assert.assertEquals(None.get(), MetricsModes.fromString("nOnE"));
+    Assert.assertEquals(Counts.get(), MetricsModes.fromString("counts"));
+    Assert.assertEquals(Counts.get(), MetricsModes.fromString("coUntS"));
+    Assert.assertEquals(Truncate.withLength(1), MetricsModes.fromString("truncate(1)"));
+    Assert.assertEquals(Truncate.withLength(10), MetricsModes.fromString("truNcAte(10)"));
+    Assert.assertEquals(Full.get(), MetricsModes.fromString("full"));
+    Assert.assertEquals(Full.get(), MetricsModes.fromString("FULL"));
+  }
+
+  @Test
+  public void testInvalidTruncationLength() {
+    exceptionRule.expect(IllegalArgumentException.class);
+    exceptionRule.expectMessage("length should be positive");
+    MetricsModes.fromString("truncate(0)");
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
@@ -23,19 +23,20 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
 public class ParquetWriteAdapter<D> implements FileAppender<D> {
-  private ParquetWriter<D> writer = null;
-  private ParquetMetadata footer = null;
-  private int statsTruncateLength;
+  private ParquetWriter<D> writer;
+  private MetricsConfig metricsConfig;
+  private ParquetMetadata footer;
 
-  public ParquetWriteAdapter(ParquetWriter<D> writer, int statsTruncateLength) {
+  public ParquetWriteAdapter(ParquetWriter<D> writer, MetricsConfig metricsConfig) {
     this.writer = writer;
-    this.statsTruncateLength = statsTruncateLength;
+    this.metricsConfig = metricsConfig;
   }
 
   @Override
@@ -50,7 +51,7 @@ public class ParquetWriteAdapter<D> implements FileAppender<D> {
   @Override
   public Metrics metrics() {
     Preconditions.checkState(footer != null, "Cannot produce metrics until closed");
-    return ParquetUtil.footerMetrics(footer, statsTruncateLength);
+    return ParquetUtil.footerMetrics(footer, metricsConfig);
   }
 
   @Override

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -23,7 +23,8 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.parquet.compression-codec    | gzip               | Parquet compression codec                          |
 | write.avro.compression-codec       | gzip               | Avro compression codec                             |
 | write.metadata.compression-codec   | none               | Metadata compression codec; none or gzip           |
-
+| write.metadata.metrics.default     | truncate(16)       | Default metrics mode for all columns in the table; none, counts, truncate(length), or full |
+| write.metadata.metrics.column.col1 | (not set)          | Metrics mode for column 'col1' to allow per-column tuning; none, counts, truncate(length), or full |
 
 ### Table behavior properties
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PendingUpdate;
 import org.apache.iceberg.ReplacePartitions;
@@ -251,12 +252,14 @@ class Writer implements DataSourceWriter {
       @Override
       public FileAppender<InternalRow> newAppender(OutputFile file, FileFormat fileFormat) {
         Schema schema = spec.schema();
+        MetricsConfig metricsConfig = MetricsConfig.fromProperties(properties);
         try {
           switch (fileFormat) {
             case PARQUET:
               return Parquet.write(file)
                   .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(schema, msgType))
                   .setAll(properties)
+                  .metricsConfig(metricsConfig)
                   .schema(schema)
                   .build();
 

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer
 import java.util
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, PathFilter}
-import org.apache.iceberg.{DataFile, DataFiles, Metrics, PartitionSpec, TableProperties}
+import org.apache.iceberg.{DataFile, DataFiles, Metrics, MetricsConfig, PartitionSpec}
 import org.apache.iceberg.hadoop.HadoopInputFile
 import org.apache.iceberg.orc.OrcMetrics
 import org.apache.iceberg.parquet.ParquetUtil
@@ -232,14 +232,14 @@ object SparkTableUtil {
   //noinspection ScalaDeprecation
   private def listParquetPartition(
       partitionPath: Map[String, String],
-      partitionUri: String): Seq[SparkDataFile] = {
+      partitionUri: String,
+      metricsSpec: MetricsConfig = MetricsConfig.getDefault): Seq[SparkDataFile] = {
     val conf = new Configuration()
     val partition = new Path(partitionUri)
     val fs = partition.getFileSystem(conf)
 
     fs.listStatus(partition, HiddenPathFilter).filter(_.isFile).map { stat =>
-      val metrics = ParquetUtil.footerMetrics(ParquetFileReader.readFooter(conf, stat),
-        TableProperties.WRITE_METADATA_TRUNCATE_BYTES_DEFAULT)
+      val metrics = ParquetUtil.footerMetrics(ParquetFileReader.readFooter(conf, stat), metricsSpec)
 
       SparkDataFile(
         stat.getPath.toString,

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestWriteMetricsConfig {
+
+  private static final Configuration CONF = new Configuration();
+  private static final Schema SIMPLE_SCHEMA = new Schema(
+      optional(1, "id", Types.IntegerType.get()),
+      optional(2, "data", Types.StringType.get())
+  );
+  private static final Schema COMPLEX_SCHEMA = new Schema(
+      required(1, "longCol", Types.IntegerType.get()),
+      optional(2, "strCol", Types.StringType.get()),
+      required(3, "record", Types.StructType.of(
+          required(4, "id", Types.IntegerType.get()),
+          required(5, "data", Types.StringType.get())
+      ))
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private static SparkSession spark = null;
+  private static JavaSparkContext sc = null;
+
+  @BeforeClass
+  public static void startSpark() {
+    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
+    TestWriteMetricsConfig.sc = new JavaSparkContext(spark.sparkContext());
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestWriteMetricsConfig.spark;
+    TestWriteMetricsConfig.spark = null;
+    TestWriteMetricsConfig.sc = null;
+    currentSpark.stop();
+  }
+
+  @Test
+  public void testFullMetricsCollectionForParquet() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full");
+    Table table = tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation);
+
+    List<SimpleRecord> expectedRecords = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c")
+    );
+    Dataset<Row> df = spark.createDataFrame(expectedRecords, SimpleRecord.class);
+    df.select("id", "data")
+        .coalesce(1)
+        .write()
+        .format("iceberg")
+        .option("write-format", "parquet")
+        .mode("append")
+        .save(tableLocation);
+
+    for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
+      DataFile file = task.file();
+      Assert.assertEquals(2, file.nullValueCounts().size());
+      Assert.assertEquals(2, file.valueCounts().size());
+      Assert.assertEquals(2, file.lowerBounds().size());
+      Assert.assertEquals(2, file.upperBounds().size());
+    }
+  }
+
+  @Test
+  public void testCountMetricsCollectionForParquet() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "counts");
+    Table table = tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation);
+
+    List<SimpleRecord> expectedRecords = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c")
+    );
+    Dataset<Row> df = spark.createDataFrame(expectedRecords, SimpleRecord.class);
+    df.select("id", "data")
+        .coalesce(1)
+        .write()
+        .format("iceberg")
+        .option("write-format", "parquet")
+        .mode("append")
+        .save(tableLocation);
+
+    for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
+      DataFile file = task.file();
+      Assert.assertEquals(2, file.nullValueCounts().size());
+      Assert.assertEquals(2, file.valueCounts().size());
+      Assert.assertTrue(file.lowerBounds().isEmpty());
+      Assert.assertTrue(file.upperBounds().isEmpty());
+    }
+  }
+
+  @Test
+  public void testNoMetricsCollectionForParquet() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none");
+    Table table = tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation);
+
+    List<SimpleRecord> expectedRecords = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c")
+    );
+    Dataset<Row> df = spark.createDataFrame(expectedRecords, SimpleRecord.class);
+    df.select("id", "data")
+        .coalesce(1)
+        .write()
+        .format("iceberg")
+        .option("write-format", "parquet")
+        .mode("append")
+        .save(tableLocation);
+
+    for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
+      DataFile file = task.file();
+      Assert.assertTrue(file.nullValueCounts().isEmpty());
+      Assert.assertTrue(file.valueCounts().isEmpty());
+      Assert.assertTrue(file.lowerBounds().isEmpty());
+      Assert.assertTrue(file.upperBounds().isEmpty());
+    }
+  }
+
+  @Test
+  public void testCustomMetricCollectionForParquet() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "counts");
+    properties.put("write.metadata.metrics.column.id", "full");
+    Table table = tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation);
+
+    List<SimpleRecord> expectedRecords = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c")
+    );
+    Dataset<Row> df = spark.createDataFrame(expectedRecords, SimpleRecord.class);
+    df.select("id", "data")
+        .coalesce(1)
+        .write()
+        .format("iceberg")
+        .option("write-format", "parquet")
+        .mode("append")
+        .save(tableLocation);
+
+    Schema schema = table.schema();
+    Types.NestedField id = schema.findField("id");
+    for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
+      DataFile file = task.file();
+      Assert.assertEquals(2, file.nullValueCounts().size());
+      Assert.assertEquals(2, file.valueCounts().size());
+      Assert.assertEquals(1, file.lowerBounds().size());
+      Assert.assertTrue(file.lowerBounds().containsKey(id.fieldId()));
+      Assert.assertEquals(1, file.upperBounds().size());
+      Assert.assertTrue(file.upperBounds().containsKey(id.fieldId()));
+    }
+  }
+
+  @Test
+  public void testCustomMetricCollectionForNestedParquet() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(COMPLEX_SCHEMA)
+        .identity("strCol")
+        .build();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none");
+    properties.put("write.metadata.metrics.column.longCol", "counts");
+    properties.put("write.metadata.metrics.column.record.id", "full");
+    properties.put("write.metadata.metrics.column.record.data", "truncate(2)");
+    Table table = tables.create(COMPLEX_SCHEMA, spec, properties, tableLocation);
+
+    Iterable<InternalRow> rows = RandomData.generateSpark(COMPLEX_SCHEMA, 10, 0);
+    JavaRDD<InternalRow> rdd = sc.parallelize(Lists.newArrayList(rows));
+    Dataset<Row> df = spark.internalCreateDataFrame(JavaRDD.toRDD(rdd), convert(COMPLEX_SCHEMA), false);
+
+    df.coalesce(1).write()
+        .format("iceberg")
+        .option("write-format", "parquet")
+        .mode("append")
+        .save(tableLocation);
+
+    Schema schema = table.schema();
+    Types.NestedField longCol = schema.findField("longCol");
+    Types.NestedField recordId = schema.findField("record.id");
+    Types.NestedField recordData = schema.findField("record.data");
+    for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
+      DataFile file = task.file();
+
+      Map<Integer, Long> nullValueCounts = file.nullValueCounts();
+      Assert.assertEquals(3, nullValueCounts.size());
+      Assert.assertTrue(nullValueCounts.containsKey(longCol.fieldId()));
+      Assert.assertTrue(nullValueCounts.containsKey(recordId.fieldId()));
+      Assert.assertTrue(nullValueCounts.containsKey(recordData.fieldId()));
+
+      Map<Integer, Long> valueCounts = file.valueCounts();
+      Assert.assertEquals(3, valueCounts.size());
+      Assert.assertTrue(valueCounts.containsKey(longCol.fieldId()));
+      Assert.assertTrue(valueCounts.containsKey(recordId.fieldId()));
+      Assert.assertTrue(valueCounts.containsKey(recordData.fieldId()));
+
+      Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
+      Assert.assertEquals(2, lowerBounds.size());
+      Assert.assertTrue(lowerBounds.containsKey(recordId.fieldId()));
+      ByteBuffer recordDataLowerBound = lowerBounds.get(recordData.fieldId());
+      Assert.assertEquals(2, ByteBuffers.toByteArray(recordDataLowerBound).length);
+
+      Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
+      Assert.assertEquals(2, upperBounds.size());
+      Assert.assertTrue(upperBounds.containsKey(recordId.fieldId()));
+      ByteBuffer recordDataUpperBound = upperBounds.get(recordData.fieldId());
+      Assert.assertEquals(2, ByteBuffers.toByteArray(recordDataUpperBound).length);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces `MetricsConfig` that allows us to control metrics collection and resolves #173.

Currently, this logic is integrated only into the Parquet write path.