### PR TITLE
Add projectStrict for Dates and Timestamps

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Projections.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Projections.java
@@ -221,9 +221,10 @@ public class Projections {
         // similarly, if partitioning by day(ts) and hour(ts), the more restrictive
         // projection should be used. ts = 2019-01-01T01:00:00 produces day=2019-01-01 and
         // hour=2019-01-01-01. the value will be in 2019-01-01-01 and not in 2019-01-01-02.
-        result = Expressions.and(
-            result,
-            ((Transform<T, ?>) part.transform()).project(part.name(), pred));
+        UnboundPredicate<?> inclusiveProjection = ((Transform<T, ?>) part.transform()).project(part.name(), pred);
+        if (inclusiveProjection != null) {
+          result = Expressions.and(result, inclusiveProjection);
+        }
       }
 
       return result;
@@ -251,9 +252,10 @@ public class Projections {
         // any timestamp where either projection predicate is true must match the original
         // predicate. For example, ts = 2019-01-01T03:00:00 matches the hour projection but not
         // the day, but does match the original predicate.
-        result = Expressions.or(
-            result,
-            ((Transform<T, ?>) part.transform()).projectStrict(part.name(), pred));
+        UnboundPredicate<?> strictProjection = ((Transform<T, ?>) part.transform()).projectStrict(part.name(), pred);
+        if (strictProjection != null) {
+          result = Expressions.or(result, strictProjection);
+        }
       }
 
       return result;

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -150,48 +150,48 @@ public class ResidualEvaluator implements Serializable {
 
     @Override
     public <T> Expression isNull(BoundReference<T> ref) {
-      return (ref.get(struct) == null) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (ref.get(struct) == null) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression notNull(BoundReference<T> ref) {
-      return (ref.get(struct) != null) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (ref.get(struct) != null) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression lt(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
-      return (cmp.compare(ref.get(struct), lit.value()) < 0) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (cmp.compare(ref.get(struct), lit.value()) < 0) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression ltEq(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
-      return (cmp.compare(ref.get(struct), lit.value()) <= 0) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (cmp.compare(ref.get(struct), lit.value()) <= 0) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression gt(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
-      return (cmp.compare(ref.get(struct), lit.value()) > 0) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (cmp.compare(ref.get(struct), lit.value()) > 0) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression gtEq(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
-      return (cmp.compare(ref.get(struct), lit.value()) >= 0) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (cmp.compare(ref.get(struct), lit.value()) >= 0) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression eq(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
-      return (cmp.compare(ref.get(struct), lit.value()) == 0) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (cmp.compare(ref.get(struct), lit.value()) == 0) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression notEq(BoundReference<T> ref, Literal<T> lit) {
       Comparator<T> cmp = lit.comparator();
-      return (cmp.compare(ref.get(struct), lit.value()) != 0) ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+      return (cmp.compare(ref.get(struct), lit.value()) != 0) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -73,8 +73,11 @@ enum Dates implements Transform<Integer, Integer> {
   }
 
   @Override
-  public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Integer> predicate) {
-    return null;
+  public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Integer> pred) {
+    if (pred.op() == NOT_NULL || pred.op() == IS_NULL) {
+      return Expressions.predicate(pred.op(), fieldName);
+    }
+    return ProjectionUtil.truncateStrictToInteger(fieldName, pred, this);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -77,7 +77,7 @@ enum Dates implements Transform<Integer, Integer> {
     if (pred.op() == NOT_NULL || pred.op() == IS_NULL) {
       return Expressions.predicate(pred.op(), fieldName);
     }
-    return ProjectionUtil.truncateStrictToInteger(fieldName, pred, this);
+    return ProjectionUtil.truncateIntegerStrictToInteger(fieldName, pred, this);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -77,7 +77,7 @@ enum Dates implements Transform<Integer, Integer> {
     if (pred.op() == NOT_NULL || pred.op() == IS_NULL) {
       return Expressions.predicate(pred.op(), fieldName);
     }
-    return ProjectionUtil.truncateIntegerStrictToInteger(fieldName, pred, this);
+    return ProjectionUtil.truncateIntegerStrict(fieldName, pred, this);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -52,6 +52,23 @@ class ProjectionUtil {
     }
   }
 
+  static <T> UnboundPredicate<Integer> truncateStrictToInteger(
+      String name, BoundPredicate<T> pred, Transform<T, Integer> transform) {
+    T boundary = pred.literal().value();
+    switch (pred.op()) {
+      case LT:
+      case LT_EQ:
+        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+      case GT:
+      case GT_EQ:
+        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+      case NOT_EQ:
+        return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      default:
+        return null;
+    }
+  }
+
   static <T> UnboundPredicate<T> truncateLong(
       String name, BoundPredicate<Long> pred, Transform<Long, T> transform) {
     long boundary = pred.literal().value();

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -52,16 +52,57 @@ class ProjectionUtil {
     }
   }
 
-  static <T> UnboundPredicate<Integer> truncateStrictToInteger(
-      String name, BoundPredicate<T> pred, Transform<T, Integer> transform) {
-    T boundary = pred.literal().value();
+  static UnboundPredicate<Integer> truncateIntegerStrictToInteger(
+      String name, BoundPredicate<Integer> pred, Transform<Integer, Integer> transform) {
+    Integer boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
-      case LT_EQ:
         return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+      case LT_EQ:
+        // Checking if the timestamp is at the date boundary
+        if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+        } else {
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+        }
       case GT:
-      case GT_EQ:
         return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+      case GT_EQ:
+        // Checking if the timestamp is at the date boundary
+        if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+        } else {
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+        }
+      case NOT_EQ:
+        return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      default:
+        return null;
+    }
+  }
+
+  static UnboundPredicate<Integer> truncateLongStrictToInteger(
+      String name, BoundPredicate<Long> pred, Transform<Long, Integer> transform) {
+    Long boundary = pred.literal().value();
+    switch (pred.op()) {
+      case LT:
+        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+      case LT_EQ:
+        // Checking if the timestamp is at the date boundary
+        if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+        } else {
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+        }
+      case GT:
+        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+      case GT_EQ:
+        // Checking if the timestamp is at the date boundary
+        if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+        } else {
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+        }
       case NOT_EQ:
         return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
       default:

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -52,21 +52,13 @@ class ProjectionUtil {
     }
   }
 
-  static <T> UnboundPredicate<T> truncateIntegerStrict(
-      String name, BoundPredicate<Integer> pred, Transform<Integer, T> transform) {
+  static UnboundPredicate<Integer> truncateIntegerStrict(
+      String name, BoundPredicate<Integer> pred, Transform<Integer, Integer> transform) {
     int boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
-        // Checking if the literal is at the lower partition boundary
-        if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
-          // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be < 2019-07-02
-          return predicate(Expression.Operation.LT, name, transform.apply(boundary - 1));
-        } else {
-          // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
-          // the predicate can be <= 2019-07-01
-          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1));
-        }
+        // predicate would be <= the previous partition
+        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
       case LT_EQ:
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
@@ -79,16 +71,8 @@ class ProjectionUtil {
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
         }
       case GT:
-        // Checking if the literal is at the upper partition boundary
-        if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
-          // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be > 2019-07-02
-          return predicate(Expression.Operation.GT, name, transform.apply(boundary + 1));
-        } else {
-          // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
-          // the predicate can be >= 2019-07-03
-          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1));
-        }
+        // predicate would be >= the next partition
+        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
       case GT_EQ:
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
@@ -110,21 +94,13 @@ class ProjectionUtil {
     }
   }
 
-  static <T> UnboundPredicate<T> truncateLongStrict(
-      String name, BoundPredicate<Long> pred, Transform<Long, T> transform) {
+  static UnboundPredicate<Integer> truncateLongStrict(
+      String name, BoundPredicate<Long> pred, Transform<Long, Integer> transform) {
     long boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
-        // Checking if the literal is at the lower partition boundary
-        if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
-          // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be < 2019-07-02
-          return predicate(Expression.Operation.LT, name, transform.apply(boundary - 1L));
-        } else {
-          // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
-          // the predicate can be <= 2019-07-01
-          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1L));
-        }
+        // predicate would be <= the previous partition
+        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
       case LT_EQ:
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
@@ -137,16 +113,8 @@ class ProjectionUtil {
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
         }
       case GT:
-        // Checking if the literal is at the upper partition boundary
-        if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
-          // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be > 2019-07-02
-          return predicate(Expression.Operation.GT, name, transform.apply(boundary + 1L));
-        } else {
-          // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
-          // the predicate can be >= 2019-07-03
-          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1L));
-        }
+        // predicate would be >= the next partition
+        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
       case GT_EQ:
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -52,25 +52,35 @@ class ProjectionUtil {
     }
   }
 
