### PR TITLE
Avoid parallel runs of Spark Hive table tests

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -104,7 +104,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveTablesSupport() throws Exception {
+  public synchronized void testHiveTablesSupport() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     try {
       catalog.createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
@@ -137,7 +137,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveEntriesTable() throws Exception {
+  public synchronized void testHiveEntriesTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
     try {
       Table table = catalog.createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
@@ -178,7 +178,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveFilesTable() throws Exception {
+  public synchronized void testHiveFilesTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_test");
     try {
       Table table = catalog.createTable(tableIdentifier, SCHEMA,
@@ -233,7 +233,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveFilesUnpartitionedTable() throws Exception {
+  public synchronized void testHiveFilesUnpartitionedTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "unpartitioned_files_test");
     try {
       Table table = catalog.createTable(tableIdentifier, SCHEMA);
@@ -290,7 +290,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveHistoryTable() throws Exception {
+  public synchronized void testHiveHistoryTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "history_test");
     try {
       Table table = catalog.createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
@@ -373,7 +373,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveSnapshotsTable() throws Exception {
+  public synchronized void testHiveSnapshotsTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "snapshots_test");
     try {
       Table table = catalog.createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
@@ -449,7 +449,7 @@ public class TestIcebergSourceHiveTables {
   }
 
   @Test
-  public void testHiveManifestsTable() throws Exception {
+  public synchronized void testHiveManifestsTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "manifests_test");
     try {
       Table table = catalog.createTable(


### PR DESCRIPTION
Spark has a [method that uses a cached client or creates a new one](https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L274-L282) that could be causing multiple clients to get created. If that's the case, then the small 5-thread metastore would run out of handlers when called from parallel test cases.

Reducing the number of clients used by tests doesn't seem to help, so this fix for the flaky tests runs each test case in sequence by adding `synchronized`.