### PR TITLE
Avoid write failures if metrics mode is invalid

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -44,6 +44,7 @@ public class MetricsConfig {
     return spec;
   }
 
+  @SuppressWarnings("checkstyle:CatchBlockLogException")
   public static MetricsConfig fromProperties(Map<String, String> props) {
     MetricsConfig spec = new MetricsConfig();
     String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
@@ -56,7 +57,7 @@ public class MetricsConfig {
           MetricsMode mode;
           try {
             mode = MetricsModes.fromString(props.get(key));
-          } catch (IllegalArgumentException e) {
+          } catch (IllegalArgumentException ignored) {
             // Mode was invalid, log the error and use the default
             LOG.warn("Ignoring invalid metrics mode for column %s: %s", columnAlias, key);
             mode = spec.defaultMode;

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -31,7 +31,6 @@ import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFA
 public class MetricsConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
-  private static final String COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
 
   private Map<String, MetricsMode> columnModes = Maps.newHashMap();
   private MetricsMode defaultMode;
@@ -52,20 +51,20 @@ public class MetricsConfig {
       spec.defaultMode = MetricsModes.fromString(defaultModeAsString);
     } catch (IllegalArgumentException ignored) {
       // Mode was invalid, log the error and use the default
-      LOG.warn("Ignoring invalid default metrics mode: %s", defaultModeAsString);
+      LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeAsString);
       spec.defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
     }
 
     props.keySet().stream()
-        .filter(key -> key.startsWith(COLUMN_CONF_PREFIX))
+        .filter(key -> key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX))
         .forEach(key -> {
-          String columnAlias = key.replaceFirst(COLUMN_CONF_PREFIX, "");
+          String columnAlias = key.replaceFirst(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX, "");
           MetricsMode mode;
           try {
             mode = MetricsModes.fromString(props.get(key));
           } catch (IllegalArgumentException ignored) {
             // Mode was invalid, log the error and use the default
-            LOG.warn("Ignoring invalid metrics mode for column %s: %s", columnAlias, key);
+            LOG.warn("Ignoring invalid metrics mode for column {}: {}", columnAlias, props.get(key));
             mode = spec.defaultMode;
           }
           spec.columnModes.put(columnAlias, mode);

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -43,15 +43,14 @@ public class MetricsConfig {
     return spec;
   }
 
-  @SuppressWarnings("checkstyle:CatchBlockLogException")
   public static MetricsConfig fromProperties(Map<String, String> props) {
     MetricsConfig spec = new MetricsConfig();
     String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
     try {
       spec.defaultMode = MetricsModes.fromString(defaultModeAsString);
-    } catch (IllegalArgumentException ignored) {
+    } catch (IllegalArgumentException err) {
       // Mode was invalid, log the error and use the default
-      LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeAsString);
+      LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeAsString, err);
       spec.defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
     }
 
@@ -62,9 +61,9 @@ public class MetricsConfig {
           MetricsMode mode;
           try {
             mode = MetricsModes.fromString(props.get(key));
-          } catch (IllegalArgumentException ignored) {
+          } catch (IllegalArgumentException err) {
             // Mode was invalid, log the error and use the default
-            LOG.warn("Ignoring invalid metrics mode for column {}: {}", columnAlias, props.get(key));
+            LOG.warn("Ignoring invalid metrics mode for column {}: {}", columnAlias, props.get(key), err);
             mode = spec.defaultMode;
           }
           spec.columnModes.put(columnAlias, mode);

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -48,7 +48,13 @@ public class MetricsConfig {
   public static MetricsConfig fromProperties(Map<String, String> props) {
     MetricsConfig spec = new MetricsConfig();
     String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
-    spec.defaultMode = MetricsModes.fromString(defaultModeAsString);
+    try {
+      spec.defaultMode = MetricsModes.fromString(defaultModeAsString);
+    } catch (IllegalArgumentException ignored) {
+      // Mode was invalid, log the error and use the default
+      LOG.warn("Ignoring invalid default metrics mode: %s", defaultModeAsString);
+      spec.defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+    }
 
     props.keySet().stream()
         .filter(key -> key.startsWith(COLUMN_CONF_PREFIX))

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -89,6 +89,7 @@ public class TableProperties {
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "none";
 
+  public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.apache.iceberg.MetricsModes.Counts;
 import org.apache.iceberg.MetricsModes.Full;
 import org.apache.iceberg.MetricsModes.None;
@@ -50,5 +52,27 @@ public class TestMetricsModes {
     exceptionRule.expect(IllegalArgumentException.class);
     exceptionRule.expectMessage("length should be positive");
     MetricsModes.fromString("truncate(0)");
+  }
+
+  @Test
+  public void testInvalidColumnModeValue() {
+    Map<String, String> properties = ImmutableMap.of(
+        TableProperties.DEFAULT_WRITE_METRICS_MODE, "full",
+        TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col", "troncate(5)");
+
+    MetricsConfig config = MetricsConfig.fromProperties(properties);
+    Assert.assertEquals("Invalid mode should be defaulted to table default (full)",
+        MetricsModes.Full.get(), config.columnMode("col"));
+  }
+
+  @Test
+  public void testInvalidDefaultColumnModeValue() {
+    Map<String, String> properties = ImmutableMap.of(
+        TableProperties.DEFAULT_WRITE_METRICS_MODE, "fuull",
+        TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col", "troncate(5)");
+
+    MetricsConfig config = MetricsConfig.fromProperties(properties);
+    Assert.assertEquals("Invalid mode should be defaulted to library default (truncate(16))",
+        MetricsModes.Truncate.withLength(16), config.columnMode("col"));
   }
 }


### PR DESCRIPTION
This updates the `MetricsConfig` class to catch exceptions thrown by `MetricsMode.fromString`. The intent is to avoid failing write jobs when a metrics mode is invalid, because users may make changes to a table while a pipeline that writes to it is deployed and running. A live pipeline should not fail because of a typo in table tuning settings.