-  static UnboundPredicate<Integer> truncateIntegerStrictToInteger(
-      String name, BoundPredicate<Integer> pred, Transform<Integer, Integer> transform) {
-    Integer boundary = pred.literal().value();
+  static <T> UnboundPredicate<T> truncateIntegerStrict(
+      String name, BoundPredicate<Integer> pred, Transform<Integer, T> transform) {
+    int boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+        // Checking if the literal is at the lower partition boundary
+        if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.LT, name, transform.apply(boundary - 1));
+        } else {
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1));
+        }
       case LT_EQ:
-        // Checking if the timestamp is at the date boundary
+        // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
-          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+          return predicate(Expression.Operation.LT, name, transform.apply(boundary));
         } else {
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
         }
       case GT:
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+        // Checking if the literal is at the upper partition boundary
+        if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.GT, name, transform.apply(boundary + 1));
+        } else {
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1));
+        }
       case GT_EQ:
-        // Checking if the timestamp is at the date boundary
+        // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
-          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+          return predicate(Expression.Operation.GT, name, transform.apply(boundary));
         } else {
           return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
         }
@@ -81,25 +91,35 @@ class ProjectionUtil {
     }
   }
 
-  static UnboundPredicate<Integer> truncateLongStrictToInteger(
-      String name, BoundPredicate<Long> pred, Transform<Long, Integer> transform) {
-    Long boundary = pred.literal().value();
+  static <T> UnboundPredicate<T> truncateLongStrict(
+      String name, BoundPredicate<Long> pred, Transform<Long, T> transform) {
+    long boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+        // Checking if the literal is at the lower partition boundary
+        if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.LT, name, transform.apply(boundary - 1L));
+        } else {
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1L));
+        }
       case LT_EQ:
