### PR TITLE
Optimize ExpressionVisitors.visit method to traverse minimum nodes number required for determining the result

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -60,7 +60,7 @@ public class Evaluator implements Serializable {
 
     private boolean eval(StructLike row) {
       this.struct = row;
-      return ExpressionVisitors.visit(expr, this);
+      return ExpressionVisitors.visitEvaluator(expr, this);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -141,9 +141,8 @@ public class ExpressionVisitors {
   /**
    * Traverses the given {@link Expression expression} with a {@link ExpressionVisitor visitor}.
    * <p>
-   * The visitor will be called to handle only nodes required for determining result
-   * in the expression tree in postfix order. Result values produced by child nodes
-   * are passed when parent nodes are handled.
+   * The visitor will be called to handle each node in the expression tree in postfix order. Result
+   * values produced by child nodes are passed when parent nodes are handled.
    *
    * @param expr an expression to traverse
    * @param visitor a visitor that will be called to handle each node in the expression tree
@@ -168,18 +167,58 @@ public class ExpressionVisitors {
           return visitor.not(visit(not.child(), visitor));
         case AND:
           And and = (And) expr;
-          R andLeftOperand = visit(and.left(), visitor);
-          if (andLeftOperand == visitor.alwaysFalse()) {
-            return visitor.alwaysFalse();
-          }
-          return visitor.and(andLeftOperand, visit(and.right(), visitor));
+          return visitor.and(visit(and.left(), visitor), visit(and.right(), visitor));
         case OR:
           Or or = (Or) expr;
-          R orLeftOperand = visit(or.left(), visitor);
-          if (orLeftOperand == visitor.alwaysTrue()) {
+          return visitor.or(visit(or.left(), visitor), visit(or.right(), visitor));
+        default:
+          throw new UnsupportedOperationException(
+              "Unknown operation: " + expr.op());
+      }
+    }
+  }
+
+  /**
+   * Traverses the given {@link Expression expression} with a {@link ExpressionVisitor visitor}.
+   * <p>
+   * The visitor will be called to handle only nodes required for determining result
+   * in the expression tree in postfix order. Result values produced by child nodes
+   * are passed when parent nodes are handled.
+   *
+   * @param expr an expression to traverse
+   * @param visitor a visitor that will be called to handle each node in the expression tree
+   * @return the value returned by the visitor for the root expression node
+   */
+  public static Boolean visitEvaluator(Expression expr, ExpressionVisitor<Boolean> visitor) {
+    if (expr instanceof Predicate) {
+      if (expr instanceof BoundPredicate) {
+        return visitor.predicate((BoundPredicate<?>) expr);
+      } else {
+        return visitor.predicate((UnboundPredicate<?>) expr);
+      }
+    } else {
+      switch (expr.op()) {
+        case TRUE:
+          return visitor.alwaysTrue();
+        case FALSE:
+          return visitor.alwaysFalse();
+        case NOT:
+          Not not = (Not) expr;
+          return visitor.not(visitEvaluator(not.child(), visitor));
+        case AND:
+          And and = (And) expr;
+          Boolean andLeftOperand = visitEvaluator(and.left(), visitor);
+          if (!andLeftOperand) {
+            return visitor.alwaysFalse();
+          }
+          return visitor.and(Boolean.TRUE, visitEvaluator(and.right(), visitor));
+        case OR:
+          Or or = (Or) expr;
+          Boolean orLeftOperand = visitEvaluator(or.left(), visitor);
+          if (orLeftOperand) {
             return visitor.alwaysTrue();
           }
-          return visitor.or(orLeftOperand, visit(or.right(), visitor));
+          return visitor.or(Boolean.FALSE, visitEvaluator(or.right(), visitor));
         default:
           throw new UnsupportedOperationException(
               "Unknown operation: " + expr.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -96,7 +96,7 @@ public class InclusiveMetricsEvaluator {
       this.lowerBounds = file.lowerBounds();
       this.upperBounds = file.upperBounds();
 
-      return ExpressionVisitors.visit(expr, this);
+      return ExpressionVisitors.visitEvaluator(expr, this);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -92,7 +92,7 @@ public class ManifestEvaluator {
         return ROWS_MIGHT_MATCH;
       }
 
-      return ExpressionVisitors.visit(expr, this);
+      return ExpressionVisitors.visitEvaluator(expr, this);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -90,7 +90,7 @@ public class StrictMetricsEvaluator {
       this.lowerBounds = file.lowerBounds();
       this.upperBounds = file.upperBounds();
 
-      return ExpressionVisitors.visit(expr, this);
+      return ExpressionVisitors.visitEvaluator(expr, this);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -125,7 +125,7 @@ public class ParquetDictionaryRowGroupFilter {
         }
       }
 
-      return ExpressionVisitors.visit(expr, this);
+      return ExpressionVisitors.visitEvaluator(expr, this);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.function.Function;
@@ -31,7 +30,6 @@ import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
@@ -104,7 +102,7 @@ public class ParquetMetricsRowGroupFilter {
         }
       }
 
-      return ExpressionVisitors.visit(expr, this);
+      return ExpressionVisitors.visitEvaluator(expr, this);
     }
 
     @Override


### PR DESCRIPTION
For issue #439 