### PR TITLE
Throw an exception when using Iceberg with Spark embedded metastore

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.BaseMetastoreCatalog;
@@ -39,10 +38,6 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   private final Configuration conf;
 
   public HiveCatalog(Configuration conf) {
-    if (isEmbeddedMetaStore(conf)) {
-      throw new IllegalStateException("Iceberg Hive catalog cannot work with embedded metastore");
-    }
-
     this.clients = new HiveClientPool(2, conf);
     this.conf = conf;
   }
@@ -140,14 +135,5 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   @Override
   public void close() {
     clients.close();
-  }
-
-  private boolean isEmbeddedMetaStore(Configuration configuration) {
-    String msUri = configuration.get(HiveConf.ConfVars.METASTOREURIS.varname,
-        HiveConf.ConfVars.METASTOREURIS.defaultStrVal);
-    String msConnUrl = configuration.get(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
-        HiveConf.ConfVars.METASTORECONNECTURLKEY.defaultStrVal);
-    return (msUri == null || msUri.trim().isEmpty()) &&
-       (msConnUrl != null && msConnUrl.startsWith("jdbc:derby"));
   }
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.BaseMetastoreCatalog;
@@ -38,6 +39,10 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   private final Configuration conf;
 
   public HiveCatalog(Configuration conf) {
+    if (isEmbeddedMetaStore(conf)) {
+      throw new IllegalStateException("Iceberg Hive catalog cannot work with embedded metastore");
+    }
+
     this.clients = new HiveClientPool(2, conf);
     this.conf = conf;
   }
@@ -135,5 +140,14 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   @Override
   public void close() {
     clients.close();
+  }
+
+  private boolean isEmbeddedMetaStore(Configuration configuration) {
+    String msUri = configuration.get(HiveConf.ConfVars.METASTOREURIS.varname,
+        HiveConf.ConfVars.METASTOREURIS.defaultStrVal);
+    String msConnUrl = configuration.get(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
+        HiveConf.ConfVars.METASTORECONNECTURLKEY.defaultStrVal);
+    return (msUri == null || msUri.trim().isEmpty()) &&
+       (msConnUrl != null && msConnUrl.startsWith("jdbc:derby"));
   }
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -25,12 +25,8 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class HiveClientPool extends ClientPool<HiveMetaStoreClient, TException> {
-  private static final Logger LOG = LoggerFactory.getLogger(HiveClientPool.class);
-
   private final HiveConf hiveConf;
 
   HiveClientPool(Configuration conf) {
@@ -50,8 +46,9 @@ class HiveClientPool extends ClientPool<HiveMetaStoreClient, TException> {
       throw new RuntimeMetaException(e, "Failed to connect to Hive Metastore");
     } catch (Throwable t) {
       if (t.getMessage().contains("Another instance of Derby may have already booted")) {
-        LOG.error("Failed to start an embedded metastore because embedded Derby supports only one" +
-            " client at a time. To fix this, use a metastore that supports multiple clients.", t);
+        throw new RuntimeMetaException(t, "Failed to start an embedded metastore because embedded " +
+            "Derby supports only one client at a time. To fix this, use a metastore that supports " +
+            "multiple clients.");
       }
 
       throw new RuntimeMetaException(t, "Failed to connect to Hive Metastore");

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -50,9 +50,8 @@ class HiveClientPool extends ClientPool<HiveMetaStoreClient, TException> {
       throw new RuntimeMetaException(e, "Failed to connect to Hive Metastore");
     } catch (Throwable t) {
       if (t.getMessage().contains("Another instance of Derby may have already booted")) {
-        LOG.error("Another instance of Derby may have already booted. This is happened when using" +
-            " embedded metastore, which only supports one client at time. Please change to use " +
-            "other metastores which could support multiple clients, like metastore service.", t);
+        LOG.error("Failed to start an embedded metastore because embedded Derby supports only one" +
+          " client at a time. To fix this, use a metastore that supports multiple clients.", t);
       }
 
       throw new RuntimeMetaException(t, "Failed to connect to Hive Metastore");

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -51,7 +51,7 @@ class HiveClientPool extends ClientPool<HiveMetaStoreClient, TException> {
     } catch (Throwable t) {
       if (t.getMessage().contains("Another instance of Derby may have already booted")) {
         LOG.error("Failed to start an embedded metastore because embedded Derby supports only one" +
-          " client at a time. To fix this, use a metastore that supports multiple clients.", t);
+            " client at a time. To fix this, use a metastore that supports multiple clients.", t);
       }
 
       throw new RuntimeMetaException(t, "Failed to connect to Hive Metastore");

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -183,6 +183,12 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       }
       threw = false;
     } catch (TException | UnknownHostException e) {
+      if (e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
+        LOG.error("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't exist, " +
+            "this probably happened when using embedded metastore or doesn't create transactional" +
+            " meta table. Please reconfigure and start the metastore.", e);
+      }
+
       throw new RuntimeException(String.format("Metastore operation failed for %s.%s", database, tableName), e);
 
     } catch (InterruptedException e) {

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -184,9 +184,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       threw = false;
     } catch (TException | UnknownHostException e) {
       if (e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
-        LOG.error("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't exist, " +
-            "this probably happened when using embedded metastore or doesn't create transactional" +
-            " meta table. Please reconfigure and start the metastore.", e);
+        throw new RuntimeException("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't " +
+            "exist, this probably happened when using embedded metastore or doesn't create a " +
+            "transactional meta table. To fix this, use an alternative metastore", e);
       }
 
       throw new RuntimeException(String.format("Metastore operation failed for %s.%s", database, tableName), e);

--- a/hive/src/main/java/org/apache/iceberg/hive/RuntimeMetaException.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/RuntimeMetaException.java
@@ -32,4 +32,8 @@ public class RuntimeMetaException extends RuntimeException {
   public RuntimeMetaException(MetaException cause, String message, Object... args) {
     super(String.format(message, args), cause);
   }
+
+  public RuntimeMetaException(Throwable throwable, String message, Object... args) {
+    super(String.format(message, args), throwable);
+  }
 }


### PR DESCRIPTION
Iceberg's hive catalog has two issues work with Spark embedded metastore:

1. Iceberg requires HIVE_LOCKS which doesn't exist in embedded metastore.
2. Embedded metastore restricts only one client at a time, so once Spark creates a client, then Iceberg cannot open a client anymore, vice versa.

Here propose a simple fix to restrict users to use iceberg when embedded metastore is enabled.

This addresses issue #370 
