### PR TITLE
Refactor BaseMetastoreCatalog and remove dependency on Hadoop Config

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import com.google.common.collect.Maps;
 import java.util.Locale;
 import java.util.Map;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -46,12 +45,6 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     }
   }
 
-  private final Configuration conf;
-
-  protected BaseMetastoreCatalog(Configuration conf) {
-    this.conf = conf;
-  }
-
   @Override
   public Table createTable(
       TableIdentifier identifier,
@@ -59,7 +52,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       PartitionSpec spec,
       String location,
       Map<String, String> properties) {
-    TableOperations ops = newTableOps(conf, identifier);
+    TableOperations ops = newTableOps(identifier);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table already exists: " + identifier);
     }
@@ -68,7 +61,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     if (location != null) {
       baseLocation = location;
     } else {
-      baseLocation = defaultWarehouseLocation(conf, identifier);
+      baseLocation = defaultWarehouseLocation(identifier);
     }
 
     TableMetadata metadata = TableMetadata.newTableMetadata(
@@ -85,7 +78,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
   @Override
   public Table loadTable(TableIdentifier identifier) {
-    TableOperations ops = newTableOps(conf, identifier);
+    TableOperations ops = newTableOps(identifier);
     if (ops.current() == null) {
       String name = identifier.name();
       TableType type = TableType.from(name);
@@ -100,7 +93,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
   }
 
   private Table loadMetadataTable(TableIdentifier identifier, TableType type) {
-    TableOperations ops = newTableOps(conf, identifier);
+    TableOperations ops = newTableOps(identifier);
     if (ops.current() == null) {
       throw new NoSuchTableException("Table does not exist: " + identifier);
     }
@@ -123,7 +116,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     }
   }
 
-  protected abstract TableOperations newTableOps(Configuration newConf, TableIdentifier tableIdentifier);
+  protected abstract TableOperations newTableOps(TableIdentifier tableIdentifier);
 
-  protected abstract String defaultWarehouseLocation(Configuration hadoopConf, TableIdentifier tableIdentifier);
+  protected abstract String defaultWarehouseLocation(TableIdentifier tableIdentifier);
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -35,10 +35,11 @@ import org.apache.thrift.TException;
 public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
 
   private final HiveClientPool clients;
+  private final Configuration conf;
 
   public HiveCatalog(Configuration conf) {
-    super(conf);
     this.clients = new HiveClientPool(2, conf);
+    this.conf = conf;
   }
 
   @Override
@@ -113,14 +114,14 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
-  public TableOperations newTableOps(Configuration configuration, TableIdentifier tableIdentifier) {
+  public TableOperations newTableOps(TableIdentifier tableIdentifier) {
     String dbName = tableIdentifier.namespace().level(0);
     String tableName = tableIdentifier.name();
-    return new HiveTableOperations(configuration, clients, dbName, tableName);
+    return new HiveTableOperations(conf, clients, dbName, tableName);
   }
 
-  protected String defaultWarehouseLocation(Configuration hadoopConf, TableIdentifier tableIdentifier) {
-    String warehouseLocation = hadoopConf.get("hive.metastore.warehouse.dir");
+  protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+    String warehouseLocation = conf.get("hive.metastore.warehouse.dir");
     Preconditions.checkNotNull(
         warehouseLocation,
         "Warehouse location is not set: hive.metastore.warehouse.dir=null");


### PR DESCRIPTION
IMHO, Class `BaseMetastoreCatalog` should not contain assumptions that we are dealing with a Hadoop/ Hive metastore, and hence it should not contain references to a Hadoop `Configuration` class