-        // Checking if the timestamp is at the date boundary
+        // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
-          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
+          return predicate(Expression.Operation.LT, name, transform.apply(boundary));
         } else {
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
         }
       case GT:
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+        // Checking if the literal is at the upper partition boundary
+        if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
+          return predicate(Expression.Operation.GT, name, transform.apply(boundary + 1L));
+        } else {
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1L));
+        }
       case GT_EQ:
-        // Checking if the timestamp is at the date boundary
+        // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
-          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
+          return predicate(Expression.Operation.GT, name, transform.apply(boundary));
         } else {
           return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
         }

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -63,8 +63,8 @@ class ProjectionUtil {
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
           // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be < 2019-07-02
-          return predicate(Expression.Operation.LT, name, transform.apply(boundary));
+          // the predicate can be < 2019-07-01
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
         } else {
           // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
           // the predicate can be <= 2019-07-02
@@ -77,8 +77,8 @@ class ProjectionUtil {
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
           // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be > 2019-07-02
-          return predicate(Expression.Operation.GT, name, transform.apply(boundary));
+          // the predicate can be >= 2019-07-03
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
         } else {
           // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
           // the predicate can be >= 2019-07-02
@@ -105,8 +105,8 @@ class ProjectionUtil {
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
           // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be < 2019-07-02
-          return predicate(Expression.Operation.LT, name, transform.apply(boundary));
+          // the predicate can be <= 2019-07-01
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) -1);
         } else {
           // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
           // the predicate can be <= 2019-07-02
@@ -119,8 +119,8 @@ class ProjectionUtil {
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
           // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
-          // the predicate can be > 2019-07-02
-          return predicate(Expression.Operation.GT, name, transform.apply(boundary));
+          // the predicate can be >= 2019-07-03
+          return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary) + 1);
         } else {
           // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
           // the predicate can be >= 2019-07-02

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -106,7 +106,7 @@ class ProjectionUtil {
         if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
           // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
           // the predicate can be <= 2019-07-01
-          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) -1);
+          return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary) - 1);
         } else {
           // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
           // the predicate can be <= 2019-07-02

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -59,29 +59,45 @@ class ProjectionUtil {
       case LT:
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
+          // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be < 2019-07-02
           return predicate(Expression.Operation.LT, name, transform.apply(boundary - 1));
         } else {
+          // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
+          // the predicate can be <= 2019-07-01
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1));
         }
       case LT_EQ:
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
+          // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be < 2019-07-02
           return predicate(Expression.Operation.LT, name, transform.apply(boundary));
         } else {
+          // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
+          // the predicate can be <= 2019-07-02
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
         }
       case GT:
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1).equals(transform.apply(boundary))) {
+          // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be > 2019-07-02
           return predicate(Expression.Operation.GT, name, transform.apply(boundary + 1));
         } else {
+          // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
+          // the predicate can be >= 2019-07-03
           return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1));
         }
       case GT_EQ:
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1).equals(transform.apply(boundary))) {
+          // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be > 2019-07-02
           return predicate(Expression.Operation.GT, name, transform.apply(boundary));
         } else {
+          // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
+          // the predicate can be >= 2019-07-02
           return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
         }
       case NOT_EQ:
@@ -101,29 +117,45 @@ class ProjectionUtil {
       case LT:
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
+          // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be < 2019-07-02
           return predicate(Expression.Operation.LT, name, transform.apply(boundary - 1L));
         } else {
+          // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
+          // the predicate can be <= 2019-07-01
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1L));
         }
       case LT_EQ:
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
+          // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be < 2019-07-02
           return predicate(Expression.Operation.LT, name, transform.apply(boundary));
         } else {
+          // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
+          // the predicate can be <= 2019-07-02
           return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
         }
       case GT:
         // Checking if the literal is at the upper partition boundary
         if (transform.apply(boundary + 1L).equals(transform.apply(boundary))) {
+          // Literal is not at upper boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be > 2019-07-02
           return predicate(Expression.Operation.GT, name, transform.apply(boundary + 1L));
         } else {
+          // Literal is not at upper boundary, for eg: 2019-07-02T23:59:59.99999
+          // the predicate can be >= 2019-07-03
           return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1L));
         }
       case GT_EQ:
         // Checking if the literal is at the lower partition boundary
         if (transform.apply(boundary - 1L).equals(transform.apply(boundary))) {
+          // Literal is not at lower boundary, for eg: 2019-07-02T02:12:34.0000
+          // the predicate can be > 2019-07-02
           return predicate(Expression.Operation.GT, name, transform.apply(boundary));
         } else {
+          // Literal was at the lower boundary, for eg: 2019-07-02T00:00:00.0000
+          // the predicate can be >= 2019-07-02
           return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
         }
       case NOT_EQ:

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -86,6 +86,9 @@ class ProjectionUtil {
         }
       case NOT_EQ:
         return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      case EQ:
+        // there is no predicate that guarantees equality because adjacent ints transform to the same value
+        return null;
       default:
         return null;
     }
@@ -125,6 +128,9 @@ class ProjectionUtil {
         }
       case NOT_EQ:
         return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      case EQ:
+        // there is no predicate that guarantees equality because adjacent longs transform to the same value
+        return null;
       default:
         return null;
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -76,8 +76,11 @@ enum Timestamps implements Transform<Long, Integer> {
   }
 
   @Override
