### PR TITLE
Update metadata tables for unpartitioned tables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Filterable.java
+++ b/api/src/main/java/org/apache/iceberg/Filterable.java
@@ -61,6 +61,14 @@ public interface Filterable<T extends Filterable<T>> extends CloseableIterable<D
   T select(Collection<String> columns);
 
   /**
+   * Set the projection from a schema.
+   *
+   * @param fileProjection a projection of the DataFile schema
+   * @return a Filterable that will load only the given schema's columns
+   */
+  T project(Schema fileProjection);
+
+  /**
    * Adds a filter expression on partition data for matching files.
    * <p>
    * If the Filterable object already has partition filters, the new filter will be added as an
@@ -90,4 +98,30 @@ public interface Filterable<T extends Filterable<T>> extends CloseableIterable<D
    * @return a Filterable that will load only rows that match expr
    */
   T filterRows(Expression expr);
+
+  /**
+   * Sets case sensitivity.
+   *
+   * @param isCaseSensitive true if expression binding and schema projection should be case sensitive
+   * @return a Filterable that will use the specified case sensitivity
+   */
+  T caseSensitive(boolean isCaseSensitive);
+
+  /**
+   * Sets case sensitive binding and projection.
+   *
+   * @return a Filterable that will case sensitive binding and projection
+   */
+  default T caseSensitive() {
+    return caseSensitive(true);
+  }
+
+  /**
+   * Sets case insensitive binding and projection.
+   *
+   * @return a Filterable that will case insensitive binding and projection
+   */
+  default T caseInsensitive() {
+    return caseSensitive(false);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -81,15 +81,15 @@ public class DataTableScan extends BaseTableScan {
     Iterable<CloseableIterable<FileScanTask>> readers = Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader reader = ManifestReader
-              .read(ops.io().newInputFile(manifest.path()), ops.current()::spec)
-              .caseSensitive(caseSensitive);
+          ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current()::spec);
           PartitionSpec spec = ops.current().spec(manifest.partitionSpecId());
           String schemaString = SchemaParser.toJson(spec.schema());
           String specString = PartitionSpecParser.toJson(spec);
           ResidualEvaluator residuals = ResidualEvaluator.of(spec, rowFilter, caseSensitive);
           return CloseableIterable.transform(
-              reader.filterRows(rowFilter).select(colStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS),
+              reader.filterRows(rowFilter)
+                  .caseSensitive(caseSensitive)
+                  .select(colStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS),
               file -> new BaseFileScanTask(file, schemaString, specString, residuals)
           );
         });

--- a/core/src/main/java/org/apache/iceberg/FilteredManifest.java
+++ b/core/src/main/java/org/apache/iceberg/FilteredManifest.java
@@ -43,6 +43,7 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
   private final ManifestReader reader;
   private final Expression partFilter;
   private final Expression rowFilter;
+  private final Schema fileSchema;
   private final Collection<String> columns;
   private final boolean caseSensitive;
 
@@ -51,37 +52,41 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
   private InclusiveMetricsEvaluator lazyMetricsEvaluator = null;
 
   FilteredManifest(ManifestReader reader, Expression partFilter, Expression rowFilter,
-                   Collection<String> columns, boolean caseSensitive) {
+                   Schema fileSchema, Collection<String> columns, boolean caseSensitive) {
     Preconditions.checkNotNull(reader, "ManifestReader cannot be null");
     this.reader = reader;
     this.partFilter = partFilter;
     this.rowFilter = rowFilter;
+    this.fileSchema = fileSchema;
     this.columns = columns;
     this.caseSensitive = caseSensitive;
   }
 
   @Override
   public FilteredManifest select(Collection<String> selectedColumns) {
-    return new FilteredManifest(reader, partFilter, rowFilter, selectedColumns, caseSensitive);
+    return new FilteredManifest(reader, partFilter, rowFilter, fileSchema, selectedColumns, caseSensitive);
+  }
+
+  @Override
+  public FilteredManifest project(Schema fileProjection) {
+    return new FilteredManifest(reader, partFilter, rowFilter, fileProjection, columns, caseSensitive);
   }
 
   @Override
   public FilteredManifest filterPartitions(Expression expr) {
-    return new FilteredManifest(reader,
-        Expressions.and(partFilter, expr),
-        rowFilter,
-        columns,
-        caseSensitive);
+    return new FilteredManifest(
+        reader, Expressions.and(partFilter, expr), rowFilter, fileSchema, columns, caseSensitive);
   }
 
   @Override
   public FilteredManifest filterRows(Expression expr) {
-    Expression projected = Projections.inclusive(reader.spec(), caseSensitive).project(expr);
-    return new FilteredManifest(reader,
-        Expressions.and(partFilter, projected),
-        Expressions.and(rowFilter, expr),
-        columns,
-        caseSensitive);
+    return new FilteredManifest(
+        reader, partFilter, Expressions.and(rowFilter, expr), fileSchema, columns, caseSensitive);
+  }
+
+  @Override
+  public FilteredManifest caseSensitive(boolean isCaseSensitive) {
+    return new FilteredManifest(reader, partFilter, rowFilter, fileSchema, columns, isCaseSensitive);
   }
 
   CloseableIterable<ManifestEntry> allEntries() {
@@ -90,13 +95,13 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
       Evaluator evaluator = evaluator();
       InclusiveMetricsEvaluator metricsEvaluator = metricsEvaluator();
 
-      return CloseableIterable.filter(reader.entries(columns),
+      return CloseableIterable.filter(reader.entries(projection(fileSchema, columns, caseSensitive)),
           entry -> entry != null &&
               evaluator.eval(entry.file().partition()) &&
               metricsEvaluator.eval(entry.file()));
 
     } else {
-      return reader.entries(columns);
+      return reader.entries(projection(fileSchema, columns, caseSensitive));
     }
   }
 
