### PR TITLE
Create data files using overwrite

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -286,6 +286,7 @@ class Writer implements DataSourceWriter {
                   .setAll(properties)
                   .metricsConfig(metricsConfig)
                   .schema(schema)
+                  .overwrite()
                   .build();
 
             case AVRO:
@@ -293,6 +294,7 @@ class Writer implements DataSourceWriter {
                   .createWriterFunc(ignored -> new SparkAvroWriter(schema))
                   .setAll(properties)
                   .schema(schema)
+                  .overwrite()
                   .build();
 
             default:


### PR DESCRIPTION
This updates Spark writes to create data files with overwrite set. Data file paths are always unique, so the purpose of this change is not to overwrite existing files. Instead, this will avoid an existence check in the file system to avoid negative caching the result of that existence check.