-  public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Long> predicate) {
-    return null;
+  public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Long> pred) {
+    if (pred.op() == NOT_NULL || pred.op() == IS_NULL) {
+      return Expressions.predicate(pred.op(), fieldName);
+    }
+    return ProjectionUtil.truncateStrictToInteger(fieldName, pred, this);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -80,7 +80,7 @@ enum Timestamps implements Transform<Long, Integer> {
     if (pred.op() == NOT_NULL || pred.op() == IS_NULL) {
       return Expressions.predicate(pred.op(), fieldName);
     }
-    return ProjectionUtil.truncateStrictToInteger(fieldName, pred, this);
+    return ProjectionUtil.truncateLongStrictToInteger(fieldName, pred, this);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -80,7 +80,7 @@ enum Timestamps implements Transform<Long, Integer> {
     if (pred.op() == NOT_NULL || pred.op() == IS_NULL) {
       return Expressions.predicate(pred.op(), fieldName);
     }
-    return ProjectionUtil.truncateLongStrictToInteger(fieldName, pred, this);
+    return ProjectionUtil.truncateLongStrict(fieldName, pred, this);
   }
 
   @Override

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -78,7 +78,7 @@ public class TestDatesProjection {
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016-12");
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "2017-01");
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "2017-01");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-02");
     // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01");
@@ -90,7 +90,7 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
-    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "2017-12");
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11");
     // bound should include the same month for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
@@ -160,7 +160,7 @@ public class TestDatesProjection {
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "2017");
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "2017");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
     // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
@@ -172,7 +172,7 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
-    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "2017");
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
     // bound should include the same year for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -75,9 +75,8 @@ public class TestDatesProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016-12");
-    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "2017-01");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2016-12");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-02");
-    // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01");
   }
@@ -88,10 +87,9 @@ public class TestDatesProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11");
-    // bound should include the same month for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "2017-12");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12");
   }
 
@@ -151,9 +149,8 @@ public class TestDatesProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "2017");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2016");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
-    // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
   }
@@ -164,10 +161,9 @@ public class TestDatesProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
-    // bound should include the same year for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "2017");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -56,6 +56,20 @@ public class TestDatesProjection {
     Assert.assertEquals(expectedLiteral, output);
   }
 
+  public void assertProjectionStrictValue(PartitionSpec spec, UnboundPredicate<?> filter,
+                                          Expression.Operation expectedOp) {
+
+    Expression projection = Projections.strict(spec).project(filter);
+    Assert.assertEquals(projection.op(), expectedOp);
+  }
+
+  public void assertProjectionInclusiveValue(PartitionSpec spec, UnboundPredicate<?> filter,
+                                             Expression.Operation expectedOp) {
+
+    Expression projection = Projections.inclusive(spec).project(filter);
+    Assert.assertEquals(projection.op(), expectedOp);
+  }
+
   public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
                                         Expression.Operation expectedOp, String expectedLiteral) {
     Expression projection = Projections.inclusive(spec).project(filter);
@@ -79,6 +93,7 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-02");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -91,6 +106,7 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -103,6 +119,7 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -115,6 +132,7 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -129,6 +147,7 @@ public class TestDatesProjection {
     // should be the same date for >=
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01-01");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -141,6 +160,7 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-01-02");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-01-01");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -153,6 +173,7 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -165,6 +186,7 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -177,6 +199,7 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -189,5 +212,6 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iceberg.transforms;
 
 import org.apache.iceberg.PartitionSpec;
@@ -11,15 +30,20 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
-import static org.apache.iceberg.expressions.Expressions.*;
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.greaterThan;
+import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public class TestDatesProjection {
   private static final Types.DateType TYPE = Types.DateType.get();
-  private static final Schema SCHEMA = new Schema(
-    optional(1, "date", TYPE));
+  private static final Schema SCHEMA = new Schema(optional(1, "date", TYPE));
 
-  public void assertProjectionStrict(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+  public void assertProjectionStrict(PartitionSpec spec, UnboundPredicate<?> filter,
+                                     Expression.Operation expectedOp, String expectedLiteral) {
 
     Expression projection = Projections.strict(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
@@ -33,7 +57,8 @@ public class TestDatesProjection {
 
   }
 
-  public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+  public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
+                                        Expression.Operation expectedOp, String expectedLiteral) {
     Expression projection = Projections.inclusive(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -54,7 +54,6 @@ public class TestDatesProjection {
     Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
     Assert.assertEquals(expectedLiteral, output);
-
   }
 
   public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
@@ -68,7 +67,6 @@ public class TestDatesProjection {
     Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
     Assert.assertEquals(expectedLiteral, output);
-
   }
 
   @Test
@@ -82,7 +80,6 @@ public class TestDatesProjection {
     // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01");
-
   }
 
   @Test
@@ -96,7 +93,6 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "2017-12");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12");
-
   }
 
   @Test
@@ -109,7 +105,6 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12");
-
   }
 
   @Test
@@ -122,7 +117,6 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12");
-
   }
 
   @Test
@@ -137,7 +131,6 @@ public class TestDatesProjection {
     // should be the same date for >=
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01-01");
-
   }
 
   @Test
@@ -150,7 +143,6 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-01-02");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-01-01");
-
   }
 
   @Test
@@ -164,7 +156,6 @@ public class TestDatesProjection {
     // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
-
   }
 
   @Test
@@ -178,7 +169,6 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
-
   }
 
   @Test
