### PR TITLE
Make original ManifestReader factory method public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -53,8 +53,17 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
   static final List<String> CHANGE_COLUNNS = Lists.newArrayList(
       "file_path", "file_format", "partition", "record_count", "file_size_in_bytes");
 
-  // Visible for testing
-  static ManifestReader read(InputFile file) {
+  /**
+   * Returns a new {@link ManifestReader} for an {@link InputFile}.
+   * <p>
+   * <em>Note:</em> Most callers should use {@link #read(InputFile, Function)} to ensure that the
+   * schema used by filters is the latest table schema. This should be used only when reading a
+   * manifest without filters.
+   *
+   * @param file an InputFile
+   * @return a manifest reader
+   */
+  public static ManifestReader read(InputFile file) {
     return new ManifestReader(file, null);
   }
 


### PR DESCRIPTION
This is easier to use when reading a manifest directly, even though the partition spec will use the schema from when the manifest was written, not the current table schema.