### PR TITLE
Add Spark application ID to snapshot summary

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -74,7 +74,8 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
     Configuration conf = new Configuration(lazyBaseConf());
     Table table = getTableAndResolveHadoopConfiguration(options, conf);
     validateWriteSchema(table.schema(), dsStruct);
-    return Optional.of(new Writer(table, options, mode == SaveMode.Overwrite));
+    String appId = lazySparkSession().sparkContext().applicationId();
+    return Optional.of(new Writer(table, options, mode == SaveMode.Overwrite, appId));
   }
 
   @Override
@@ -89,7 +90,8 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
     // Spark 2.4.x passes runId to createStreamWriter instead of real queryId,
     // so we fetch it directly from sparkContext to make writes idempotent
     String queryId = lazySparkSession().sparkContext().getLocalProperty(StreamExecution.QUERY_ID_KEY());
-    return new StreamingWriter(table, options, queryId, mode);
+    String appId = lazySparkSession().sparkContext().applicationId();
+    return new StreamingWriter(table, options, queryId, mode, appId);
   }
 
   protected Table findTable(DataSourceOptions options, Configuration conf) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
@@ -43,8 +43,8 @@ public class StreamingWriter extends Writer implements StreamWriter {
   private final String queryId;
   private final OutputMode mode;
 
-  StreamingWriter(Table table, DataSourceOptions options, String queryId, OutputMode mode) {
-    super(table, options, false);
+  StreamingWriter(Table table, DataSourceOptions options, String queryId, OutputMode mode, String applicationId) {
+    super(table, options, false, applicationId);
     this.queryId = queryId;
     this.mode = mode;
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -40,9 +40,9 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PendingUpdate;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -85,13 +85,15 @@ class Writer implements DataSourceWriter {
   private final FileIO fileIo;
   private final EncryptionManager encryptionManager;
   private final boolean replacePartitions;
+  private final String applicationId;
 
-  Writer(Table table, DataSourceOptions options, boolean replacePartitions) {
+  Writer(Table table, DataSourceOptions options, boolean replacePartitions, String applicationId) {
     this.table = table;
     this.format = getFileFormat(table.properties(), options);
     this.fileIo = table.io();
     this.encryptionManager = table.encryption();
     this.replacePartitions = replacePartitions;
+    this.applicationId = applicationId;
   }
 
   private FileFormat getFileFormat(Map<String, String> tableProperties, DataSourceOptions options) {
@@ -116,8 +118,11 @@ class Writer implements DataSourceWriter {
     }
   }
 
-  protected void commitOperation(PendingUpdate<?> operation, int numFiles, String description) {
+  protected void commitOperation(SnapshotUpdate<?> operation, int numFiles, String description) {
     LOG.info("Committing {} with {} files to table {}", description, numFiles, table);
+    if (applicationId != null) {
+      operation.set("spark.app.id", applicationId);
+    }
     long start = System.currentTimeMillis();
     operation.commit(); // abort is automatically called if this fails
     long duration = System.currentTimeMillis() - start;


### PR DESCRIPTION
This adds a property, "spark.app.id" to the snapshot summary to automatically track the Spark application that wrote a snapshot.