### PR TITLE
Fix Parquet page size property

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -195,7 +195,7 @@ public class Parquet {
 
         ParquetProperties parquetProperties = ParquetProperties.builder()
             .withWriterVersion(writerVersion)
-            .withDictionaryPageSize(pageSize)
+            .withPageSize(pageSize)
             .withDictionaryPageSize(dictionaryPageSize)
             .build();
 


### PR DESCRIPTION
This PR fixes the propagation of `write.parquet.page-size-bytes` to `ParquetWriter`.