### PR TITLE
Correctly publish artifacts on JitPack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,10 +64,6 @@ subprojects {
   apply plugin: 'maven' // make pom files for deployment
   apply plugin: 'nebula.maven-base-publish'
 
-  artifacts {
-    archives sourceJar
-  }
-
   compileJava {
     options.encoding = "UTF-8"
   }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+  - ./gradlew publishToMavenLocal


### PR DESCRIPTION
The Gradle install target produces invalid POM files that are missing
the dependencyManagement section and versions for some dependencies.
Instead, we directly tell JitPack to run the correct Gradle target.

This reverts the change in #310.