### PR TITLE
Fix Literal serializability

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -95,7 +95,7 @@ class Literals {
 
   private abstract static class BaseLiteral<T> implements Literal<T> {
     private final T value;
-    private volatile ByteBuffer byteBuffer = null;
+    private transient volatile ByteBuffer byteBuffer = null;
 
     BaseLiteral(T value) {
       Preconditions.checkNotNull(value, "Literal values cannot be null");

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.api.java.UDF1;
@@ -452,6 +453,21 @@ public class TestFilteredScan {
     pushFilters(reader, new StringStartsWith("data", "junc"));
 
     Assert.assertEquals(1, reader.planInputPartitions().size());
+  }
+
+  @Test
+  public void testUnpartitionedStartsWith() {
+    Dataset<Row> df = spark.read()
+        .format("iceberg")
+        .load(unpartitioned.toString());
+
+    List<String> matchedData = df.select("data")
+        .where("data LIKE 'jun%'")
+        .as(Encoders.STRING())
+        .collectAsList();
+
+    Assert.assertEquals(1, matchedData.size());
+    Assert.assertEquals("junction", matchedData.get(0));
   }
 
   private static Record projectFlat(Schema projection, Record record) {


### PR DESCRIPTION
This PR fixes literal serializability to avoid `Task not serializable` exceptions in Spark.

```
Caused by: java.io.NotSerializableException: java.nio.HeapByteBuffer
Serialization stack:
	- object not serializable (class: java.nio.HeapByteBuffer, value: java.nio.HeapByteBuffer[pos=0 lim=1 cap=1])
	- field (class: org.apache.iceberg.expressions.Literals$BaseLiteral, name: byteBuffer, type: class java.nio.ByteBuffer)
	- object (class org.apache.iceberg.expressions.Literals$StringLiteral, "a")
	- field (class: org.apache.iceberg.expressions.Predicate, name: literal, type: interface org.apache.iceberg.expressions.Literal)
	- object (class org.apache.iceberg.expressions.UnboundPredicate, ref(name="value") startsWith ""a"")
	- field (class: org.apache.iceberg.expressions.And, name: right, type: interface org.apache.iceberg.expressions.Expression)
	- object (class org.apache.iceberg.expressions.And, (not_null(ref(name="value")) and ref(name="value") startsWith ""a""))
	- field (class: org.apache.iceberg.expressions.ResidualEvaluator, name: expr, type: interface org.apache.iceberg.expressions.Expression)
```