### PR TITLE
Add table UUID

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -20,10 +20,11 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopFileIO;
-import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
@@ -94,15 +95,22 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     if (!Objects.equal(currentMetadataLocation, newLocation)) {
       LOG.info("Refreshing table metadata from new version: {}", newLocation);
 
+      AtomicReference<TableMetadata> newMetadata = new AtomicReference<>();
       Tasks.foreach(newLocation)
           .retry(numRetries).exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */)
           .suppressFailureWhenFinished()
-          .run(metadataLocation -> {
-            this.currentMetadata = TableMetadataParser.read(
-                this, HadoopInputFile.fromLocation(metadataLocation, conf));
-            this.currentMetadataLocation = metadataLocation;
-            this.version = parseVersion(metadataLocation);
-          });
+          .run(metadataLocation -> newMetadata.set(
+              TableMetadataParser.read(this, io().newInputFile(metadataLocation))));
+
+      String newUUID = newMetadata.get().uuid();
+      if (currentMetadata != null) {
+        Preconditions.checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),
+            "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
+      }
+
+      this.currentMetadata = newMetadata.get();
+      this.currentMetadataLocation = newLocation;
+      this.version = parseVersion(newLocation);
     }
     this.shouldRefresh = false;
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -231,7 +231,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             Snapshot newSnapshot = apply();
             newSnapshotId.set(newSnapshot.snapshotId());
             TableMetadata updated = base.replaceCurrentSnapshot(newSnapshot);
