### PR TITLE
Allow writers to control size of files generated

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -101,6 +101,6 @@ public class TableProperties {
   public static final String WRITE_AUDIT_PUBLISH_ENABLED = "write.wap.enabled";
   public static final String WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT = "false";
 
-  public static final String WRITE_TARGET_FILE_SIZE = "write.target-file-size";
-  public static final long WRITE_TARGET_FILE_SIZE_DEFAULT = Long.MAX_VALUE;
+  public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
+  public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = Long.MAX_VALUE;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -100,4 +100,7 @@ public class TableProperties {
 
   public static final String WRITE_AUDIT_PUBLISH_ENABLED = "write.wap.enabled";
   public static final String WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT = "false";
+
+  public static final String WRITE_TARGET_FILE_SIZE = "write.target-file-size";
+  public static final long WRITE_TARGET_FILE_SIZE_DEFAULT = Long.MAX_VALUE;
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -126,7 +126,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   @Override
   public long length() {
     try {
-      return writer.getPos();
+      return writer.getPos() + writeStore.getBufferedSize();
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to get file length");
     }

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -25,7 +25,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.metadata.compression-codec   | none               | Metadata compression codec; none or gzip           |
 | write.metadata.metrics.default     | truncate(16)       | Default metrics mode for all columns in the table; none, counts, truncate(length), or full |
 | write.metadata.metrics.column.col1 | (not set)          | Metrics mode for column 'col1' to allow per-column tuning; none, counts, truncate(length), or full |
-| write.target-file-size             | Long.MAX_VALUE     | Controls the size of files generated to target about this many bytes. |
+| write.target-file-size-bytes       | Long.MAX_VALUE     | Controls the size of files generated to target about this many bytes. |
 
 ### Table behavior properties
 
@@ -76,5 +76,5 @@ df.write
 | Spark option | Default                    | Description                                                  |
 | ------------ | -------------------------- | ------------------------------------------------------------ |
 | write-format | Table write.format.default | File format to use for this write operation; parquet or avro |
-| target-file-size | As per table property | Overrides this table's write.target-file-size       |
+| target-file-size-bytes | As per table property | Overrides this table's write.target-file-size-bytes     |
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -25,6 +25,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.metadata.compression-codec   | none               | Metadata compression codec; none or gzip           |
 | write.metadata.metrics.default     | truncate(16)       | Default metrics mode for all columns in the table; none, counts, truncate(length), or full |
 | write.metadata.metrics.column.col1 | (not set)          | Metrics mode for column 'col1' to allow per-column tuning; none, counts, truncate(length), or full |
+| write.target-file-size             | Long.MAX_VALUE     | Controls the size of files generated to target about this many bytes. |
 
 ### Table behavior properties
 
@@ -75,4 +76,5 @@ df.write
 | Spark option | Default                    | Description                                                  |
 | ------------ | -------------------------- | ------------------------------------------------------------ |
 | write-format | Table write.format.default | File format to use for this write operation; parquet or avro |
+| target-file-size | As per table property | Overrides this table's write.target-file-size       |
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.spark.data.SparkAvroWriter;
 import org.apache.iceberg.spark.data.SparkParquetWriters;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
@@ -74,8 +75,8 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
-import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE;
-import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
 // TODO: parameterize DataSourceWriter with subclass of WriterCommitMessage
 class Writer implements DataSourceWriter {
@@ -103,9 +104,9 @@ class Writer implements DataSourceWriter {
     this.applicationId = applicationId;
     this.wapId = wapId;
 
-    long tableTargetFileSize = Long.parseLong(table.properties().getOrDefault(
-        WRITE_TARGET_FILE_SIZE, String.valueOf(WRITE_TARGET_FILE_SIZE_DEFAULT)));
-    this.targetFileSize = options.getLong("target-file-size", tableTargetFileSize);
+    long tableTargetFileSize = PropertyUtil.propertyAsLong(
+        table.properties(), WRITE_TARGET_FILE_SIZE_BYTES, WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
+    this.targetFileSize = options.getLong("target-file-size-bytes", tableTargetFileSize);
   }
 
   private FileFormat getFileFormat(Map<String, String> tableProperties, DataSourceOptions options) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -373,7 +373,7 @@ class Writer implements DataSourceWriter {
     protected long currentRows;
 
     BaseWriter(PartitionSpec spec, FileFormat format, AppenderFactory<InternalRow> appenderFactory,
-        OutputFileFactory<EncryptedOutputFile> fileFactory, FileIO fileIo, long targetFileSize) {
+               OutputFileFactory<EncryptedOutputFile> fileFactory, FileIO fileIo, long targetFileSize) {
       this.spec = spec;
       this.format = format;
       this.appenderFactory = appenderFactory;

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -75,6 +75,8 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_DEFAULT;
 
 // TODO: parameterize DataSourceWriter with subclass of WriterCommitMessage
 class Writer implements DataSourceWriter {
@@ -101,7 +103,10 @@ class Writer implements DataSourceWriter {
     this.replacePartitions = replacePartitions;
     this.applicationId = applicationId;
     this.wapId = wapId;
-    this.targetFileSize = options.getLong("target-file-size", Long.MAX_VALUE);
+
+    long tableTargetFileSize = Long.parseLong(table.properties().getOrDefault(
+        WRITE_TARGET_FILE_SIZE, String.valueOf(WRITE_TARGET_FILE_SIZE_DEFAULT)));
+    this.targetFileSize = options.getLong("target-file-size", tableTargetFileSize);
   }
 
   private FileFormat getFileFormat(Map<String, String> tableProperties, DataSourceOptions options) {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
@@ -259,7 +259,7 @@ public class TestParquetWrite {
     Table table = tables.create(SCHEMA, spec, location.toString());
 
     table.updateProperties()
-        .set(TableProperties.WRITE_TARGET_FILE_SIZE, "4") // ~4 bytes; low enough to trigger
+        .set(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "4") // ~4 bytes; low enough to trigger
         .commit();
 
     List<SimpleRecord> expected = Lists.newArrayListWithCapacity(4000);
@@ -316,7 +316,7 @@ public class TestParquetWrite {
     df.select("id", "data").sort("data").write()
         .format("iceberg")
         .mode("append")
-        .option("target-file-size", 4) // ~4 bytes; low enough to trigger
+        .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
         .save(location.toString());
 
     table.refresh();


### PR DESCRIPTION
For big jobs where parquet files generated get to be >= 10GB, we have found latency on read related to reading the parquet footer.

For our data and tech stack, we observe that it takes about 1 second per 10GB of file size:

```
Time to read footer of ~302 MB parquet file:
ms: 273
ms: 214
ms: 289
ms: 262

Time to read footer of ~17GB parquet file:
ms: 1907
ms: 1925
ms: 1933
ms: 1855

Time to read footer of ~67GB parquet file:
ms: 6073
ms: 5587
ms: 5293
ms: 5691
```

To avoid this, we propose this PR that allows iceberg writers to close and open new files when a target file size is achieved. The semantics of having at most one file open per writers are not changed, and for the case of a `PartitionedWriter`, the semantics of failing if the data is not ordered is kept as well.

With this PR, now we can do:
```
df
  .sort(...)
  .write
  .format("iceberg")
  .option("target-file-size", 1 * 1024 * 1024 * 1024) // target 1GB files
  .mode("append")
  .save("...")
```