### PR TITLE
Do not use original manifest list when adding filters

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -148,7 +148,7 @@ class ManifestGroup {
       // only scan manifests that have entries other than deletes
       // remove any manifests that don't have any existing or added files. if either the added or
       // existing files count is missing, the manifest must be scanned.
-      matchingManifests = Iterables.filter(manifests,
+      matchingManifests = Iterables.filter(matchingManifests,
           manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles());
     }
 
@@ -156,7 +156,7 @@ class ManifestGroup {
       // only scan manifests that have entries other than existing
       // remove any manifests that don't have any deleted or added files. if either the added or
       // deleted files count is missing, the manifest must be scanned.
-      matchingManifests = Iterables.filter(manifests,
+      matchingManifests = Iterables.filter(matchingManifests,
           manifest -> manifest.hasAddedFiles() || manifest.hasDeletedFiles());
     }
 


### PR DESCRIPTION
This fixes a bug in `ManifestGroup` that caused all manifests to be read instead of correctly filtering when either `ignoreExisting` or `ignoreDeleted` was used because those filters were applied to the wrong variable, `manifests` instead of `filteredManifests`.