@@ -191,7 +181,6 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017");
-
   }
 
   @Test
@@ -204,7 +193,5 @@ public class TestDatesProjection {
     assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017");
-
   }
-
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -29,7 +29,7 @@ public class TestDatesProjection {
     Literal literal = predicate.literal();
     Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
-    Assert.assertEquals(output, expectedLiteral);
+    Assert.assertEquals(expectedLiteral, output);
 
   }
 
@@ -42,7 +42,7 @@ public class TestDatesProjection {
     Literal literal = predicate.literal();
     Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
-    Assert.assertEquals(output, expectedLiteral);
+    Assert.assertEquals(expectedLiteral, output);
 
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -48,7 +48,7 @@ public class TestDatesProjection {
     Expression projection = Projections.strict(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
 
-    Assert.assertEquals(predicate.op(), expectedOp);
+    Assert.assertEquals(expectedOp, predicate.op());
 
     Literal literal = predicate.literal();
     Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
@@ -77,8 +77,8 @@ public class TestDatesProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016-12");
-    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2016-12");
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-02");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "2017-01");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "2017-01");
     // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01");
@@ -90,11 +90,11 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
-    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "2017-12");
     // bound should include the same month for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "2017-12");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12");
 
   }
@@ -142,14 +142,14 @@ public class TestDatesProjection {
 
   @Test
   public void testDayInclusive() {
-    Integer date = (Integer) Literal.of("2017-12-01").to(TYPE).value();
+    Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
 
-    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11-30");
-    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12-01");
-    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-12-02");
-    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12-01");
-    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12-01");
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016-12-31");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-01-01");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-01-02");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-01-01");
 
   }
 
@@ -159,8 +159,8 @@ public class TestDatesProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
     assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "2017");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "2017");
     // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
@@ -172,11 +172,11 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
-    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "2017");
     // bound should include the same year for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "2017");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
 
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -126,7 +126,7 @@ public class TestDatesProjection {
   }
 
   @Test
-  public void testDayStrictLowerBound() {
+  public void testDayStrict() {
     Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
 
@@ -137,21 +137,6 @@ public class TestDatesProjection {
     // should be the same date for >=
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01-01");
-
-  }
-
-  @Test
-  public void testDayStrictUpperBound() {
-    Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
-
-    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-12-30");
-    // should be the same date for <=
-    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12-31");
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01-01");
-    // should be the same date for >=
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12-31");
-    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12-31");
 
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -1,0 +1,200 @@
+package org.apache.iceberg.transforms;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
+import static org.apache.iceberg.expressions.Expressions.*;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestDatesProjection {
+  private static final Types.DateType TYPE = Types.DateType.get();
+  private static final Schema SCHEMA = new Schema(
+    optional(1, "date", TYPE));
+
+  public void assertProjectionStrict(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+
+    Expression projection = Projections.strict(spec).project(filter);
+    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+
+    Assert.assertEquals(predicate.op(), expectedOp);
+
+    Literal literal = predicate.literal();
+    Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
+    String output = transform.toHumanString((int) literal.value());
+    Assert.assertEquals(output, expectedLiteral);
+
+  }
+
+  public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+    Expression projection = Projections.inclusive(spec).project(filter);
+    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+
+    Assert.assertEquals(predicate.op(), expectedOp);
+
+    Literal literal = predicate.literal();
+    Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
+    String output = transform.toHumanString((int) literal.value());
+    Assert.assertEquals(output, expectedLiteral);
+
+  }
+
+  @Test
+  public void testMonthStrictLowerBound() {
+    Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016-12");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2016-12");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-02");
+    // bound should include the same month for lower bound
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01");
+
+  }
+
+  @Test
+  public void testMonthStrictUpperBound() {
+    Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11");
+    // bound should include the same month for upper bound
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12");
+
+  }
+
+  @Test
+  public void testMonthInclusiveLowerBound() {
+    Integer date = (Integer) Literal.of("2017-12-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12");
+
+  }
+
+  @Test
+  public void testMonthInclusiveUpperBound() {
+    Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12");
+
+  }
+
+  @Test
+  public void testDayStrictLowerBound() {
+    Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016-12-31");
+    // should be the same date for <=
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-01-01");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-01-02");
+    // should be the same date for >=
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-01-01");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-01-01");
+
+  }
+
+  @Test
+  public void testDayStrictUpperBound() {
+    Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-12-30");
+    // should be the same date for <=
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12-31");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018-01-01");
+    // should be the same date for >=
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12-31");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017-12-31");
+
+  }
+
+  @Test
+  public void testDayInclusive() {
+    Integer date = (Integer) Literal.of("2017-12-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017-11-30");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017-12-01");
+
+  }
+
+  @Test
+  public void testYearStrictLowerBound() {
+    Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
+    // bound should include the same year for lower bound
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
+
+  }
+
+  @Test
+  public void testYearStrictUpperBound() {
+    Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
+    // bound should include the same year for upper bound
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "2017");
+
+  }
+
+  @Test
+  public void testYearInclusiveLowerBound() {
+    Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017");
+
+  }
+
+  @Test
+  public void testYearInclusiveUpperBound() {
+    Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "2017");
+
+  }
+
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -61,9 +61,36 @@ public class TestTimestampsProjection {
   }
 
   @Test
