### PR TITLE
Add guide about how to set hive.metastore.warehouse.dir

### DIFF
--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -11,7 +11,9 @@ The Hive catalog connects to a Hive MetaStore to keep track of Iceberg tables. T
 ```scala
 import org.apache.iceberg.hive.HiveCatalog
 
-spark.sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", "path/to/warehouse")
+// Set Hive warehouse location here to make it available to Spark
+spark.conf.set("hive.metastore.warehouse.dir", "s3://bucket/path/to/warehouse")
+
 val catalog = new HiveCatalog(spark.sparkContext.hadoopConfiguration)
 ```
 

--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -11,6 +11,7 @@ The Hive catalog connects to a Hive MetaStore to keep track of Iceberg tables. T
 ```scala
 import org.apache.iceberg.hive.HiveCatalog
 
+spark.sparkContext.hadoopConfiguration.set("hive.metastore.warehouse.dir", "path/to/warehouse")
 val catalog = new HiveCatalog(spark.sparkContext.hadoopConfiguration)
 ```
 


### PR DESCRIPTION
For issue #436 
Hi @rdblue , I have to open this new PR as the old PR #437 is broken by me...
The 2nd commit has 2 changes
(1) Address your comment, at https://github.com/apache/incubator-iceberg/pull/437#discussion_r320047250
(2) Set `hive.metastore.warehouse.dir` in Spark conf instead of Hadoop conf. Both of them work, but it is more safe to include that config into Spark conf, as in [this link](https://spark.apache.org/docs/2.4.3/api/scala/index.html#org.apache.spark.SparkContext@hadoopConfiguration:org.apache.hadoop.conf.Configuration): 
> As it(hadoopConfiguration) will be reused in all Hadoop RDDs, it's better not to modify it unless you plan to set some global configurations for all Hadoop RDDs.