### PR TITLE
Fix avro data test schema according to spec

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -122,10 +122,10 @@ public class TypeUtil {
   }
 
   /**
-   * Assigns strictly increasing fresh ids for all fields in a schema, starting from 0.
+   * Assigns strictly increasing fresh ids for all fields in a schema, starting from 1.
    *
    * @param schema a schema
-   * @return a structurally identical schema with new ids assigned strictly increasing from 0.
+   * @return a structurally identical schema with new ids assigned strictly increasing from 1
    */
   public static Schema assignIncreasingFreshIds(Schema schema) {
     AtomicInteger lastColumnId = new AtomicInteger(0);

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
@@ -111,13 +112,24 @@ public class TypeUtil {
    *
    * @param schema a schema
    * @param nextId an id assignment function
-   * @return an structurally identical schema with new ids assigned by the nextId function
+   * @return a structurally identical schema with new ids assigned by the nextId function
    */
   public static Schema assignFreshIds(Schema schema, NextID nextId) {
     return new Schema(TypeUtil
         .visit(schema.asStruct(), new AssignFreshIds(nextId))
         .asNestedType()
         .fields());
+  }
+
+  /**
+   * Assigns strictly increasing fresh ids for all fields in a schema, starting from 0.
+   *
+   * @param schema a schema
+   * @return a structurally identical schema with new ids assigned strictly increasing from 0.
+   */
+  public static Schema assignIncreasingFreshIds(Schema schema) {
+    AtomicInteger lastColumnId = new AtomicInteger(0);
+    return TypeUtil.assignFreshIds(schema, lastColumnId::incrementAndGet);
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.types.TypeUtil;
 import org.junit.Assert;
@@ -53,7 +52,7 @@ public class TestCreateTransaction extends TableTestBase {
         0, listManifestFiles(tableDir).size());
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+        TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
   }
@@ -90,7 +89,7 @@ public class TestCreateTransaction extends TableTestBase {
         1, listManifestFiles(tableDir).size());
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+        TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 
@@ -132,7 +131,7 @@ public class TestCreateTransaction extends TableTestBase {
         1, listManifestFiles(tableDir).size());
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+        TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 
@@ -170,7 +169,7 @@ public class TestCreateTransaction extends TableTestBase {
         0, listManifestFiles(tableDir).size());
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+        TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
     Assert.assertEquals("Should have one table property", 1, meta.properties().size());
@@ -212,7 +211,7 @@ public class TestCreateTransaction extends TableTestBase {
         0, listManifestFiles(tableDir).size());
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+        TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
     Assert.assertEquals("Should have one table property", 1, meta.properties().size());
@@ -277,7 +276,7 @@ public class TestCreateTransaction extends TableTestBase {
     Table conflict = TestTables.create(tableDir, "test_conflict", SCHEMA, unpartitioned());
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), conflict.schema().asStruct());
+        TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), conflict.schema().asStruct());
     Assert.assertEquals("Table spec should match conflict table, not transaction table",
         unpartitioned(), conflict.spec());
     Assert.assertFalse("Table should not have any snapshots",
@@ -287,10 +286,5 @@ public class TestCreateTransaction extends TableTestBase {
         CommitFailedException.class, "Commit failed: table was updated", txn::commitTransaction);
 
     Assert.assertEquals("Should clean up metadata", Sets.newHashSet(), Sets.newHashSet(listManifestFiles(tableDir)));
-  }
-
-  private static Schema assignFreshIds(Schema schema) {
-    AtomicInteger lastColumnId = new AtomicInteger(0);
-    return TypeUtil.assignFreshIds(schema, lastColumnId::incrementAndGet);
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.data;
 
 import java.io.IOException;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.LongType;
@@ -61,7 +62,7 @@ public abstract class AvroDataTest {
 
   @Test
   public void testSimpleStruct() throws IOException {
-    writeAndValidate(new Schema(SUPPORTED_PRIMITIVES.fields()));
+    writeAndValidate(TypeUtil.assignIncreasingFreshIds(new Schema(SUPPORTED_PRIMITIVES.fields())));
   }
 
   @Test
@@ -75,9 +76,9 @@ public abstract class AvroDataTest {
 
   @Test
   public void testArrayOfStructs() throws IOException {
-    Schema schema = new Schema(
+    Schema schema = TypeUtil.assignIncreasingFreshIds(new Schema(
         required(0, "id", LongType.get()),
-        optional(1, "data", ListType.ofOptional(2, SUPPORTED_PRIMITIVES)));
+        optional(1, "data", ListType.ofOptional(2, SUPPORTED_PRIMITIVES))));
 
     writeAndValidate(schema);
   }
@@ -119,18 +120,18 @@ public abstract class AvroDataTest {
 
   @Test
   public void testMapOfStructs() throws IOException {
-    Schema schema = new Schema(
+    Schema schema = TypeUtil.assignIncreasingFreshIds(new Schema(
         required(0, "id", LongType.get()),
         optional(1, "data", MapType.ofOptional(2, 3,
             Types.StringType.get(),
-            SUPPORTED_PRIMITIVES)));
+            SUPPORTED_PRIMITIVES))));
 
     writeAndValidate(schema);
   }
 
   @Test
   public void testMixedTypes() throws IOException {
-    Schema schema = new Schema(
+    Schema schema = TypeUtil.assignIncreasingFreshIds(new Schema(
         required(0, "id", LongType.get()),
         optional(1, "list_of_maps",
             ListType.ofOptional(2, MapType.ofOptional(3, 4,
@@ -158,7 +159,7 @@ public abstract class AvroDataTest {
                 Types.StringType.get(),
                 SUPPORTED_PRIMITIVES))
         )))
-    );
+    ));
 
     writeAndValidate(schema);
   }


### PR DESCRIPTION
According to the spec, struct fields must have unique IDs within the table schema:

> A struct is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema.

This PR fixes the `AvroDataTest` defined nested structs to match the spec.