+  public void testMonthStrictLowerBound() {
+    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    // bound should include the same month for lower bound
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
+
+  }
+
+  @Test
+  public void testMonthStrictUpperBound() {
+    Long date = (long) Literal.of("2017-12-31T23:59:59.99999").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    // bound should include the same month for upper bound
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
+
+  }
+
+  @Test
   public void testMonthInclusive() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
     assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
@@ -77,7 +104,6 @@ public class TestTimestampsProjection {
   @Test
   public void testDayStrict() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
@@ -89,9 +115,36 @@ public class TestTimestampsProjection {
   }
 
   @Test
+  public void testDayStrictLowerBound() {
+    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    // bound should include the same day for lower bound
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
+
+  }
+
+  @Test
+  public void testDayStrictUpperBound() {
+    Long date = (long) Literal.of("2017-12-01T23:59:59.99999").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
+    // bound should include the same day for lower bound
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
+
+  }
+
+  @Test
   public void testDayInclusive() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
     assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
@@ -105,11 +158,38 @@ public class TestTimestampsProjection {
   @Test
   public void testYearStrict() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
+
+  }
+
+  @Test
+  public void testYearStrictLowerBound() {
+    Long date = (long) Literal.of("2017-01-01T00:00:00.00000").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    // bound should include the same year for lower bound
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
+
+  }
+
+  @Test
+  public void testYearStrictUpperBound() {
+    Long date = (long) Literal.of("2017-12-31T23:59:59.99999").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    // bound should include the same year for upper bound
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
@@ -133,7 +213,6 @@ public class TestTimestampsProjection {
   @Test
   public void testHourStrict() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
@@ -145,9 +224,36 @@ public class TestTimestampsProjection {
   }
 
   @Test
+  public void testHourStrictLowerBound() {
+    Long date = (long) Literal.of("2017-12-01T10:00:00.00000").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    // bound should include the same hour for lower bound
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
+
+  }
+
+  @Test
+  public void testHourStrictUpperBound() {
+    Long date = (long) Literal.of("2017-12-01T10:59:59.99999").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    // bound should include the same hour for upper bound
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
+
+  }
+
+  @Test
   public void testHourInclusive() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -48,7 +48,7 @@ public class TestTimestampsProjection {
     Expression projection = Projections.strict(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
 
-    Assert.assertEquals(predicate.op(), expectedOp);
+    Assert.assertEquals(expectedOp, predicate.op());
 
     Literal literal = predicate.literal();
     Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
@@ -77,8 +77,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12");
     // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
@@ -91,8 +91,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12");
     // bound should include the same month for upper bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
@@ -131,8 +131,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12-01");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12-01");
     // bound should include the same day for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
@@ -144,11 +144,11 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-01T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017-12-01");
     // bound should include the same day for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
 
   }
@@ -185,8 +185,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017");
     // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
@@ -198,11 +198,11 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017");
     // bound should include the same year for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
 
   }
@@ -239,8 +239,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12-01-10");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12-01-10");
     // bound should include the same hour for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
@@ -252,11 +252,11 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-01T10:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017-12-01-10");
     // bound should include the same hour for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
 
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -54,7 +54,6 @@ public class TestTimestampsProjection {
     Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
     Assert.assertEquals(expectedLiteral, output);
-
   }
 
   public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
@@ -68,7 +67,6 @@ public class TestTimestampsProjection {
     Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
     Assert.assertEquals(expectedLiteral, output);
-
   }
 
   @Test
@@ -82,7 +80,6 @@ public class TestTimestampsProjection {
     // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
-
   }
 
   @Test
@@ -96,7 +93,6 @@ public class TestTimestampsProjection {
     // bound should include the same month for upper bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
-
   }
 
   @Test
@@ -109,7 +105,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12");
-
   }
 
   @Test
@@ -122,7 +117,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12");
-
   }
 
   @Test
@@ -136,7 +130,6 @@ public class TestTimestampsProjection {
     // bound should include the same day for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
-
   }
 
   @Test
@@ -150,7 +143,6 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
-
   }
 
   @Test
@@ -163,7 +155,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01");
-
   }
 
   @Test
@@ -176,7 +167,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01");
-
   }
 
   @Test
@@ -190,7 +180,6 @@ public class TestTimestampsProjection {
     // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
-
   }
 
   @Test
@@ -204,7 +193,6 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
-
   }
 
   @Test
@@ -217,7 +205,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017");
-
   }
 
   @Test
@@ -230,7 +217,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017");
-
   }
 
   @Test
@@ -244,7 +230,6 @@ public class TestTimestampsProjection {
     // bound should include the same hour for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
-
   }
 
   @Test
@@ -258,7 +243,6 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
-
   }
 
   @Test
@@ -271,7 +255,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
-
   }
 
   @Test
@@ -284,8 +267,5 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
-
   }
-
-
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -29,7 +29,7 @@ public class TestTimestampsProjection {
     Literal literal = predicate.literal();
     Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
-    Assert.assertEquals(output, expectedLiteral);
+    Assert.assertEquals(expectedLiteral, output);
 
   }
 
@@ -42,21 +42,7 @@ public class TestTimestampsProjection {
     Literal literal = predicate.literal();
     Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
     String output = transform.toHumanString((int) literal.value());
-    Assert.assertEquals(output, expectedLiteral);
-
-  }
-
-  @Test
-  public void testMonthStrict() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
-
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
-    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
+    Assert.assertEquals(expectedLiteral, output);
 
   }
 
