### PR TITLE
[python] Fixing typo in DecimalType and some small linting fixes

### DIFF
--- a/python/iceberg/api/expressions/residual_evaluator.py
+++ b/python/iceberg/api/expressions/residual_evaluator.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import threading
-
 from .expressions import Expressions, ExpressionVisitors
 from .predicate import BoundPredicate, Predicate, UnboundPredicate
 

--- a/python/iceberg/api/types/types.py
+++ b/python/iceberg/api/types/types.py
@@ -371,8 +371,8 @@ class BinaryType(PrimitiveType):
 class DecimalType(PrimitiveType):
 
     @staticmethod
-    def of(precison, scale):
-        return DecimalType(precison, scale)
+    def of(precision, scale):
+        return DecimalType(precision, scale)
 
     def __init__(self, precision, scale):
         if int(precision) > 38:
@@ -385,7 +385,7 @@ class DecimalType(PrimitiveType):
         return TypeID.DECIMAL
 
     def __repr__(self):
-        return "decimal(%s,%s)" % (self.precision, self.scale)
+        return "decimal(%s, %s)" % (self.precision, self.scale)
 
     def __str__(self):
         return self.__repr__()
@@ -396,7 +396,7 @@ class DecimalType(PrimitiveType):
         elif other is None or not isinstance(other, DecimalType):
             return False
 
-        return self.precision == other.precison and self.scale == other.scale
+        return self.precision == other.precision and self.scale == other.scale
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/python/iceberg/core/avro/avro_schema_util.py
+++ b/python/iceberg/core/avro/avro_schema_util.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 class AvroSchemaUtil(object):
     FIELD_ID_PROP = "field-id"
     KEY_ID_PROP = "key-id"

--- a/python/iceberg/core/filesystem/s3_filesystem.py
+++ b/python/iceberg/core/filesystem/s3_filesystem.py
@@ -40,7 +40,6 @@ ROLE_ARN = "default"
 AUTOREFRESH_SESSION = None
 
 
-
 @retry(wait_incrementing_start=100, wait_exponential_multiplier=4,
        wait_exponential_max=5000, stop_max_delay=600000, stop_max_attempt_number=7)
 def get_s3(obj="resource"):

--- a/python/iceberg/core/table_properties.py
+++ b/python/iceberg/core/table_properties.py
@@ -16,7 +16,6 @@
 # under the License.
 
 
-
 class TableProperties(object):
     COMMIT_NUM_RETRIES = "commit.retry.num-retries"
     COMMIT_NUM_RETRIES_DEFAULT = 4


### PR DESCRIPTION
This PR fixes the currently failing tests.  I'm not sure how this got out of sync, but is a pretty minor typo issue.  There were also a couple of linter issues with line spacing and importing of an unused module(which has been removed). @danielcweeks @rdblue 