### PR TITLE
Throw IllegalArgumentExcpetion exception in ReassignIds if field not found in sourceSchema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
@@ -73,6 +73,9 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
     Types.StructType sourceStruct = sourceType.asStructType();
     Types.NestedField sourceField = sourceStruct.field(field.name());
+    if (sourceField == null) {
+      throw new IllegalArgumentException("Field " + field.name() + " not found in source schema");
+    }
 
     this.sourceType = sourceField.type();
     try {

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.iceberg.types;
+
+import org.apache.iceberg.Schema;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+
+public class TestTypeUtil {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReassignIdsIllegalArgumentException() {
+    Schema schema = new Schema(
+        required(1, "a", Types.IntegerType.get()),
+        required(2, "b", Types.IntegerType.get())
+    );
+    Schema sourceSchema = new Schema(
+        required(1, "a", Types.IntegerType.get())
+    );
+    TypeUtil.reassignIds(schema, sourceSchema);
+  }
+}


### PR DESCRIPTION
`TypeUtil.reassignIds` should throw an `IllegalArgumentExcpetion` if field is not found in source schema according to https://github.com/apache/incubator-iceberg/blob/master/api/src/main/java/org/apache/iceberg/types/TypeUtil.java#L134
Currently though, it throws an NPE at https://github.com/apache/incubator-iceberg/blob/master/api/src/main/java/org/apache/iceberg/types/ReassignIds.java#L77

NPE stacktrace:
```
java.lang.NullPointerException
  at org.apache.iceberg.types.ReassignIds.field(ReassignIds.java:77)
  at org.apache.iceberg.types.ReassignIds.field(ReassignIds.java:28)
  at org.apache.iceberg.types.TypeUtil$VisitFieldFuture.get(TypeUtil.java:331)
  at org.apache.iceberg.shaded.com.google.common.collect.Iterators$6.transform(Iterators.java:783)
  at org.apache.iceberg.shaded.com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
  at org.apache.iceberg.shaded.com.google.common.collect.Iterators.addAll(Iterators.java:356)
  at org.apache.iceberg.shaded.com.google.common.collect.Lists.newArrayList(Lists.java:143)
  at org.apache.iceberg.shaded.com.google.common.collect.Lists.newArrayList(Lists.java:130)
  at org.apache.iceberg.types.ReassignIds.struct(ReassignIds.java:55)
  at org.apache.iceberg.types.ReassignIds.struct(ReassignIds.java:28)
  at org.apache.iceberg.types.TypeUtil.visit(TypeUtil.java:364)
  at org.apache.iceberg.types.TypeUtil$VisitFuture.get(TypeUtil.java:316)
  at org.apache.iceberg.types.ReassignIds.schema(ReassignIds.java:40)
  at org.apache.iceberg.types.ReassignIds.schema(ReassignIds.java:28)
  at org.apache.iceberg.types.TypeUtil.visit(TypeUtil.java:336)
  at org.apache.iceberg.types.TypeUtil.reassignIds(TypeUtil.java:137)
  at org.apache.iceberg.spark.SparkSchemaUtil.convert(SparkSchemaUtil.java:163)
  at org.apache.iceberg.spark.source.IcebergSource.validateWriteSchema(IcebergSource.java:146)
  at org.apache.iceberg.spark.source.IcebergSource.createWriter(IcebergSource.java:76)
  at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:254)
  at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:228)
  ... 51 elided
```