### PR TITLE
Add friendly names to catalog tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -89,6 +89,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
+  protected String name() {
+    return "hadoop";
+  }
+
+  @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
     Preconditions.checkArgument(namespace.levels().length >= 1,
         "Missing database in table identifier: %s", namespace);

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -82,7 +82,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
 
   @Override
   protected String name() {
-    return conf.get("hive.metastore.uris");
+    return "hive";
   }
 
   @Override

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -81,6 +81,11 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
+  protected String name() {
+    return conf.get("hive.metastore.uris");
+  }
+
+  @Override
   public boolean dropTable(TableIdentifier identifier, boolean purge) {
     if (!isValidIdentifier(identifier)) {
       throw new NoSuchTableException("Invalid identifier: %s", identifier);


### PR DESCRIPTION
This adds an abstract `name` method to `BaseMetastoreCatalog` and a new method to generate full table names from a catalog.