### PR TITLE
Publish resolved versions in POMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,11 @@ subprojects {
     publications {
       nebula(MavenPublication) {
         from components.java
+        versionMapping {
+          allVariants {
+            fromResolutionResult()
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Before this PR

#241 converted the project to use GCV, but didn't add an equivalent functionality to [nebula.maven-resolved-dependencies](https://github.com/nebula-plugins/nebula-publishing-plugin#nebulamaven-resolved-dependencies), hence some dependencies are missing a version in the POM. This in turn makes the POM technically invalid and unparseable by some maven clients like aether.

## After this PR

Use a gradle feature that [exposes resolved versions](https://docs.gradle.org/5.2/release-notes.html#maven-publication-can-expose-resolved-versions) in the POMs.
This ensures the POM contains the actual versions you resolved, and that no entries are missing a version.

<details>
<summary>Example POM diff</summary>
<p>


```diff
--- core/build/publications/nebula/pom-default.old.xml	2019-07-08 16:54:27.000000000 +0100
+++ core/build/publications/nebula/pom-default.xml	2019-07-08 16:54:32.000000000 +0100
@@ -4,5 +4,5 @@
   <groupId>org.apache.iceberg</groupId>
   <artifactId>iceberg-core</artifactId>
-  <version>08e3f2d</version>
+  <version>08e3f2d.dirty</version>
   <name>iceberg-core</name>
   <dependencyManagement>
@@ -17,5 +17,5 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
+        <version>1.7.25</version>
         <scope>compile</scope>
       </dependency>
@@ -116,4 +116,5 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
       <scope>compile</scope>
       <exclusions>
@@ -127,4 +128,5 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>28.0-jre</version>
       <scope>compile</scope>
       <exclusions>
@@ -138,5 +140,5 @@
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
-      <version>08e3f2d</version>
+      <version>08e3f2d.dirty</version>
       <scope>compile</scope>
       <exclusions>
@@ -150,5 +152,5 @@
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-common</artifactId>
-      <version>08e3f2d</version>
+      <version>08e3f2d.dirty</version>
       <scope>compile</scope>
       <exclusions>
@@ -162,4 +164,5 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <version>1.8.2</version>
       <scope>compile</scope>
       <exclusions>
@@ -201,4 +204,5 @@
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
+      <version>2.7.0</version>
       <scope>compile</scope>
       <exclusions>
```


(ignore the .dirty suffixes, that'd just since I modified the working copy)

</p>
</details