### PR TITLE
Fix reading of old .metadata.json.gz files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -116,6 +116,11 @@ public class TableMetadataParser {
     return codec.extension + ".metadata.json";
   }
 
+  public static String getOldFileExtension(Codec codec) {
+    // we have to be backward-compatible with .metadata.json.gz files
+    return ".metadata.json" + codec.extension;
+  }
+
   public static String toJson(TableMetadata metadata) {
     StringWriter writer = new StringWriter();
     try {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -178,12 +178,26 @@ public class HadoopTableOperations implements TableOperations {
       if (fs.exists(metadataFile)) {
         return metadataFile;
       }
+
+      if (codec.equals(TableMetadataParser.Codec.GZIP)) {
+        // we have to be backward-compatible with .metadata.json.gz files
+        metadataFile = oldMetadataFilePath(metadataVersion, codec);
+        fs = getFileSystem(metadataFile, conf);
+        if (fs.exists(metadataFile)) {
+          return metadataFile;
+        }
+      }
     }
+
     return null;
   }
 
   private Path metadataFilePath(int metadataVersion, TableMetadataParser.Codec codec) {
     return metadataPath("v" + metadataVersion + TableMetadataParser.getFileExtension(codec));
+  }
+
+  private Path oldMetadataFilePath(int metadataVersion, TableMetadataParser.Codec codec) {
+    return metadataPath("v" + metadataVersion + TableMetadataParser.getOldFileExtension(codec));
   }
 
   private Path metadataPath(String filename) {


### PR DESCRIPTION
Reading of iceberg tables with metadata files like `v1.metadata.json.gz` broke after #258.

Example stack trace:
```
org.apache.iceberg.exceptions.ValidationException: Metadata file for version 2 is missing

	at org.apache.iceberg.hadoop.HadoopTableOperations.refresh(HadoopTableOperations.java:82)
	at org.apache.iceberg.hadoop.HadoopTableOperations.current(HadoopTableOperations.java:68)
	at org.apache.iceberg.hadoop.HadoopTables.load(HadoopTables.java:62)
	at org.apache.iceberg.hadoop.TestHadoopCommits.testCanReadOldCompressedManifestFiles(TestHadoopCommits.java:331)
```

In this PR we add a test case that reproduces the issue, and a fix.