### PR TITLE
include column_sizes in stats columns

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -44,7 +44,7 @@ public class DataTableScan extends BaseTableScan {
   );
   private static final List<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.<String>builder()
       .addAll(SCAN_COLUMNS)
-      .add("value_counts", "null_value_counts", "lower_bounds", "upper_bounds")
+      .add("value_counts", "null_value_counts", "lower_bounds", "upper_bounds", "column_sizes")
       .build();
   private static final boolean PLAN_SCANS_WITH_WORKER_POOL =
       SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);

--- a/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
@@ -66,7 +66,7 @@ public class TestScanDataFileColumns {
             .withPath("file1.parquet")
             .withFileSizeInBytes(100)
             .withMetrics(new Metrics(3L,
-                null, // no column sizes
+                ImmutableMap.of(1, 50L), // column size
                 ImmutableMap.of(1, 3L), // value count
                 ImmutableMap.of(1, 0L), // null count
                 ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
@@ -76,7 +76,7 @@ public class TestScanDataFileColumns {
             .withPath("file2.parquet")
             .withFileSizeInBytes(100)
             .withMetrics(new Metrics(3L,
-                null, // no column sizes
+                ImmutableMap.of(1, 60L), // column size
                 ImmutableMap.of(1, 3L), // value count
                 ImmutableMap.of(1, 0L), // null count
                 ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
@@ -86,7 +86,7 @@ public class TestScanDataFileColumns {
             .withPath("file3.parquet")
             .withFileSizeInBytes(100)
             .withMetrics(new Metrics(3L,
-                null, // no column sizes
+                ImmutableMap.of(1, 70L), // column size
                 ImmutableMap.of(1, 3L), // value count
                 ImmutableMap.of(1, 0L), // null count
                 ImmutableMap.of(1, longToBuffer(20L)), // lower bounds
@@ -114,6 +114,7 @@ public class TestScanDataFileColumns {
       Assert.assertNotNull(fileTask.file().nullValueCounts());
       Assert.assertNotNull(fileTask.file().lowerBounds());
       Assert.assertNotNull(fileTask.file().upperBounds());
+      Assert.assertNotNull(fileTask.file().columnSizes());
     }
   }
 


### PR DESCRIPTION
this is for Issue #269

My understand is that `column_sizes` was calculated by `ParquetUtil.footerMetrics` or `ParquetUtil.fileMetrics` but calling `table.newScan().includeColumnStats()` is still not populating.

@aokolnychyi if you want to review, please.