### PR TITLE
Fix transaction cleanup.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -270,11 +270,11 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       } else {
         // saved may not be present if the latest metadata couldn't be loaded due to eventual
         // consistency problems in refresh. in that case, don't clean up.
-        LOG.info("Failed to load committed snapshot, skipping manifest clean-up");
+        LOG.warn("Failed to load committed snapshot, skipping manifest clean-up");
       }
 
     } catch (RuntimeException e) {
-      LOG.info("Failed to load committed table metadata, skipping manifest clean-up", e);
+      LOG.warn("Failed to load committed table metadata, skipping manifest clean-up", e);
     }
   }
 


### PR DESCRIPTION
#218 refactored how intermediate metadata files are handled in transactions by adding a callback to collect files to delete in each transaction attempt and delete just that set of files when the transaction successfully commits. This avoided deleting files that were deleted in an early attempt and eventually used, but it fails to delete other metadata files that are deleted once and removed from operation caches.

A better solution is to track all of the metadata files that are deleted in any attempt and delete the ones that are not referenced by table metadata after the commit succeeds.

This uses a set to track deleted files, but does not clear that set between transaction commit attempts. Instead, all manifests and manifest lists that are committed are collected and used to block deletes.

Fixes #330.