### PR TITLE
test cases for parquetMetrics with multiple rowgroup

### DIFF
--- a/parquet/src/test/java/org/apache/iceberg/parquet/ParquetWritingTestUtils.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/ParquetWritingTestUtils.java
@@ -46,6 +46,10 @@ class ParquetWritingTestUtils {
     return writeRecords(temp, schema, Collections.emptyMap(), null, records);
   }
 
+  static File writeRecords(TemporaryFolder temp, Schema schema, Map<String, String> properties, GenericData.Record... records) throws IOException {
+    return writeRecords(temp, schema, properties, null, records);
+  }
+
   static File writeRecords(
       TemporaryFolder temp,
       Schema schema, Map<String, String> properties,

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
@@ -21,31 +21,18 @@ package org.apache.iceberg.parquet;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestMetrics;
-import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.types.Types;
 import org.apache.parquet.hadoop.ParquetFileReader;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.Files.localInput;
-import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
-import static org.apache.iceberg.types.Types.NestedField.optional;
-import static org.apache.iceberg.types.Types.NestedField.required;
 
 /**
  * Test Metrics for Parquet.
@@ -71,7 +58,7 @@ public class TestParquetMetrics extends TestMetrics {
   }
 
   @Override
-  public int getRowGroupSize(File parquetFile) throws IOException {
+  public int splitCount(File parquetFile) throws IOException {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
       return reader.getRowGroups().size();
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.parquet;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Schema;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
@@ -21,13 +21,31 @@ package org.apache.iceberg.parquet;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestMetrics;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.junit.Assert;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 /**
  * Test Metrics for Parquet.
@@ -45,5 +63,17 @@ public class TestParquetMetrics extends TestMetrics {
   @Override
   public File writeRecords(Schema schema, GenericData.Record... records) throws IOException {
     return ParquetWritingTestUtils.writeRecords(temp, schema, records);
+  }
+
+  @Override
+  public File writeRecords(Schema schema, Map<String, String> properties, GenericData.Record... records) throws IOException {
+    return ParquetWritingTestUtils.writeRecords(temp, schema, properties, records);
+  }
+
+  @Override
+  public int getRowGroupSize(File parquetFile) throws IOException {
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
+      return reader.getRowGroups().size();
+    }
   }
 }


### PR DESCRIPTION
this PR is for issue #132.
-- tested firstLevel fields and nestedStructure with multipleRowGroups.

closing old [PR-314](https://github.com/apache/incubator-iceberg/pull/314)

@rdblue @aokolnychyi can you please check.