### PR TITLE
Exclude transitive artifacts already part of orc-core fat jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -294,6 +294,9 @@ project(':iceberg-orc') {
     compile("org.apache.orc:orc-core::nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
+      // These artifacts are shaded and included in the orc-core fat jar
+      exclude group: 'com.google.protobuf', module: 'protobuf-java'
+      exclude group: 'org.apache.hive', module: 'hive-storage-api'
     }
 
     compileOnly("org.apache.hadoop:hadoop-client") {
@@ -415,8 +418,6 @@ project(':iceberg-spark-runtime') {
     relocate 'org.codehaus.jackson', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
-    relocate 'org.apache.hive', 'org.apache.iceberg.shaded.org.apache.hive'
-    relocate 'org.apache.hadoop.hive', 'org.apache.iceberg.shaded.org.apache.hadoop.hive'
 
     archiveName = "iceberg-spark-runtime-${version}.${extension}"
   }


### PR DESCRIPTION
We were relocating hive classes in spark-runtime artifact. This relocated classes which were not part our dependency graph. [Shadow plugin has this issue]. These Hive classes were coming from hive-storage-api artifact which is a transitive dependency of orc-core. orc-core, being a fat jar, already includes hive-storage-api and protobuf-java jars, which are already shaded.  A simple fix in this case is to exclude storage-api  from orc-core as this is already part of orc-core

Fixes #260

Note: protobuf is also excluded just because it is already part of orc-core. It is not related to the issue reported in #260