### PR TITLE
Remove Hadoop Configuration dependency in BaseMetastoreTableOperations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -23,7 +23,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Tasks;
@@ -41,16 +40,12 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   private static final String METADATA_FOLDER_NAME = "metadata";
   private static final String DATA_FOLDER_NAME = "data";
 
-  private final FileIO fileIo;
-
   private TableMetadata currentMetadata = null;
   private String currentMetadataLocation = null;
   private boolean shouldRefresh = true;
   private int version = -1;
 
-  protected BaseMetastoreTableOperations(FileIO fileIo) {
-    this.fileIo = fileIo;
-  }
+  protected BaseMetastoreTableOperations() { }
 
   @Override
   public TableMetadata current() {
@@ -74,7 +69,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
 
   protected String writeNewMetadata(TableMetadata metadata, int newVersion) {
     String newTableMetadataFilePath = newTableMetadataFilePath(metadata, newVersion);
-    OutputFile newMetadataLocation = fileIo.newOutputFile(newTableMetadataFilePath);
+    OutputFile newMetadataLocation = io().newOutputFile(newTableMetadataFilePath);
 
     // write the new metadata
     TableMetadataParser.write(metadata, newMetadataLocation);
@@ -125,11 +120,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   @Override
   public String metadataFileLocation(String filename) {
     return metadataFileLocation(current(), filename);
-  }
-
-  @Override
-  public FileIO io() {
-    return fileIo;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -23,8 +23,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
@@ -43,7 +41,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   private static final String METADATA_FOLDER_NAME = "metadata";
   private static final String DATA_FOLDER_NAME = "data";
 
-  private final Configuration conf;
   private final FileIO fileIo;
 
   private TableMetadata currentMetadata = null;
@@ -51,9 +48,8 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   private boolean shouldRefresh = true;
   private int version = -1;
 
-  protected BaseMetastoreTableOperations(Configuration conf) {
-    this.conf = conf;
-    this.fileIo = new HadoopFileIO(conf);
+  protected BaseMetastoreTableOperations(FileIO fileIo) {
+    this.fileIo = fileIo;
   }
 
   @Override

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +65,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private final String tableName;
 
   protected HiveTableOperations(Configuration conf, HiveClientPool metaClients, String database, String table) {
-    super(conf);
+    super(new HadoopFileIO(conf));
     this.metaClients = metaClients;
     this.database = database;
     this.tableName = table;

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,12 +64,24 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private final HiveClientPool metaClients;
   private final String database;
   private final String tableName;
+  private final Configuration conf;
+
+  private FileIO fileIO;
 
   protected HiveTableOperations(Configuration conf, HiveClientPool metaClients, String database, String table) {
-    super(new HadoopFileIO(conf));
+    this.conf = conf;
     this.metaClients = metaClients;
     this.database = database;
     this.tableName = table;
+  }
+
+  @Override
+  public FileIO io() {
+    if (fileIO == null) {
+      fileIO = new HadoopFileIO(conf);
+    }
+
+    return fileIO;
   }
 
   @Override


### PR DESCRIPTION
This is for issue #353 , to remove the Configuration dependency in `BaseMetastoreOperations`. 

No new UT added, using existing UTs.

CC @aokolnychyi , please help to review, thanks!