### PR TITLE
Add dropTableAndData to Catalog API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -121,6 +121,14 @@ public interface Catalog {
   boolean dropTable(TableIdentifier identifier);
 
   /**
+   * Drop a table and remove all data and metadata files.
+   *
+   * @param identifier a table identifier
+   * @return true if the table was dropped, false if the table did not exist
+   */
+  boolean dropTableAndData(TableIdentifier identifier);
+
+  /**
    * Rename a table.
    *
    * @param from identifier of the table to rename

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -19,16 +19,30 @@
 
 package org.apache.iceberg;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class BaseMetastoreCatalog implements Catalog {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseMetastoreCatalog.class);
+
   enum TableType {
     ENTRIES,
     FILES,
@@ -90,6 +104,91 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     }
 
     return new BaseTable(ops, identifier.toString());
+  }
+
+  @Override
+  public boolean dropTableAndData(TableIdentifier identifier) {
+    // load the table state to get the data files to delete
+    TableOperations ops = newTableOps(identifier);
+    if (ops.current() == null) {
+      return false;
+    }
+
+    // drop the table
+    if (!dropTable(identifier)) {
+      // the table was dropped by another process after it was loaded, do nothing
+      return false;
+    }
+
+    // Reads and deletes are done using Tasks.foreach(...).suppressFailureWhenFinished to complete
+    // as much of the delete work as possible and avoid orphaned data or manifest files.
+
+    Set<String> manifestListsToDelete = Sets.newHashSet();
+    Set<ManifestFile> manifestsToDelete = Sets.newHashSet();
+    for (Snapshot snapshot : ops.current().snapshots()) {
+      manifestsToDelete.addAll(snapshot.manifests());
+      // add the manifest list to the delete set, if present
+      if (snapshot.manifestListLocation() != null) {
+        manifestListsToDelete.add(snapshot.manifestListLocation());
+      }
+    }
+
+    LOG.info("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
+
+    // run all of the deletes
+
+    FileIO io = ops.io();
+    deleteFiles(io, manifestsToDelete);
+
+    Tasks.foreach(Iterables.transform(manifestsToDelete, ManifestFile::path))
+        .noRetry().suppressFailureWhenFinished()
+        .onFailure((manifest, exc) -> LOG.warn("Delete failed for manifest: {}", manifest, exc))
+        .run(io::deleteFile);
+
+    Tasks.foreach(manifestListsToDelete)
+        .noRetry().suppressFailureWhenFinished()
+        .onFailure((list, exc) -> LOG.warn("Delete failed for manifest list: {}", list, exc))
+        .run(io::deleteFile);
+
+    Tasks.foreach(ops.current().file().location())
+        .noRetry().suppressFailureWhenFinished()
+        .onFailure((list, exc) -> LOG.warn("Delete failed for metadata file: {}", list, exc))
+        .run(io::deleteFile);
+
+    return true;
+  }
+
+  private void deleteFiles(FileIO io, Set<ManifestFile> allManifests) {
+    // keep track of deleted files in a map that can be cleaned up when memory runs low
+    Map<String, Boolean> deletedFiles = new MapMaker()
+        .concurrencyLevel(ThreadPools.WORKER_THREAD_POOL_SIZE)
+        .weakKeys()
+        .makeMap();
+
+    Tasks.foreach(allManifests)
+        .noRetry().suppressFailureWhenFinished()
+        .executeWith(ThreadPools.getWorkerPool())
+        .onFailure((item, exc) ->
+            LOG.warn("Failed to get deleted files: this may cause orphaned data files", exc)
+        ).run(manifest -> {
+      try (ManifestReader reader = ManifestReader.read(io.newInputFile(manifest.path()))) {
+        for (ManifestEntry entry : reader.entries()) {
+          // intern the file path because the weak key map uses identity (==) instead of equals
+          String path = entry.file().path().toString().intern();
+          Boolean alreadyDeleted = deletedFiles.putIfAbsent(path, true);
+          if (alreadyDeleted == null || !alreadyDeleted) {
+            try {
+              io.deleteFile(path);
+            } catch (RuntimeException e) {
+              // this may happen if the map of deleted files gets cleaned up by gc
+              LOG.warn("Delete failed for data file: {}", path, e);
+            }
+          }
+        }
+      } catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to read manifest file: " + manifest.path());
+      }
+    });
   }
 
   private Table loadMetadataTable(TableIdentifier identifier, TableType type) {

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -65,7 +65,9 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
 
     try {
       clients.run(client -> {
-        client.dropTable(database, identifier.name());
+        client.dropTable(database, identifier.name(),
+            false /* do not delete data */,
+            false /* throw NoSuchObjectException if the table doesn't exist */);
         return null;
       });
 


### PR DESCRIPTION
This fixes [concerns](https://github.com/apache/incubator-iceberg/pull/240#discussion_r298692031) [raised](https://github.com/apache/incubator-iceberg/pull/240#discussion_r298690327) on the commit that added `HiveCatalog`. Specifically:

* The call to Hive's drop table should specify not to delete data, in case older tables are not external
* There should be a way to clean up table data as part of the drop operation

For the second change, this adds `Catalog.dropTableAndData` that deletes all files referenced in the metadata tree.