### PR TITLE
Support DS read/write without specifying namespace

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -104,7 +104,9 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
       return tables.load(path.get());
     } else {
       HiveCatalog hiveCatalog = HiveCatalogs.loadCatalog(conf);
-      TableIdentifier tableIdentifier = TableIdentifier.parse(path.get());
+      TableIdentifier tableIdentifier = path.get().contains(".") ?
+          TableIdentifier.parse(path.get()) :
+          TableIdentifier.of(lazySparkSession().catalog().currentDatabase(), path.get());
       return hiveCatalog.loadTable(tableIdentifier);
     }
   }


### PR DESCRIPTION
Current iceberg must specify namespace when read/write through DS API, for example: ` spark.read.format("iceberg").load("default.logs") `,  otherwise it will throw an exception. 

Actually we could leverage Spark's catalog information to pick the current namespace when it is not specified. So here changing to use default namespace when it is not specified.