### PR TITLE
Error message too heavy when table type is not iceberg (#403)

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -92,7 +92,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       String tableType = table.getParameters().get(TABLE_TYPE_PROP);
 
       if (tableType == null || !tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE)) {
-        throw new IllegalArgumentException(String.format("Invalid tableName, not Iceberg: %s.%s", database, table));
+        throw new IllegalArgumentException(String.format("Type of %s.%s is %s, not %s",
+            database, tableName,
+            tableType /* actual type */, ICEBERG_TABLE_TYPE_VALUE /* expected type */));
       }
 
       metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);


### PR DESCRIPTION
1. The original code uses "table", which includes too much information when calling "toString()". tableName (as a String) could be used instead;
2. The original error message "Invalid tableName, not Iceberg" seem not quite clear to indicate that the type is invalid, so improve it a little