### PR TITLE
Return full stats for added files from Snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -167,7 +167,7 @@ class BaseSnapshot implements Snapshot {
       for (ManifestEntry entry : entries) {
         switch (entry.status()) {
           case ADDED:
-            adds.add(entry.file().copyWithoutStats());
+            adds.add(entry.file().copy());
             break;
           case DELETED:
             deletes.add(entry.file().copyWithoutStats());


### PR DESCRIPTION
This restores stats for data files returned by `Snapshot#addedFiles` for use in incremental processing, like #315.

Deleted files are still cached without file stats to save space.