### PR TITLE
Migrate spark table to iceberg table

### DIFF
--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -111,6 +111,7 @@ public class TestHiveMetastore {
     HiveConf newHiveConf = new HiveConf(new Configuration(), TestHiveMetastore.class);
     newHiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, "thrift://localhost:" + port);
     newHiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:" + hiveLocalDir.getAbsolutePath());
+    newHiveConf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname,"false");
     return newHiveConf;
   }
 

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -102,7 +102,7 @@ public class TestHiveMetastore {
         .transportFactory(new TTransportFactory())
         .protocolFactory(new TBinaryProtocol.Factory())
         .minWorkerThreads(3)
-        .maxWorkerThreads(8);
+        .maxWorkerThreads(10);
 
     return new TThreadPoolServer(args);
   }

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -102,7 +102,7 @@ public class TestHiveMetastore {
         .transportFactory(new TTransportFactory())
         .protocolFactory(new TBinaryProtocol.Factory())
         .minWorkerThreads(3)
-        .maxWorkerThreads(12);
+        .maxWorkerThreads(10);
 
     return new TThreadPoolServer(args);
   }

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -102,7 +102,7 @@ public class TestHiveMetastore {
         .transportFactory(new TTransportFactory())
         .protocolFactory(new TBinaryProtocol.Factory())
         .minWorkerThreads(3)
-        .maxWorkerThreads(5);
+        .maxWorkerThreads(8);
 
     return new TThreadPoolServer(args);
   }
@@ -111,7 +111,7 @@ public class TestHiveMetastore {
     HiveConf newHiveConf = new HiveConf(new Configuration(), TestHiveMetastore.class);
     newHiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, "thrift://localhost:" + port);
     newHiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:" + hiveLocalDir.getAbsolutePath());
