### PR TITLE
Minor updates to BaseMetastoreTableOperations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -74,7 +74,9 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     OutputFile newMetadataLocation = io().newOutputFile(newTableMetadataFilePath);
 
     // write the new metadata
-    TableMetadataParser.write(metadata, newMetadataLocation);
+    // use overwrite to avoid negative caching in S3. this is safe because the metadata location is
+    // always unique because it includes a UUID.
+    TableMetadataParser.overwrite(metadata, newMetadataLocation);
 
     return newTableMetadataFilePath;
   }


### PR DESCRIPTION
This includes 2 updates to BaseMetastoreTableOperations:

* Use overwrite to create metadata JSON files to avoid S3 negative caching
* Add an optional predicate to determine if loading metadata should be retried after an exception