### PR TITLE
Fix create transaction metadata locations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -402,6 +402,8 @@ class BaseTransaction implements Transaction {
   }
 
   public class TransactionTableOperations implements TableOperations {
+    private TableOperations tempOps = ops.temp(current);
+
     @Override
     public TableMetadata current() {
       return current;
@@ -427,31 +429,33 @@ class BaseTransaction implements Transaction {
       }
 
       BaseTransaction.this.current = metadata;
+
+      this.tempOps = ops.temp(metadata);
     }
 
     @Override
     public FileIO io() {
-      return ops.io();
+      return tempOps.io();
     }
 
     @Override
     public EncryptionManager encryption() {
-      return ops.encryption();
+      return tempOps.encryption();
     }
 
     @Override
     public String metadataFileLocation(String fileName) {
-      return ops.metadataFileLocation(fileName);
+      return tempOps.metadataFileLocation(fileName);
     }
 
     @Override
     public LocationProvider locationProvider() {
-      return ops.locationProvider();
+      return tempOps.locationProvider();
     }
 
     @Override
     public long newSnapshotId() {
-      return ops.newSnapshotId();
+      return tempOps.newSnapshotId();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -88,6 +88,21 @@ public interface TableOperations {
   LocationProvider locationProvider();
 
   /**
+   * Return a temporary {@link TableOperations} instance that uses configuration from uncommitted metadata.
+   * <p>
+   * This is called by transactions when uncommitted table metadata should be used; for example, to create a metadata
+   * file location based on metadata in the transaction that has not been committed.
+   * <p>
+   * Transactions will not call {@link #refresh()} or {@link #commit(TableMetadata, TableMetadata)}.
+   *
+   * @param uncommittedMetadata uncommitted table metadata
+   * @return a temporary table operations that behaves like the uncommitted metadata is current
+   */
+  default TableOperations temp(TableMetadata uncommittedMetadata) {
+    return this;
+  }
+
+  /**
    * Create a new ID for a Snapshot
    *
    * @return a long snapshot ID


### PR DESCRIPTION
When a create transaction creates table metadata, it calls the underlying table operations to construct a location for the new metadata file. For metastore tables, that call fails because the base metadata for that table operations is null.

This adds a method to get a temporary `TableOperations` instance that uses uncommitted table metadata. Transactions create temporary ops instances from intermediate metadata to ensure that the behavior of methods like `metadataFileLocation` and `locationProvider` use current table metadata instead of the base metadata, which may be null.