### PR TITLE
Fix iceberg-spark-runtime transitive dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -382,10 +382,6 @@ project(':iceberg-pig') {
 project(':iceberg-spark-runtime') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
-  shadowJar {
-    from(project.sourceSets.main.output)
-  }
-
   tasks.build.dependsOn tasks.shadowJar
   tasks.install.dependsOn tasks.shadowJar
   tasks.javadocJar.dependsOn tasks.shadowJar
@@ -403,10 +399,13 @@ project(':iceberg-spark-runtime') {
   }
 
   dependencies {
-    compile project(':iceberg-spark')
+    compileOnly project(':iceberg-spark')
   }
 
   shadowJar {
+    // shade compileOnly dependencies to avoid including in transitive dependencies
+    configurations = [project.configurations.compileOnly]
+
     zip64 true
 
     // Relocate dependencies to avoid conflicts
@@ -420,7 +419,7 @@ project(':iceberg-spark-runtime') {
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
     relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
     // relocate Avro's jackson dependency to share parquet-jackson locations
-    relocate 'org.codehaus.jackson', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+    relocate 'org.codehaus.jackson', 'org.apache.iceberg.shaded.org.apache.parquet.shaded.org.codehaus.jackson'
     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
 


### PR DESCRIPTION
This updates the iceberg-spark-runtime Jar to fix dependency leaks.

Now, compileOnly dependencies (and transitive dependencies from compileOnly) are shaded and relocated. Compile dependencies remain declared compile dependencies in the output artifact. The only compile dependencies are slf4j and guava. All other dependencies are shaded.