-    newHiveConf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname,"false");
+    newHiveConf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname, "false");
     return newHiveConf;
   }
 

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -102,7 +102,7 @@ public class TestHiveMetastore {
         .transportFactory(new TTransportFactory())
         .protocolFactory(new TBinaryProtocol.Factory())
         .minWorkerThreads(3)
-        .maxWorkerThreads(10);
+        .maxWorkerThreads(12);
 
     return new TThreadPoolServer(args);
   }

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -102,7 +102,7 @@ public class TestHiveMetastore {
         .transportFactory(new TTransportFactory())
         .protocolFactory(new TBinaryProtocol.Factory())
         .minWorkerThreads(3)
-        .maxWorkerThreads(10);
+        .maxWorkerThreads(5);
 
     return new TThreadPoolServer(args);
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/hacks/Hive.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/hacks/Hive.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.hive.HiveUtils$;
@@ -62,17 +61,5 @@ public class Hive {
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(expressions).asScala().toSeq();
 
     return client.getPartitionsByFilter(client.getTable(db, table), exprs);
-  }
-
-  public static CatalogTable getTable(SparkSession spark, String name) {
-    List<String> parts = Lists.newArrayList(Splitter.on('.').limit(2).split(name));
-    String db = parts.size() == 1 ? "default" : parts.get(0);
-    String table = parts.get(parts.size() == 1 ? 0 : 1);
-
-    HiveClient client = HiveUtils$.MODULE$.newClientForMetadata(
-            spark.sparkContext().conf(),
-            spark.sparkContext().hadoopConfiguration());
-
-    return client.getTable(db, table);
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/hacks/Hive.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/hacks/Hive.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.hive.HiveUtils$;
@@ -61,5 +62,17 @@ public class Hive {
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(expressions).asScala().toSeq();
 
     return client.getPartitionsByFilter(client.getTable(db, table), exprs);
+  }
+
+  public static CatalogTable getTable(SparkSession spark, String name) {
+    List<String> parts = Lists.newArrayList(Splitter.on('.').limit(2).split(name));
+    String db = parts.size() == 1 ? "default" : parts.get(0);
+    String table = parts.get(parts.size() == 1 ? 0 : 1);
+
+    HiveClient client = HiveUtils$.MODULE$.newClientForMetadata(
+            spark.sparkContext().conf(),
+            spark.sparkContext().hadoopConfiguration());
+
+    return client.getTable(db, table);
   }
 }

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark
 
+import com.google.common.collect.ImmutableMap
 import com.google.common.collect.Maps
 import java.nio.ByteBuffer
 import java.util
@@ -27,7 +28,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.iceberg._
 import org.apache.iceberg.exceptions.NoSuchTableException
-import org.apache.iceberg.hadoop.HadoopInputFile
+import org.apache.iceberg.hadoop.{HadoopInputFile, HadoopTables}
 import org.apache.iceberg.orc.OrcMetrics
 import org.apache.iceberg.parquet.ParquetUtil
 import org.apache.iceberg.spark.hacks.Hive
@@ -36,7 +37,6 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 object SparkTableUtil {
   /**
@@ -302,7 +302,7 @@ object SparkTableUtil {
     }
   }
 
-  def buildManifest(table: Table,
+  private def buildManifest(table: Table,
                     sparkDataFiles: Seq[SparkDataFile],
                     partitionSpec: PartitionSpec): ManifestFile = {
     val outputFile = table.io
@@ -319,70 +319,63 @@ object SparkTableUtil {
     writer.toManifestFile
   }
 
-  def partitionToMap(partition: String): Map[String, String] = {
-    val map = new mutable.HashMap[String, String]()
-    val list = partition.split("/")
-    list.foreach { str =>
-      val kv = str.split("=")
-      map.put(kv(0), kv(1))
-    }
-
-    map.toMap
-  }
-
   /**
-   * Migrate a spark table to a iceberg table.
+   * Import a spark table to a iceberg table.
    *
-   * The migration uses the spark session to get table metadata. It assumes no
+   * The import uses the spark session to get table metadata. It assumes no
    * operation is going on original table and target table and thus is not
    * thread-safe.
    *
-   * @param dbName the database name of the table to be migrated
-   * @param tableName the table to be migrated
-   * @param table the target table to migrate in
+   * @param source the database name of the table to be import
+   * @param location the location used to store table metadata
    *
-   * @return table the target table
+   * @return table the imported table
    */
-  def migrateSparkTable(dbName: String, tableName: String, table: Table): Table = {
+  def importSparkTable(source: TableIdentifier, location: String): Table = {
     val sparkSession = SparkSession.builder().getOrCreate()
+    import sparkSession.sqlContext.implicits._
+
+    val dbName = source.database.getOrElse("default")
+    val tableName = source.table
 
     if (!sparkSession.catalog.tableExists(dbName, tableName)) {
       throw new NoSuchTableException(s"Table $dbName.$tableName does not exist")
     }
 
-    val tableMetadata = sparkSession.sessionState.catalog.
-      getTableMetadata(new TableIdentifier(tableName, Some(dbName)))
-
-    val format = tableMetadata.provider.getOrElse("none")
-    if (format != "avro" && format != "parquet" && format != "orc") {
-      throw new UnsupportedOperationException(s"Unsupported format: $format")
-    }
-
-    val location = tableMetadata.location.toString
     val partitionSpec = SparkSchemaUtil.specForTable(sparkSession, s"$dbName.$tableName")
+    val conf = sparkSession.sparkContext.hadoopConfiguration
+    val tables = new HadoopTables(conf)
+    val schema = SparkSchemaUtil.schemaForTable(sparkSession, s"$dbName.$tableName")
+    val table = tables.create(schema, partitionSpec, ImmutableMap.of(), location)
+    val appender = table.newAppend()
 
-    val fastAppender = table.newFastAppend()
+    if (partitionSpec == PartitionSpec.unpartitioned) {
+      val tableMetadata = sparkSession.sessionState.catalog.getTableMetadata(source)
+      val format = tableMetadata.provider.getOrElse("none")
 
-    val partitions = sparkSession.sessionState.catalog.externalCatalog
-      .listPartitionNames(dbName, tableName)
-    if (partitions.isEmpty) {
-      val dataFiles = SparkTableUtil.listPartition(Map.empty[String, String], location, format)
-      fastAppender.appendManifest(buildManifest(table, dataFiles, PartitionSpec.unpartitioned))
+      if (format != "avro" && format != "parquet" && format != "orc") {
+        throw new UnsupportedOperationException(s"Unsupported format: $format")
+      }
+      listPartition(Map.empty[String, String], tableMetadata.location.toString,
+        format).foreach{f => appender.appendFile(f.toDataFile(PartitionSpec.unpartitioned))}
+      appender.commit()
     } else {
-      // Retrieve data files according to partition. result = [[datafiles], [datafiles]]
-      val dataFiles = partitions.map { e =>
-        SparkTableUtil.listPartition(partitionToMap(e), location + "/" + e, format)
-      }
-
-      // Append manifest for each partition
-      dataFiles.foreach { partition =>
-        fastAppender.appendManifest(buildManifest(table, partition, partitionSpec))
-      }
+      val partitions = partitionDF(sparkSession, s"$dbName.$tableName")
+      partitions.flatMap { row =>
+        listPartition(row.getMap[String, String](0).toMap, row.getString(1), row.getString(2))
+      }.coalesce(1).mapPartitions {
+        files =>
+          val tables = new HadoopTables(new Configuration())
+          val table = tables.load(location)
+          val appender = table.newAppend()
+          appender.appendManifest(buildManifest(table, files.toSeq, partitionSpec))
+          appender.commit()
+          Seq.empty[String].iterator
+      }.count()
     }
 
-    fastAppender.apply()
-    fastAppender.commit()
     table
   }
+
 }
 

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -311,7 +311,7 @@ object SparkTableUtil {
       partitionSpec: PartitionSpec,
       basePath: String): Iterator[Manifest] = {
     if (sparkDataFiles.isEmpty) {
-      return Seq.empty.iterator
+      Seq.empty.iterator
     } else {
       val io = new HadoopFileIO(conf.get())
       val ctx = TaskContext.get()

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark
 
-import com.google.common.collect.ImmutableMap
 import com.google.common.collect.Maps
 import java.nio.ByteBuffer
 import java.util
@@ -147,7 +146,7 @@ object SparkTableUtil {
           arrayToMap(lowerBounds),
           arrayToMap(upperBounds)))
 
-      if (partitionKey == "") {
+      if (partitionKey.isEmpty) {
         builder.build()
       } else {
         builder.withPartitionPath(partitionKey).build()
@@ -312,7 +311,7 @@ object SparkTableUtil {
       partitionSpec: PartitionSpec,
       basePath: String): Iterator[Manifest] = {
     if (sparkDataFiles.isEmpty) {
-      Seq.empty.iterator
+      return Seq.empty.iterator
     }
 
     val io = new HadoopFileIO(conf.get())
@@ -386,7 +385,7 @@ object SparkTableUtil {
     val appender = table.newAppend()
 
     if (partitionSpec == PartitionSpec.unpartitioned) {
-      val catalogTable = Hive.getTable(sparkSession, s"$dbName.$tableName")
+      val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(source)
       val files = listPartition(Map.empty[String, String], catalogTable.location.toString,
         catalogTable.storage.serde.getOrElse("none"))
       files.foreach{f => appender.appendFile(f.toDataFile(PartitionSpec.unpartitioned))}

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -26,7 +26,8 @@ import java.util
 import java.util.UUID
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, PathFilter}
-import org.apache.iceberg._
+import org.apache.iceberg.{DataFile, DataFiles, FileFormat, ManifestFile, ManifestWriter, Metrics,
+  MetricsConfig, PartitionSpec, Table}
 import org.apache.iceberg.exceptions.NoSuchTableException
 import org.apache.iceberg.hadoop.{HadoopInputFile, HadoopTables}
 import org.apache.iceberg.orc.OrcMetrics
@@ -303,13 +304,13 @@ object SparkTableUtil {
   }
 
   private def buildManifest(table: Table,
-                    sparkDataFiles: Seq[SparkDataFile],
-                    partitionSpec: PartitionSpec): ManifestFile = {
+      sparkDataFiles: Seq[SparkDataFile],
+      partitionSpec: PartitionSpec): ManifestFile = {
     val outputFile = table.io
       .newOutputFile(FileFormat.AVRO.addExtension("/tmp/" + UUID.randomUUID.toString))
     val writer = ManifestWriter.write(partitionSpec, outputFile)
     try {
-      for (file <- sparkDataFiles) {
+      sparkDataFiles.foreach { file =>
         writer.add(file.toDataFile(partitionSpec))
       }
     } finally {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -125,13 +125,25 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
   }
 
   @Test
-  public void testMigrateSparkTable() throws Exception {
+  public void testImportPartitionedTable() throws Exception {
     File parent = temp.newFolder("iceberg_warehouse");
     File location = new File(parent, "test");
     spark.table(qualifiedTableName).write().mode("overwrite").partitionBy("data").format("parquet")
             .saveAsTable("test_parquet");
     TableIdentifier source = spark.sessionState().sqlParser().parseTableIdentifier("test_parquet");
-    SparkTableUtil.importSparkTable(source, location.getCanonicalPath());
+    SparkTableUtil.importSparkTable(source, location.getCanonicalPath(), 1, "/tmp");
+    long count = spark.read().format("iceberg").load(location.toString()).count();
+    Assert.assertEquals("three values ", 3, count);
+  }
+
+  @Test
+  public void testImportUnpartitionedTable() throws Exception {
+    File parent = temp.newFolder("iceberg_warehouse");
+    File location = new File(parent, "test_unpartitioned_table");
+    spark.table(qualifiedTableName).write().mode("overwrite").format("parquet")
+            .saveAsTable("test_parquet");
+    TableIdentifier source = spark.sessionState().sqlParser().parseTableIdentifier("test_parquet");
+    SparkTableUtil.importSparkTable(source, location.getCanonicalPath(), 1,  "/tmp");
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -149,7 +149,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
 
   @Test
   public void testImportUnpartitionedTable() throws Exception {
-    File parent = temp.newFolder("iceberg_warehouse");
+    File parent = temp.newFolder("iceberg_warehouse2");
     File location = new File(parent, "unpartitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").format("parquet")
             .saveAsTable("test_unpartitioned_table");

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -56,7 +56,10 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
   private static SparkSession spark = null;
 
   @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  public TemporaryFolder temp1 = new TemporaryFolder();
+
+  @Rule
+  public TemporaryFolder temp2 = new TemporaryFolder();
 
   @BeforeClass
   public static void startSpark() {
@@ -130,8 +133,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
 
   @Test
   public void testImportPartitionedTable() throws Exception {
-    File parent = temp.newFolder("iceberg_warehouse");
-    File location = new File(parent, "partitioned_table");
+    File location = temp1.newFolder("partitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").partitionBy("data").format("parquet")
             .saveAsTable("test_partitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
@@ -141,7 +143,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
             location.getCanonicalPath());
-    File stageDir = temp.newFolder("staging1");
+    File stageDir = temp1.newFolder("staging1");
     SparkTableUtil.importSparkTable(source, stageDir.getCanonicalPath(), table);
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);
@@ -149,8 +151,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
 
   @Test
   public void testImportUnpartitionedTable() throws Exception {
-    File parent = temp.newFolder("iceberg_warehouse2");
-    File location = new File(parent, "unpartitioned_table");
+    File location = temp2.newFolder("unpartitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").format("parquet")
             .saveAsTable("test_unpartitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
@@ -160,7 +161,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
             location.getCanonicalPath());
-    File stageDir = temp.newFolder("staging2");
+    File stageDir = temp2.newFolder("staging2");
     SparkTableUtil.importSparkTable(source, stageDir.getCanonicalPath(), table);
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -129,37 +129,39 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
   }
 
   @Test
-  public void testImportPartitionedHadoopTable() throws Exception {
+  public void testImportPartitionedTable() throws Exception {
     File parent = temp.newFolder("iceberg_warehouse");
-    File location = new File(parent, "partitioned_hadoop_table");
+    File location = new File(parent, "partitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").partitionBy("data").format("parquet")
-            .saveAsTable("test_partitioned_hadoop_table");
+            .saveAsTable("test_partitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
-            .parseTableIdentifier("test_partitioned_hadoop_table");
+            .parseTableIdentifier("test_partitioned_table");
     HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
     Table table = tables.create(SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
             location.getCanonicalPath());
-    SparkTableUtil.importSparkTable(source, "/tmp", table);
+    File stageDir = temp.newFolder("staging1");
+    SparkTableUtil.importSparkTable(source, stageDir.getCanonicalPath(), table);
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);
   }
 
   @Test
-  public void testImportUnpartitionedHadoopTable() throws Exception {
+  public void testImportUnpartitionedTable() throws Exception {
     File parent = temp.newFolder("iceberg_warehouse");
-    File location = new File(parent, "test_unpartitioned_hadoop_table");
+    File location = new File(parent, "unpartitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").format("parquet")
-            .saveAsTable("test_unpartitioned_hadoop_table");
+            .saveAsTable("test_unpartitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
-            .parseTableIdentifier("test_unpartitioned_hadoop_table");
+            .parseTableIdentifier("test_unpartitioned_table");
     HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
     Table table = tables.create(SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
             location.getCanonicalPath());
-    SparkTableUtil.importSparkTable(source, "/tmp", table);
+    File stageDir = temp.newFolder("staging2");
+    SparkTableUtil.importSparkTable(source, stageDir.getCanonicalPath(), table);
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -56,10 +56,8 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
   private static SparkSession spark = null;
 
   @Rule
-  public TemporaryFolder temp1 = new TemporaryFolder();
+  public TemporaryFolder temp = new TemporaryFolder();
 
-  @Rule
-  public TemporaryFolder temp2 = new TemporaryFolder();
 
   @BeforeClass
   public static void startSpark() {
@@ -133,7 +131,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
 
   @Test
   public void testImportPartitionedTable() throws Exception {
-    File location = temp1.newFolder("partitioned_table");
+    File location = temp.newFolder("partitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").partitionBy("data").format("parquet")
             .saveAsTable("test_partitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
@@ -143,15 +141,14 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
             location.getCanonicalPath());
-    File stageDir = temp1.newFolder("staging1");
-    SparkTableUtil.importSparkTable(source, stageDir.getCanonicalPath(), table);
+    SparkTableUtil.importSparkTable(source, "tmp", table);
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);
   }
 
   @Test
   public void testImportUnpartitionedTable() throws Exception {
-    File location = temp2.newFolder("unpartitioned_table");
+    File location = temp.newFolder("unpartitioned_table");
     spark.table(qualifiedTableName).write().mode("overwrite").format("parquet")
             .saveAsTable("test_unpartitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
@@ -161,8 +158,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
             location.getCanonicalPath());
-    File stageDir = temp2.newFolder("staging2");
-    SparkTableUtil.importSparkTable(source, stageDir.getCanonicalPath(), table);
+    SparkTableUtil.importSparkTable(source, "/tmp", table);
     long count = spark.read().format("iceberg").load(location.toString()).count();
     Assert.assertEquals("three values ", 3, count);
   }


### PR DESCRIPTION
This PR converts a spark table to iceberg table. It assumes no parallel operation is going on the original table and target table and thus is not thread-safe.

PR is still working in progress. Unit tests will be added when APIs is settled down.