@@ -106,14 +111,14 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
       Evaluator evaluator = evaluator();
       InclusiveMetricsEvaluator metricsEvaluator = metricsEvaluator();
 
-      return CloseableIterable.filter(reader.entries(columns),
+      return CloseableIterable.filter(reader.entries(projection(fileSchema, columns, caseSensitive)),
           entry -> entry != null &&
               entry.status() != Status.DELETED &&
               evaluator.eval(entry.file().partition()) &&
               metricsEvaluator.eval(entry.file()));
 
     } else {
-      return CloseableIterable.filter(reader.entries(columns),
+      return CloseableIterable.filter(reader.entries(projection(fileSchema, columns, caseSensitive)),
           entry -> entry != null && entry.status() != Status.DELETED);
     }
   }
@@ -133,14 +138,16 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
       boolean dropStats = Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS).isEmpty();
 
       return Iterators.transform(
-          Iterators.filter(reader.iterator(partFilter, projectColumns),
+          Iterators.filter(reader.iterator(partFilter, projection(fileSchema, projectColumns, caseSensitive)),
               input -> input != null &&
                   evaluator.eval(input.partition()) &&
                   metricsEvaluator.eval(input)),
           dropStats ? DataFile::copyWithoutStats : DataFile::copy);
 
     } else {
-      return Iterators.transform(reader.iterator(partFilter, columns), DataFile::copy);
+      return Iterators.transform(
+          reader.iterator(partFilter, projection(fileSchema, columns, caseSensitive)),
+          DataFile::copy);
     }
   }
 
@@ -149,10 +156,24 @@ public class FilteredManifest implements Filterable<FilteredManifest> {
     reader.close();
   }
 
+  private static Schema projection(Schema fileSchema, Collection<String> columns, boolean caseSensitive) {
+    if (columns != null) {
+      if (caseSensitive) {
+        return fileSchema.select(columns);
+      } else {
+        return fileSchema.caseInsensitiveSelect(columns);
+      }
+    }
+
+    return fileSchema;
+  }
+
   private Evaluator evaluator() {
     if (lazyEvaluator == null) {
-      if (partFilter != null) {
-        this.lazyEvaluator = new Evaluator(reader.spec().partitionType(), partFilter, caseSensitive);
+      Expression projected = Projections.inclusive(reader.spec(), caseSensitive).project(rowFilter);
+      Expression finalPartFilter = Expressions.and(projected, partFilter);
+      if (finalPartFilter != null) {
+        this.lazyEvaluator = new Evaluator(reader.spec().partitionType(), finalPartFilter, caseSensitive);
       } else {
         this.lazyEvaluator = new Evaluator(reader.spec().partitionType(), Expressions.alwaysTrue(), caseSensitive);
       }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -166,7 +166,7 @@ class ManifestEntry implements IndexedRecord, SpecificData.SchemaConstructable {
         new Schema(DataFile.getType(partitionType).fields()).select(columns).asStruct());
   }
 
-  private static Schema wrapFileSchema(StructType fileStruct) {
+  static Schema wrapFileSchema(StructType fileStruct) {
     // ids for top-level columns are assigned from 1000
     return new Schema(
         required(0, "status", IntegerType.get()),

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -506,9 +506,10 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
 
     private CloseableIterable<InternalRow> newDataIterable(DataTask task, Schema readSchema) {
       StructInternalRow row = new StructInternalRow(tableSchema.asStruct());
-      Iterable<InternalRow> asSparkRows = Iterables.transform(task.asDataTask().rows(), row::setStruct);
-      return CloseableIterable.withNoopClose(
-          Iterables.transform(asSparkRows, APPLY_PROJECTION.bind(projection(readSchema, tableSchema))::invoke));
+      CloseableIterable<InternalRow> asSparkRows = CloseableIterable.transform(
+          task.asDataTask().rows(), row::setStruct);
+      return CloseableIterable.transform(
+          asSparkRows, APPLY_PROJECTION.bind(projection(readSchema, tableSchema))::invoke);
     }
   }
 


### PR DESCRIPTION
This removes the `partition` column from the `files` and `entries` metadata tables when the underlying table is not partitioned. For unpartitioned tables, this is an empty struct and cannot be projected in Spark.

In support of suppressing the `partition` column, this also updates `ManifestReader` and `FilteredManifest` to support schema-based projection. Because this is already updating the `Filterable` API, this fixes #145 and adds case sensitivity methods.