### PR TITLE
Introduce a wait before each check lock state request to HMS

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -249,6 +249,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     while (state.equals(LockState.WAITING)) {
       lockResponse = metaClients.run(client -> client.checkLock(lockId));
       state = lockResponse.getState();
+      Thread.sleep(50);
     }
 
     if (!state.equals(LockState.ACQUIRED)) {


### PR DESCRIPTION
This PR introduces a wait between check lock state requests to HMS and partially resolves #366.

The test was originally contributed by @rdsr.