### PR TITLE
Support write mode for Parquet and Avro using table property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -56,8 +56,14 @@ public class TableProperties {
   public static final String PARQUET_COMPRESSION = "write.parquet.compression-codec";
   public static final String PARQUET_COMPRESSION_DEFAULT = "gzip";
 
+  public static final String PARQUET_WRITE_MODE = "write.parquet.write-mode";
+  public static final String PARQUET_WRITE_MODE_DEFAULT = "overwrite";
+
   public static final String AVRO_COMPRESSION = "write.avro.compression-codec";
   public static final String AVRO_COMPRESSION_DEFAULT = "gzip";
+
+  public static final String AVRO_WRITE_MODE = "write.avro.write-mode";
+  public static final String AVRO_WRITE_MODE_DEFAULT = "overwrite";
 
   public static final String SPLIT_SIZE = "read.split.target-size";
   public static final long SPLIT_SIZE_DEFAULT = 134217728; // 128 MB

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -39,8 +39,9 @@ class AvroFileAppender<D> implements FileAppender<D> {
 
   AvroFileAppender(Schema schema, OutputFile file,
                    Function<Schema, DatumWriter<?>> createWriterFunc,
-                   CodecFactory codec, Map<String, String> metadata) throws IOException {
-    this.stream = file.create();
+                   CodecFactory codec, Map<String, String> metadata,
+                   Avro.WriteMode writeMode) throws IOException {
+    this.stream = writeMode == Avro.WriteMode.CREATE ? file.create() : file.createOrOverwrite();
     this.writer = newAvroWriter(schema, stream, createWriterFunc, codec, metadata);
   }
 
@@ -92,7 +93,6 @@ class AvroFileAppender<D> implements FileAppender<D> {
       writer.setMeta(entry.getKey(), entry.getValue());
     }
 
-    // TODO: support overwrite
     return writer.create(schema, stream);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroWrite.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroWrite.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+public class TestAvroWrite {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testWriteCreate() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(TableProperties.AVRO_WRITE_MODE, "create");
+
+    File file = write(10, properties, null);
+
+    thrown.expect(AlreadyExistsException.class);
+    write(5, properties, file);
+  }
+
+  @Test
+  public void testWriteOverwrite() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(TableProperties.AVRO_WRITE_MODE, "overwrite");
+
+    File file = write(10, properties, null);
+    Assert.assertEquals(10, Lists.newArrayList(Avro.read(Files.localInput(file))
+        .project(schema())
+        .build()
+    ).size());
+
+    write(5, properties, file);
+    Assert.assertEquals(5, Lists.newArrayList(Avro.read(Files.localInput(file))
+        .project(schema())
+        .build()
+    ).size());
+  }
+
+  @Test
+  public void testUnsupportedWriteMode() throws IOException {
+    thrown.expect(IllegalArgumentException.class);
+    write(10, ImmutableMap.of(TableProperties.AVRO_WRITE_MODE, "abc"), null);
+  }
+
+  private Schema schema() {
+    return new Schema(
+        Types.NestedField.required(0, "col_int", Types.IntegerType.get())
+    );
+  }
+
+  private File write(int recordsNumber, Map<String, String> properties, File file) throws IOException {
+    Schema schema = schema();
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema, "table");
+
+    List<GenericData.Record> records = IntStream.rangeClosed(1, recordsNumber)
+        .mapToObj(index -> {
+          GenericData.Record record = new GenericData.Record(avroSchema);
+          record.put("col_int", index);
+          return record;
+        })
+        .collect(Collectors.toList());
+
+    File outputFile = file;
+    if (outputFile == null) {
+      outputFile = temp.newFile();
+      Assert.assertTrue("File should have been deleted", outputFile.delete());
+    }
+
+    try (FileAppender<GenericData.Record> appender = Avro.write(Files.localOutput(outputFile))
+        .schema(schema)
+        .setAll(properties)
+        .build()) {
+      appender.addAll(records);
+    }
+
+    return outputFile;
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -83,7 +83,8 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
                 Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
                 CompressionCodecName codec,
                 ParquetProperties properties,
-                MetricsConfig metricsConfig) {
+                MetricsConfig metricsConfig,
+                ParquetFileWriter.Mode writeMode) {
     this.output = output;
     this.targetRowGroupSize = rowGroupSize;
     this.props = properties;
@@ -95,7 +96,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
 
     try {
       this.writer = new ParquetFileWriter(ParquetIO.file(output, conf), parquetSchema,
-          ParquetFileWriter.Mode.OVERWRITE, rowGroupSize, 0);
+          writeMode, rowGroupSize, 0);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to create Parquet file");
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/BaseParquetWritingTest.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/BaseParquetWritingTest.java
@@ -45,23 +45,28 @@ public abstract class BaseParquetWritingTest {
   public TemporaryFolder temp = new TemporaryFolder();
 
   File writeRecords(Schema schema, GenericData.Record... records) throws IOException {
-    return writeRecords(schema, Collections.emptyMap(), null, records);
+    return writeRecords(schema, Collections.emptyMap(), null, null, records);
   }
 
-  File writeRecords(
-      Schema schema, Map<String, String> properties,
-      Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
-      GenericData.Record... records) throws IOException {
-    File tmpFolder = temp.newFolder("parquet");
-    String filename = UUID.randomUUID().toString();
-    File file = new File(tmpFolder, FileFormat.PARQUET.addExtension(filename));
-    try (FileAppender<GenericData.Record> writer = Parquet.write(localOutput(file))
+  File writeRecords(Schema schema,
+                    Map<String, String> properties,
+                    Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
+                    File file,
+                    GenericData.Record... records) throws IOException {
+    File outputFile = file;
+    if (outputFile == null) {
+      File tmpFolder = temp.newFolder("parquet");
+      String filename = UUID.randomUUID().toString();
+      outputFile = new File(tmpFolder, FileFormat.PARQUET.addExtension(filename));
+    }
+
+    try (FileAppender<GenericData.Record> writer = Parquet.write(localOutput(outputFile))
         .schema(schema)
         .setAll(properties)
         .createWriterFunc(createWriterFunc)
         .build()) {
       writer.addAll(Lists.newArrayList(records));
     }
-    return file;
+    return outputFile;
   }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -22,23 +22,33 @@ package org.apache.iceberg.parquet;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.schema.MessageType;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.apache.iceberg.Files.localInput;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public class TestParquet extends BaseParquetWritingTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testRowGroupSizeConfigurable() throws IOException {
@@ -59,32 +69,93 @@ public class TestParquet extends BaseParquetWritingTest {
     }
   }
 
+  @Test
+  public void testCreateModeWithoutWriterFunc() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(TableProperties.PARQUET_WRITE_MODE, "create");
+
+    File file = write(null, properties, 10, null);
+
+    thrown.expect(AlreadyExistsException.class);
+    write(null, properties, 5, file);
+  }
+
+  @Test
+  public void testCreateModeWithWriterFunc() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(TableProperties.PARQUET_WRITE_MODE, "create");
+
+    File file = write(ParquetAvroWriter::buildWriter, properties, 10, null);
+
+    thrown.expect(AlreadyExistsException.class);
+    write(ParquetAvroWriter::buildWriter, properties, 5, file);
+  }
+
+  @Test
+  public void testOverwriteModeWithoutWriterFunc() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(TableProperties.PARQUET_WRITE_MODE, "overwrite");
+
+    File file = write(null, properties, 10, null);
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      Assert.assertEquals(10, reader.getRecordCount());
+    }
+
+    write(null, properties, 5, file);
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      Assert.assertEquals(5, reader.getRecordCount());
+    }
+  }
+
+  @Test
+  public void testOverwriteModeWithWriterFunc() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(TableProperties.PARQUET_WRITE_MODE, "overwrite");
+
+    File file = write(ParquetAvroWriter::buildWriter, properties, 10, null);
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      Assert.assertEquals(10, reader.getRecordCount());
+    }
+
+    write(ParquetAvroWriter::buildWriter, properties, 5, file);
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      Assert.assertEquals(5, reader.getRecordCount());
+    }
+  }
+
+  @Test
+  public void testUnsupportedWriteMode() throws IOException {
+    thrown.expect(IllegalArgumentException.class);
+    write(null, ImmutableMap.of(TableProperties.PARQUET_WRITE_MODE, "abc"), 10, null);
+  }
+
   private File generateFileWithTwoRowGroups(Function<MessageType, ParquetValueWriter<?>> createWriterFunc)
       throws IOException {
-    Schema schema = new Schema(
-        optional(1, "intCol", IntegerType.get())
-    );
-
     int minimumRowGroupRecordCount = 100;
     int desiredRecordCount = minimumRowGroupRecordCount + 1;
-
-    List<GenericData.Record> records = new ArrayList<>(desiredRecordCount);
-    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
-    for (int i = 1; i <= desiredRecordCount; i++) {
-      GenericData.Record record = new GenericData.Record(avroSchema);
-      record.put("intCol", i);
-      records.add(record);
-    }
 
     // Force multiple row groups by making the byte size very small
     // Note there'a also minimumRowGroupRecordCount which cannot be configured so we have to write
     // at least that many records for a new row group to occur
-    return writeRecords(
-        schema,
-        ImmutableMap.of(
-            PARQUET_ROW_GROUP_SIZE_BYTES,
-            Integer.toString(minimumRowGroupRecordCount * Integer.BYTES)),
-        createWriterFunc,
-        records.toArray(new GenericData.Record[] {}));
+    Map<String, String> properties = ImmutableMap.of(
+      PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(minimumRowGroupRecordCount * Integer.BYTES));
+
+    return write(createWriterFunc, properties, desiredRecordCount, null);
+  }
+
+  private File write(Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
+                     Map<String, String> properties,
+                     int recordsNumber,
+                     File file) throws IOException {
+    Schema schema = new Schema(
+        optional(1, "intCol", IntegerType.get())
+    );
+
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    List<GenericData.Record> records = IntStream.rangeClosed(1, recordsNumber)
+        .mapToObj(index -> {
+          GenericData.Record record = new GenericData.Record(avroSchema);
+          record.put("intCol", index);
+          return record;
+        })
+        .collect(Collectors.toList());
+
+    return writeRecords(schema, properties, createWriterFunc, file, records.toArray(new GenericData.Record[] {}));
   }
 }

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -21,7 +21,9 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.parquet.page-size-bytes      | 1048576 (1 MB)     | Parquet page size                                  |
 | write.parquet.dict-size-bytes      | 2097152 (2 MB)     | Parquet dictionary page size                       |
 | write.parquet.compression-codec    | gzip               | Parquet compression codec                          |
+| write.parquet.write-mode           | overwrite          | Parquet write mode                                 |
 | write.avro.compression-codec       | gzip               | Avro compression codec                             |
+| write.avro.write-mode              | overwrite          | Avro write mode                                    |
 | write.metadata.compression-codec   | none               | Metadata compression codec; none or gzip           |
 | write.metadata.metrics.default     | truncate(16)       | Default metrics mode for all columns in the table; none, counts, truncate(length), or full |
 | write.metadata.metrics.column.col1 | (not set)          | Metrics mode for column 'col1' to allow per-column tuning; none, counts, truncate(length), or full |


### PR DESCRIPTION
Currently in Parquet and Avro writers write mode is hard-coded. For Parquet - overwrite, Avro - create.
This PR allows to set write mode using table properties for each of the above mentioned writers thus write mode can be controlled based on the needs of Iceberg table user.