### PR TITLE
Add null check in GenericRecord#get method to avoid failure when value is null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,6 +266,8 @@ project(':iceberg-data') {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
+
+    testCompile project(path: ':iceberg-core', configuration: 'testArtifacts')
   }
 
   test {

--- a/data/src/main/java/org/apache/iceberg/data/GenericRecord.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericRecord.java
@@ -117,7 +117,7 @@ public class GenericRecord implements Record, StructLike {
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
     Object value = get(pos);
-    if (javaClass.isInstance(value)) {
+    if (value == null || javaClass.isInstance(value)) {
       return javaClass.cast(value);
     } else {
       throw new IllegalStateException("Not an instance of " + javaClass.getName() + ": " + value);

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericRecord.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericRecord.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestGenericRecord {
+
+  @Test
+  public void testGetNullValue() {
+    Types.LongType type = Types.LongType.get();
+    Schema schema = new Schema(optional(1, "id", type));
+    GenericRecord record = GenericRecord.create(schema);
+    record.set(0, null);
+
+    Assert.assertNull(record.get(0, type.typeId().javaClass()));
+  }
+
+  @Test
+  public void testGetNotNullValue() {
+    Types.LongType type = Types.LongType.get();
+    Schema schema = new Schema(optional(1, "id", type));
+    GenericRecord record = GenericRecord.create(schema);
+    record.set(0, 10L);
+
+    Assert.assertEquals(10L, record.get(0, type.typeId().javaClass()));
+  }
+
+  @Test
+  public void testGetIncorrectClassInstance() {
+    Schema schema = new Schema(optional(1, "id", Types.LongType.get()));
+    GenericRecord record = GenericRecord.create(schema);
+    record.set(0, 10L);
+
+    AssertHelpers.assertThrows("Should fail on incorrect class instance",
+        IllegalStateException.class,
+        "Not an instance of java.lang.CharSequence: 10",
+        () -> record.get(0, CharSequence.class));
+  }
+}


### PR DESCRIPTION
Issue was discovered when filtering data by column with null value:
```
java.lang.IllegalStateException: Not an instance of java.lang.CharSequence: null

	at org.apache.iceberg.data.GenericRecord.get(GenericRecord.java:123)
	at org.apache.iceberg.Accessors$PositionAccessor.get(Accessors.java:57)
	at org.apache.iceberg.Accessors$PositionAccessor.get(Accessors.java:44)
	at org.apache.iceberg.expressions.BoundReference.get(BoundReference.java:49)
	at org.apache.iceberg.expressions.Evaluator$EvalVisitor.eq(Evaluator.java:128)
	at org.apache.iceberg.expressions.Evaluator$EvalVisitor.eq(Evaluator.java:58)
	at org.apache.iceberg.expressions.ExpressionVisitors$BoundExpressionVisitor.predicate(ExpressionVisitors.java:120)
	at org.apache.iceberg.expressions.ExpressionVisitors.visit(ExpressionVisitors.java:156)
	at org.apache.iceberg.expressions.ExpressionVisitors.visit(ExpressionVisitors.java:171)
	at org.apache.iceberg.expressions.ExpressionVisitors.visit(ExpressionVisitors.java:171)
	at org.apache.iceberg.expressions.Evaluator$EvalVisitor.eval(Evaluator.java:63)
	at org.apache.iceberg.expressions.Evaluator$EvalVisitor.access$000(Evaluator.java:58)
	at org.apache.iceberg.expressions.Evaluator.eval(Evaluator.java:55)
	at com.google.common.collect.Iterators$7.computeNext(Iterators.java:675)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
	at org.apache.iceberg.data.TableScanIterable$ScanIterator.hasNext(TableScanIterable.java:129)
```
Since `instanceOf` check returns false when value is null, correct behavior would to be return null value instead of failing with `IllegalStateException` exception. Other classes which implement `StructLike` interface return null in case of null value, only `GenericRecord` is failing.