### PR TITLE
test cases for parquetMetrics with multiple rowgroups

### DIFF
--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetUtil.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.parquet;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -27,6 +28,8 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.avro.generic.GenericData;
@@ -52,10 +55,12 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimeType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.types.Types.UUIDType;
+import org.apache.parquet.hadoop.ParquetFileReader;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.types.Conversions.fromByteBuffer;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
@@ -65,6 +70,180 @@ public class TestParquetUtil extends BaseParquetWritingTest {
   private final GenericFixed fixed = new GenericData.Fixed(
       org.apache.avro.Schema.createFixed("fixedCol", null, null, 4),
       "abcd".getBytes(StandardCharsets.UTF_8));
+  @Test
+  public void testMetricsForTopLevelWithMultipleRG() throws Exception {
+    Schema schema = new Schema(
+        optional(1, "booleanCol", BooleanType.get()),
+        required(2, "intCol", IntegerType.get()),
+        optional(3, "longCol", LongType.get()),
+        required(4, "floatCol", FloatType.get()),
+        optional(5, "doubleCol", DoubleType.get()),
+        optional(6, "decimalCol", DecimalType.of(10, 2)),
+        optional(7, "dateCol", DateType.get()),
+        required(8, "timeCol", TimeType.get()),
+        required(9, "timestampCol", TimestampType.withoutZone()),
+        optional(10, "uuidCol", UUIDType.get()),
+        required(11, "fixedCol", FixedType.ofLength(4)),
+        required(12, "binaryCol", BinaryType.get())
+    );
+    int minimumRowGroupRecordCount = 100;
+    List<Record> records = new ArrayList<>(201);
+
+    Record firstRecord = new Record(AvroSchemaUtil.convert(schema.asStruct()));
+    firstRecord.put("booleanCol", true);
+    firstRecord.put("intCol", 3);
+    firstRecord.put("longCol", 5L);
+    firstRecord.put("floatCol", 2.0F);
+    firstRecord.put("doubleCol", 2.0D);
+    firstRecord.put("decimalCol", new BigDecimal("3.50"));
+    firstRecord.put("dateCol", 1500);
+    firstRecord.put("timeCol", 2000L);
+    firstRecord.put("timestampCol", 0L);
+    firstRecord.put("uuidCol", uuid);
+    firstRecord.put("fixedCol", fixed);
+    firstRecord.put("binaryCol", "S".getBytes());
+    records.add(firstRecord);
+
+    Record secondRecord = new Record(AvroSchemaUtil.convert(schema.asStruct()));
+    secondRecord.put("booleanCol", false);
+    secondRecord.put("intCol", Integer.MIN_VALUE);
+    secondRecord.put("longCol", null);
+    secondRecord.put("floatCol", 1.0F);
+    secondRecord.put("doubleCol", null);
+    secondRecord.put("decimalCol", null);
+    secondRecord.put("dateCol", null);
+    secondRecord.put("timeCol", 3000L);
+    secondRecord.put("timestampCol", 1000L);
+    secondRecord.put("uuidCol", null);
+    secondRecord.put("fixedCol", fixed);
+    secondRecord.put("binaryCol", "W".getBytes());
+    records.add(secondRecord);
+
+    Record lastRecord = firstRecord;
+
+    for (int i = 0; i < minimumRowGroupRecordCount * 2; i++) {
+      Record newRecord = new Record(AvroSchemaUtil.convert(schema.asStruct()));
+      newRecord.put("booleanCol", true);
+      newRecord.put("intCol", Integer.valueOf(lastRecord.get("intCol").toString()) + 1);
+      newRecord.put("longCol", Long.valueOf(lastRecord.get("longCol").toString()) + 1L);
+      newRecord.put("floatCol", Float.valueOf(lastRecord.get("floatCol").toString()) + 1.0F);
+      newRecord.put("doubleCol", Float.valueOf(lastRecord.get("doubleCol").toString()) + 1.0D);
+      newRecord.put("decimalCol", new BigDecimal(lastRecord.get("decimalCol").toString())
+          .add(new BigDecimal("1.00")));
+      newRecord.put("dateCol", Integer.valueOf(lastRecord.get("dateCol").toString()) + 1);
+      newRecord.put("timeCol", Long.valueOf(lastRecord.get("timeCol").toString()) + 1L);
+      newRecord.put("timestampCol", Long.valueOf(lastRecord.get("timestampCol").toString()) + 1L);
+      newRecord.put("uuidCol", uuid);
+      newRecord.put("fixedCol", fixed);
+      newRecord.put("binaryCol", "S".getBytes());
+      records.add(newRecord);
+      lastRecord = new Record(newRecord, false);
+    }
+
+    // create parquet file with multiple row groups. by using smaller number of bytes
+    File parquetFile = writeRecords(
+        schema,
+        ImmutableMap.of(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(minimumRowGroupRecordCount * Integer.BYTES)),
+        null,
+        records.toArray(new GenericData.Record[] {}));
+
+    Assert.assertNotNull(parquetFile);
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
+      Assert.assertEquals(3, reader.getRowGroups().size());
+    }
+
+    Metrics metrics = ParquetUtil.fileMetrics(localInput(parquetFile));
+    Assert.assertEquals(202L, (long) metrics.recordCount());
+    assertCounts(1, 202L, 0L, metrics);
+    assertBounds(1, BooleanType.get(), false, true, metrics);
+    assertBounds(2, IntegerType.get(), Integer.MIN_VALUE, 203, metrics);
+    assertCounts(3, 202L, 1L, metrics);
+    assertBounds(3, LongType.get(), 5L, 205L, metrics);
+    assertCounts(4, 202L, 0L, metrics);
+    assertBounds(4, FloatType.get(), 1.0F, 202.0F, metrics);
+    assertCounts(5, 202L, 1L, metrics);
+    assertBounds(5, DoubleType.get(), 2.0D, 202.0D, metrics);
+    assertCounts(6, 202L, 1L, metrics);
+    assertBounds(6, DecimalType.of(10, 2), new BigDecimal("3.50"), new BigDecimal("203.50"), metrics);
+  }
+
+  @Test
+  public void testMetricsForNestedStructFieldsWithMultipleRG() throws IOException {
+    StructType leafStructType = StructType.of(
+        optional(5, "leafLongCol", LongType.get()),
+        optional(6, "leafBinaryCol", BinaryType.get())
+    );
+    StructType nestedStructType = StructType.of(
+        required(3, "longCol", LongType.get()),
+        required(4, "leafStructCol", leafStructType)
+    );
+    Schema schema = new Schema(
+        required(1, "intCol", IntegerType.get()),
+        required(2, "nestedStructCol", nestedStructType)
+    );
+
+    int minimumRowGroupRecordCount = 100;
+    List<Record> records = new ArrayList(201);
+
+    Record firstLeafStruct = new Record(AvroSchemaUtil.convert(leafStructType));
+    firstLeafStruct.put("leafLongCol", 20L);
+    firstLeafStruct.put("leafBinaryCol", "A".getBytes());
+    Record firstNestedStruct = new Record(AvroSchemaUtil.convert(nestedStructType));
+    firstNestedStruct.put("longCol", 100L);
+    firstNestedStruct.put("leafStructCol", firstLeafStruct);
+    Record firstRecord = new Record(AvroSchemaUtil.convert(schema.asStruct()));
+    firstRecord.put("intCol", 5);
+    firstRecord.put("nestedStructCol", firstNestedStruct);
+    records.add(firstRecord);
+
+    Record lastLeafStruct = firstLeafStruct;
+    Record lastNestedStruct = firstNestedStruct;
+    Record lastRecord = firstRecord;
+
+    for (int i = 0; i < minimumRowGroupRecordCount * 2; i++) {
+      Record newLeafStruct = new Record(AvroSchemaUtil.convert(leafStructType));
+      newLeafStruct.put("leafLongCol", Long.valueOf(lastLeafStruct.get("leafLongCol").toString()) + 1L);
+      newLeafStruct.put("leafBinaryCol", "A".getBytes());
+      Record newNestedStruct = new Record(AvroSchemaUtil.convert(nestedStructType));
+      newNestedStruct.put("longCol", Long.valueOf(lastNestedStruct.get("longCol").toString()) + 1L);
+      newNestedStruct.put("leafStructCol", newLeafStruct);
+      Record newRecord = new Record(AvroSchemaUtil.convert(schema.asStruct()));
+      newRecord.put("intCol", Integer.valueOf(lastRecord.get("intCol").toString()) + 1);
+      newRecord.put("nestedStructCol", newNestedStruct);
+      records.add(newRecord);
+
+      lastLeafStruct = new Record(newLeafStruct, false);
+      lastNestedStruct = new Record(newNestedStruct, false);
+      lastRecord = new Record(newRecord, false);
+    }
+
+    // create parquet file with multiple row groups. by using smaller number of bytes
+    File parquetFile = writeRecords(
+        schema,
+        ImmutableMap.of(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(minimumRowGroupRecordCount * Long.BYTES)),
+        null,
+        records.toArray(new GenericData.Record[] {}));
+
+    Assert.assertNotNull(parquetFile);
+
+    // validate the # of rowgroups.
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
+      Assert.assertEquals(3, reader.getRowGroups().size());
+    }
+
+    Metrics metrics = ParquetUtil.fileMetrics(localInput(parquetFile));
+    Assert.assertEquals(201L, (long) metrics.recordCount());
+    assertCounts(1, 201L, 0L, metrics);
+    assertBounds(1, IntegerType.get(), 5, 205, metrics);
+    assertCounts(3, 201L, 0L, metrics);
+    assertBounds(3, LongType.get(), 100L, 300L, metrics);
+    assertCounts(5, 201L, 0L, metrics);
+    assertBounds(5, LongType.get(), 20L, 220L, metrics);
+    assertCounts(6, 201L, 0L, metrics);
+    assertBounds(6, BinaryType.get(),
+        ByteBuffer.wrap("A".getBytes()), ByteBuffer.wrap("A".getBytes()), metrics);
+  }
 
   @Test
   public void testMetricsForTopLevelFields() throws IOException {


### PR DESCRIPTION
this PR is for issue #132.
-- tested firstLevel fields and nestedStructure with multipleRowGroups.

@aokolnychyi can you please review.