@@ -76,20 +62,20 @@ public class TestTimestampsProjection {
 
   @Test
   public void testMonthStrictUpperBound() {
-    Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    // bound should include the same month for upper bound
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    // bound should include the same month for upper bound
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
 
   }
 
   @Test
-  public void testMonthInclusive() {
+  public void testMonthInclusiveLowerBound() {
     Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
@@ -102,15 +88,15 @@ public class TestTimestampsProjection {
   }
 
   @Test
-  public void testDayStrict() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
+  public void testMonthInclusiveUpperBound() {
+    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
-    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12");
 
   }
 
@@ -143,11 +129,11 @@ public class TestTimestampsProjection {
   }
 
   @Test
-  public void testDayInclusive() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+  public void testDayInclusiveLowerBound() {
+    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
     assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
@@ -156,15 +142,15 @@ public class TestTimestampsProjection {
   }
 
   @Test
-  public void testYearStrict() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
+  public void testDayInclusiveUpperBound() {
+    Long date = (long) Literal.of("2017-12-01T23:59:59.999999").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
-    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01");
 
   }
 
@@ -197,12 +183,11 @@ public class TestTimestampsProjection {
   }
 
   @Test
-  public void testYearInclusive() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-
+  public void testYearInclusiveLowerBound() {
+    Long date = (long) Literal.of("2017-01-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
-    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
     assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
@@ -211,15 +196,15 @@ public class TestTimestampsProjection {
   }
 
   @Test
-  public void testHourStrict() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
-    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
+  public void testYearInclusiveUpperBound() {
+    Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
-    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017");
 
   }
 
@@ -252,13 +237,26 @@ public class TestTimestampsProjection {
   }
 
   @Test
-  public void testHourInclusive() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+  public void testHourInclusiveLowerBound() {
+    Long date = (long) Literal.of("2017-12-01T10:00:00.00000").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
+
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
+
+  }
+
+  @Test
+  public void testHourInclusiveUpperBound() {
+    Long date = (long) Literal.of("2017-12-01T10:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
-    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -56,6 +56,20 @@ public class TestTimestampsProjection {
     Assert.assertEquals(expectedLiteral, output);
   }
 
+  public void assertProjectionStrictValue(PartitionSpec spec, UnboundPredicate<?> filter,
+                                          Expression.Operation expectedOp) {
+
+    Expression projection = Projections.strict(spec).project(filter);
+    Assert.assertEquals(projection.op(), expectedOp);
+  }
+
+  public void assertProjectionInclusiveValue(PartitionSpec spec, UnboundPredicate<?> filter,
+                                             Expression.Operation expectedOp) {
+
+    Expression projection = Projections.inclusive(spec).project(filter);
+    Assert.assertEquals(projection.op(), expectedOp);
+  }
+
   public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
                                         Expression.Operation expectedOp, String expectedLiteral) {
     Expression projection = Projections.inclusive(spec).project(filter);
@@ -79,6 +93,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -91,6 +106,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -103,6 +119,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -115,6 +132,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -127,6 +145,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -139,6 +158,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -151,6 +171,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -163,6 +184,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -175,6 +197,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -187,6 +210,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -199,6 +223,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -211,6 +236,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -223,6 +249,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -235,6 +262,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
+    assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
   }
 
   @Test
@@ -247,6 +275,7 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 
   @Test
@@ -259,5 +288,6 @@ public class TestTimestampsProjection {
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
+    assertProjectionInclusiveValue(spec, notEqual("timestamp", date), Expression.Operation.TRUE);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -78,7 +78,7 @@ public class TestTimestampsProjection {
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
@@ -90,7 +90,7 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017-12");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     // bound should include the same month for upper bound
@@ -132,7 +132,7 @@ public class TestTimestampsProjection {
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12-01");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12-01");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     // bound should include the same day for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
@@ -144,7 +144,7 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-01T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017-12-01");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
     // bound should include the same day for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
@@ -186,7 +186,7 @@ public class TestTimestampsProjection {
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
     // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
@@ -198,7 +198,7 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
     // bound should include the same year for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
@@ -240,7 +240,7 @@ public class TestTimestampsProjection {
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12-01-10");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12-01-10");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     // bound should include the same hour for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
@@ -252,7 +252,7 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("2017-12-01T10:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017-12-01-10");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
     // bound should include the same hour for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iceberg.transforms;
 
 import org.apache.iceberg.PartitionSpec;
@@ -11,15 +30,20 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
-import static org.apache.iceberg.expressions.Expressions.*;
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.greaterThan;
+import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public class TestTimestampsProjection {
   private static final Types.TimestampType TYPE = Types.TimestampType.withoutZone();
-  private static final Schema SCHEMA = new Schema(
-    optional(1, "timestamp", TYPE));
+  private static final Schema SCHEMA = new Schema(optional(1, "timestamp", TYPE));
 
-  public void assertProjectionStrict(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+  public void assertProjectionStrict(PartitionSpec spec, UnboundPredicate<?> filter,
+                                     Expression.Operation expectedOp, String expectedLiteral) {
 
     Expression projection = Projections.strict(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
@@ -33,7 +57,8 @@ public class TestTimestampsProjection {
 
   }
 
-  public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+  public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
+                                        Expression.Operation expectedOp, String expectedLiteral) {
     Expression projection = Projections.inclusive(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -1,0 +1,162 @@
+package org.apache.iceberg.transforms;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.TestHelpers.assertAndUnwrapUnbound;
+import static org.apache.iceberg.expressions.Expressions.*;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestTimestampsProjection {
+  private static final Types.TimestampType TYPE = Types.TimestampType.withoutZone();
+  private static final Schema SCHEMA = new Schema(
+    optional(1, "timestamp", TYPE));
+
+  public void assertProjectionStrict(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+
+    Expression projection = Projections.strict(spec).project(filter);
+    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+
+    Assert.assertEquals(predicate.op(), expectedOp);
+
+    Literal literal = predicate.literal();
+    Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
+    String output = transform.toHumanString((int) literal.value());
+    Assert.assertEquals(output, expectedLiteral);
+
+  }
+
+  public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter, Expression.Operation expectedOp, String expectedLiteral) {
+    Expression projection = Projections.inclusive(spec).project(filter);
+    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+
+    Assert.assertEquals(predicate.op(), expectedOp);
+
+    Literal literal = predicate.literal();
+    Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
+    String output = transform.toHumanString((int) literal.value());
+    Assert.assertEquals(output, expectedLiteral);
+
+  }
+
+  @Test
+  public void testMonthStrict() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
+
+  }
+
+  @Test
+  public void testMonthInclusive() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
+
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12");
+
+  }
+
+  @Test
+  public void testDayStrict() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
+
+  }
+
+  @Test
+  public void testDayInclusive() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
+
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01");
+
+  }
+
+  @Test
+  public void testYearStrict() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2016");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
+
+  }
+
+  @Test
+  public void testYearInclusive() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
+
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017");
+
+  }
+
+  @Test
+  public void testHourStrict() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
+
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
+
+  }
+
+  @Test
+  public void testHourInclusive() {
+    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
+
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
+    assertProjectionInclusive(spec, equal("timestamp", date), Expression.Operation.EQ, "2017-12-01-10");
+
+  }
+
+
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -87,24 +87,24 @@ public class TestTimestampsProjection {
 
   @Test
   public void testMonthStrictUpperBound() {
-    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12");
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "2017-12");
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "2017-12");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     // bound should include the same month for upper bound
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
 
   }
 
   @Test
   public void testMonthInclusiveLowerBound() {
-    Long date = (long) Literal.of("2017-12-01T10:12:55.038194").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
     assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
@@ -114,10 +114,10 @@ public class TestTimestampsProjection {
 
   @Test
   public void testMonthInclusiveUpperBound() {
-    Long date = (long) Literal.of("2017-12-01T00:00:00.00000").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-01T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
+    assertProjectionInclusive(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionInclusive(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionInclusive(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -75,9 +75,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
-    // bound should include the same month for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
   }
@@ -90,8 +89,7 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
-    // bound should include the same month for upper bound
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12");
   }
 
@@ -125,9 +123,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12-01");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
-    // bound should include the same day for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
   }
@@ -138,10 +135,9 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    // bound should include the same day for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01");
   }
 
@@ -175,9 +171,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2016");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
-    // bound should include the same year for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
   }
@@ -188,10 +183,9 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
-    // bound should include the same year for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2018");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2018");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017");
   }
 
@@ -225,9 +219,8 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
-    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "2017-12-01-10");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
-    // bound should include the same hour for lower bound
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
   }
@@ -238,10 +231,9 @@ public class TestTimestampsProjection {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
-    // bound should include the same hour for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "2017-12-01-10");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -76,7 +76,7 @@ public class TestTimestampsProjection {
 
   @Test
   public void testMonthStrictUpperBound() {
-    Long date = (long) Literal.of("2017-12-31T23:59:59.99999").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11");
@@ -130,11 +130,11 @@ public class TestTimestampsProjection {
 
   @Test
   public void testDayStrictUpperBound() {
-    Long date = (long) Literal.of("2017-12-01T23:59:59.99999").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-01T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-11-30");
-    // bound should include the same day for lower bound
+    // bound should include the same day for upper bound
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-02");
@@ -184,7 +184,7 @@ public class TestTimestampsProjection {
 
   @Test
   public void testYearStrictUpperBound() {
-    Long date = (long) Literal.of("2017-12-31T23:59:59.99999").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2016");
@@ -232,14 +232,14 @@ public class TestTimestampsProjection {
     assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
     // bound should include the same hour for lower bound
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-11");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT_EQ, "2017-12-01-10");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "2017-12-01-10");
 
   }
 
   @Test
   public void testHourStrictUpperBound() {
-    Long date = (long) Literal.of("2017-12-01T10:59:59.99999").to(TYPE).value();
+    Long date = (long) Literal.of("2017-12-01T10:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("timestamp").build();
 
     assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT_EQ, "2017-12-01-09");


### PR DESCRIPTION
Implementing projectStrict for Dates and Timestamps (https://github.com/apache/incubator-iceberg/issues/35)

Includes fix of ResidualEvaluator from https://github.com/moulimukherjee/incubator-iceberg/pull/1

Expected behaviour:
ts > 2019-07-07T23:59:59.9999 will be projected strict using ts_day >= 2019-07-08
ts > 2019-07-07T15:52:50.0000 will also be projected strict using ts_day >= 2019-07-08
ts > 2019-07-07T00:00:00:0000 will be projected strict using ts_day >= 2019-07-07