### PR TITLE
Optimistically query and replace files atomically

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -42,4 +42,12 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @return this for method chaining
    */
   RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd);
+
+  /**
+   * Fails to rewrite unless the current snapshot on commit is the queryTimeSnapshot.
+   *
+   * @param queryTimeSnapshot the snapshot from which the set of files to replace was constructed
+   * @return this for method chaining
+   */
+  RewriteFiles failUnlessFromSnapshot(Snapshot queryTimeSnapshot);
 }


### PR DESCRIPTION
Fixes #316 

Hi, I'm trying to learn about iceberg.

One option to perform the copy-on-write/eager updates is to provide the queryTime snapshot to the ReplaceFiles SnapshotProducer. Then if the snapshot is not the queryTime snapshot, fail the commit.

I'm hoping this doesn't get retried because it is an IllegalStateException and not a CommitFailedException.

excerpt from base SnapshotProducer
```
      Tasks.foreach(ops)
          .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
          .exponentialBackoff(
              base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
              base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
              2.0 /* exponential */)
          .onlyRetryOn(CommitFailedException.class)
          .run(taskOps -> {
```