-            taskOps.commit(base, updated);
+            // if the table UUID is missing, add it here. the UUID will be re-created each time this operation retries
+            // to ensure that if a concurrent operation assigns the UUID, this operation will not fail.
+            taskOps.commit(base, updated.withUUID());
           });
 
     } catch (RuntimeException e) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -49,6 +49,7 @@ public class TableMetadataParser {
 
   // visible for testing
   static final String FORMAT_VERSION = "format-version";
+  static final String TABLE_UUID = "table-uuid";
   static final String LOCATION = "location";
   static final String LAST_UPDATED_MILLIS = "last-updated-ms";
   static final String LAST_COLUMN_ID = "last-column-id";
@@ -65,9 +66,9 @@ public class TableMetadataParser {
 
   public static void write(TableMetadata metadata, OutputFile outputFile) {
     try (OutputStreamWriter writer = new OutputStreamWriter(
-            outputFile.location().endsWith(".gz") ?
-                    new GZIPOutputStream(outputFile.create()) :
-                    outputFile.create())) {
+        outputFile.location().endsWith(".gz") ?
+            new GZIPOutputStream(outputFile.create()) :
+            outputFile.create())) {
       JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
       generator.useDefaultPrettyPrinter();
       toJson(metadata, generator);
@@ -97,6 +98,7 @@ public class TableMetadataParser {
     generator.writeStartObject();
 
     generator.writeNumberField(FORMAT_VERSION, TableMetadata.TABLE_FORMAT_VERSION);
+    generator.writeStringField(TABLE_UUID, metadata.uuid());
     generator.writeStringField(LOCATION, metadata.location());
     generator.writeNumberField(LAST_UPDATED_MILLIS, metadata.lastUpdatedMillis());
     generator.writeNumberField(LAST_COLUMN_ID, metadata.lastColumnId());
@@ -161,6 +163,7 @@ public class TableMetadataParser {
     Preconditions.checkArgument(formatVersion == TableMetadata.TABLE_FORMAT_VERSION,
         "Cannot read unsupported version %d", formatVersion);
 
+    String uuid = JsonUtil.getStringOrNull(TABLE_UUID, node);
     String location = JsonUtil.getString(LOCATION, node);
     int lastAssignedColumnId = JsonUtil.getInt(LAST_COLUMN_ID, node);
     Schema schema = SchemaParser.fromJson(node.get(SCHEMA));
@@ -215,7 +218,7 @@ public class TableMetadataParser {
       }
     }
 
-    return new TableMetadata(ops, file, location,
+    return new TableMetadata(ops, file, uuid, location,
         lastUpdatedMillis, lastAssignedColumnId, schema, defaultSpecId, specs, properties,
         currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()));
   }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -94,8 +94,15 @@ public class HadoopTableOperations implements TableOperations {
       throw new RuntimeIOException(e, "Failed to get file system for path: %s", metadataFile);
     }
     this.version = ver;
-    this.currentMetadata = TableMetadataParser.read(this,
-        io().newInputFile(metadataFile.toString()));
+
+    TableMetadata newMetadata = TableMetadataParser.read(this, io().newInputFile(metadataFile.toString()));
+    String newUUID = newMetadata.uuid();
+    if (currentMetadata != null) {
+      Preconditions.checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),
+          "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
+    }
+
+    this.currentMetadata = newMetadata;
     this.shouldRefresh = false;
     return currentMetadata;
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataJson.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.iceberg.TableMetadata.SnapshotLogEntry;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.types.Types;
@@ -80,7 +81,7 @@ public class TestTableMetadataJson {
         .add(new SnapshotLogEntry(currentSnapshot.timestampMillis(), currentSnapshot.snapshotId()))
         .build();
 
-    TableMetadata expected = new TableMetadata(ops, null, "s3://bucket/test/location",
+    TableMetadata expected = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
         ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog);
@@ -89,6 +90,8 @@ public class TestTableMetadataJson {
     TableMetadata metadata = TableMetadataParser.fromJson(ops, null,
         JsonUtil.mapper().readValue(asJson, JsonNode.class));
 
+    Assert.assertEquals("Table UUID should match",
+        expected.uuid(), metadata.uuid());
     Assert.assertEquals("Table location should match",
         expected.location(), metadata.location());
     Assert.assertEquals("Last column ID should match",
@@ -139,7 +142,7 @@ public class TestTableMetadataJson {
 
     List<SnapshotLogEntry> reversedSnapshotLog = Lists.newArrayList();
 
-    TableMetadata expected = new TableMetadata(ops, null, "s3://bucket/test/location",
+    TableMetadata expected = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
         ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog);
@@ -164,7 +167,7 @@ public class TestTableMetadataJson {
   }
 
   @Test
-  public void testBackwardCompatMissingPartitionSpecList() throws Exception {
+  public void testBackwardCompat() throws Exception {
     Schema schema = new Schema(
         Types.NestedField.required(1, "x", Types.LongType.get()),
         Types.NestedField.required(2, "y", Types.LongType.get()),
@@ -182,16 +185,16 @@ public class TestTableMetadataJson {
         ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
         new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
 
-
-    TableMetadata expected = new TableMetadata(ops, null, "s3://bucket/test/location",
+    TableMetadata expected = new TableMetadata(ops, null, null, "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 6, ImmutableList.of(spec),
         ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of());
 
     String asJson = toJsonWithoutSpecList(expected);
-    TableMetadata metadata = TableMetadataParser.fromJson(ops, null,
-        JsonUtil.mapper().readValue(asJson, JsonNode.class));
+    TableMetadata metadata = TableMetadataParser
+        .fromJson(ops, null, JsonUtil.mapper().readValue(asJson, JsonNode.class));
 
+    Assert.assertNull("Table UUID should not be assigned", metadata.uuid());
     Assert.assertEquals("Table location should match",
         expected.location(), metadata.location());
     Assert.assertEquals("Last column ID should match",

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -330,7 +330,8 @@ Table metadata consists of the following fields:
 
 | Field | Description |
 | ----- | ----------- |
-| **`format-version`** | An integer version number for the format. Currently, this is always 1. |
+| **`format-version`** | An integer version number for the format. Currently, this is always 1. Implementations must throw an exception if a table's version is higher than the supported version. |
+| **`table-uuid`** | A UUID that identifies the table, generated when the table is created. Implementations must throw an exception if a table's UUID does not match the expected UUID after refreshing metadata. |
 | **`location`**| The table’s base location. This is used by writers to determine where to store data files, manifest files, and table metadata files. |
 | **`last-updated-ms`**| Timestamp in milliseconds from the unix epoch when the table was last updated. Each table metadata file should update this field just before writing. |
 | **`last-column-id`**| An integer; the highest assigned column ID for the table. This is used to ensure columns are always assigned an unused ID when evolving schemas. |
@@ -588,6 +589,7 @@ Table metadata is serialized as a JSON object according to the following table. 
 |Metadata field|JSON representation|Example|
 |--- |--- |--- |
 |**`format-version`**|`JSON int`|`1`|
+|**`table-uuid`**|`JSON string`|`"fb072c92-a02b-11e9-ae9c-1bb7bc9eca94"`|
 |**`location`**|`JSON string`|`"s3://b/wh/data.db/table"`|
 |**`last-updated-ms`**|`JSON long`|`1515100955770`|
 |**`last-column-id`**|`JSON int`|`22`|


### PR DESCRIPTION
This adds a UUID to table metadata that is randomly generated when new table metadata is created. Existing tables without a UUID will assign a UUID on a successful snapshot commit.