### PR TITLE
Added V1 Vectorized Reader

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,21 @@
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
+# Licensed to the Apache Software Foundation (ASF) under one	
+# or more contributor license agreements.  See the NOTICE file	
+# distributed with this work for additional information	
+# regarding copyright ownership.  The ASF licenses this file	
+# to you under the Apache License, Version 2.0 (the	
+# "License"); you may not use this file except in compliance	
+# with the License.  You may obtain a copy of the License at	
+#	
+#   http://www.apache.org/licenses/LICENSE-2.0	
+#	
+# Unless required by applicable law or agreed to in writing,	
+# software distributed under the License is distributed on an	
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY	
+# KIND, either express or implied.  See the License for the	
+# specific language governing permissions and limitations	
+# under the License.	
+	
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataFilterBenchmark.java
+++ b/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataFilterBenchmark.java
@@ -83,6 +83,21 @@ public class IcebergSourceFlatParquetDataFilterBenchmark extends IcebergSourceFl
 
   @Benchmark
   @Threads(1)
+  public void readWithFilterIcebergV1Vectorized10k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().format("iceberg")
+          .option("iceberg.read.enableV1VectorizedReader", "true")
+          .option("iceberg.read.numrecordsperbatch", "10000")
+          .load(tableLocation).filter(FILTER_COND);
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
   public void readWithFilterFileSourceVectorized() {
     Map<String, String> conf = Maps.newHashMap();
     conf.put(SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key(), "true");

--- a/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataReadBenchmark.java
+++ b/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataReadBenchmark.java
@@ -78,6 +78,54 @@ public class IcebergSourceFlatParquetDataReadBenchmark extends IcebergSourceFlat
 
   @Benchmark
   @Threads(1)
+  public void readIcebergV1Vectorized10k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df =
+          spark().read().format("iceberg")
+              .option("iceberg.read.enableV1VectorizedReader", "true")
+              .option("iceberg.read.numrecordsperbatch", "10000")
+              .load(tableLocation);
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readIcebergV1Vectorized5k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df =
+          spark().read().format("iceberg")
+              .option("iceberg.read.enableV1VectorizedReader", "true")
+              .option("iceberg.read.numrecordsperbatch", "5000")
+              .load(tableLocation);
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readIcebergV1Vectorized20k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df =
+          spark().read().format("iceberg")
+              .option("iceberg.read.enableV1VectorizedReader", "true")
+              .option("iceberg.read.numrecordsperbatch", "20000")
+              .load(tableLocation);
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
   public void readFileSourceVectorized() {
     Map<String, String> conf = Maps.newHashMap();
     conf.put(SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key(), "true");
@@ -108,6 +156,51 @@ public class IcebergSourceFlatParquetDataReadBenchmark extends IcebergSourceFlat
     withTableProperties(tableProperties, () -> {
       String tableLocation = table().location();
       Dataset<Row> df = spark().read().format("iceberg").load(tableLocation).select("longCol");
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readWithProjectionIcebergV1Vectorized10k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().format("iceberg")
+          .option("iceberg.read.enableV1VectorizedReader", "true")
+          .option("iceberg.read.numrecordsperbatch", "10000")
+          .load(tableLocation).select("longCol");
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readWithProjectionIcebergV1Vectorized5k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().format("iceberg")
+          .option("iceberg.read.enableV1VectorizedReader", "true")
+          .option("iceberg.read.numrecordsperbatch", "5000")
+          .load(tableLocation).select("longCol");
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readWithProjectionIcebergV1Vectorized20k() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().format("iceberg")
+          .option("iceberg.read.enableV1VectorizedReader", "true")
+          .option("iceberg.read.numrecordsperbatch", "20000")
+          .load(tableLocation).select("longCol");
       materialize(df);
     });
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/V1VectorizedReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/V1VectorizedReader.java
@@ -1,0 +1,522 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.SystemProperties;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.spark.SparkFilters;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
+import org.apache.spark.sql.sources.v2.reader.InputPartition;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.apache.spark.sql.sources.v2.reader.Statistics;
+import org.apache.spark.sql.sources.v2.reader.SupportsPushDownFilters;
+import org.apache.spark.sql.sources.v2.reader.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.sources.v2.reader.SupportsReportStatistics;
+import org.apache.spark.sql.sources.v2.reader.SupportsScanColumnarBatch;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.Seq;
+import scala.collection.mutable.ArrayBuffer;
+
+class V1VectorizedReader implements SupportsScanColumnarBatch,
+    DataSourceReader,
+    SupportsPushDownFilters,
+    SupportsPushDownRequiredColumns,
+    SupportsReportStatistics {
+  private static final Logger LOG = LoggerFactory.getLogger(Reader.class);
+
+  private static final Filter[] NO_FILTERS = new Filter[0];
+
+  private final Table table;
+  private final Long snapshotId;
+  private final Long asOfTimestamp;
+  private final Long splitSize;
+  private final Integer splitLookback;
+  private final Long splitOpenFileCost;
+  private final Integer maxNumVectorizedFields;
+  private final FileIO fileIo;
+  private final EncryptionManager encryptionManager;
+  private final boolean caseSensitive;
+  private final int numRecordsPerBatch;
+  // private final String sparkMaster;
+  private final Configuration hadoopConf;
+  // private final SparkConf sparkConf;
+  private final SparkSession sparkSession;
+  // default as per SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE default
+  public static final int DEFAULT_NUM_ROWS_IN_BATCH = 4096;
+  public static final int DEFAULT_MAX_NUM_FIELDS = 300;
+
+  private StructType requestedSchema = null;
+  private List<Expression> filterExpressions = null;
+  private Filter[] pushedFilters = NO_FILTERS;
+
+  // lazy variables
+  private Schema schema = null;
+  private StructType type = null; // cached because Spark accesses it multiple times
+  private List<CombinedScanTask> tasks = null; // lazy cache of tasks
+
+  V1VectorizedReader(Table table, boolean caseSensitive, DataSourceOptions options,
+      Configuration hadoopConf, int numRecordsPerBatch, SparkSession sparkSession) {
+
+    this.table = table;
+    this.snapshotId = options.get("snapshot-id").map(Long::parseLong).orElse(null);
+    this.asOfTimestamp = options.get("as-of-timestamp").map(Long::parseLong).orElse(null);
+    if (snapshotId != null && asOfTimestamp != null) {
+      throw new IllegalArgumentException(
+          "Cannot scan using both snapshot-id and as-of-timestamp to select the table snapshot");
+    }
+
+    this.numRecordsPerBatch = numRecordsPerBatch;
+
+
+    this.splitSize = options.get("split-size").map(Long::parseLong).orElse(null);
+    this.splitLookback = options.get("lookback").map(Integer::parseInt).orElse(null);
+    this.splitOpenFileCost = options.get("file-open-cost").map(Long::parseLong).orElse(null);
+    this.maxNumVectorizedFields =
+        options.get("max-num-vectorized-fields").map(Integer::parseInt).orElse(DEFAULT_MAX_NUM_FIELDS);
+
+    this.schema = table.schema();
+    this.fileIo = table.io();
+    this.encryptionManager = table.encryption();
+    this.caseSensitive = caseSensitive;
+    this.hadoopConf = hadoopConf;
+    this.sparkSession = sparkSession;
+
+    LOG.debug("=> Set Config numRecordsPerBatch: {}, " +
+            "Split size: {}, " +
+            "Planning Thread count: {}, " +
+            "Max Num Vectorized Fields: {}",
+        numRecordsPerBatch,
+        splitSize,
+        System.getProperty(SystemProperties.WORKER_THREAD_POOL_SIZE_PROP),
+        maxNumVectorizedFields);
+  }
+
+  private Schema lazySchema() {
+    if (schema == null) {
+      if (requestedSchema != null) {
+        this.schema = SparkSchemaUtil.prune(table.schema(), requestedSchema);
+      } else {
+        this.schema = table.schema();
+      }
+    }
+    return schema;
+  }
+
+  private StructType lazyType() {
+    if (type == null) {
+      this.type = SparkSchemaUtil.convert(lazySchema());
+    }
+    return type;
+  }
+
+  @Override
+  public StructType readSchema() {
+    return lazyType();
+  }
+
+  @Override
+  public List<InputPartition<ColumnarBatch>> planBatchInputPartitions() {
+
+    long start = System.currentTimeMillis();
+
+    String tableSchemaString = SchemaParser.toJson(table.schema());
+    String expectedSchemaString = SchemaParser.toJson(lazySchema());
+
+    //
+    // pre-process static parameters here, once
+    //
+
+    // prepare filters
+    Filter[] processedFilters = pushFilters(pushedFilters);
+    // prepare filter seq
+    scala.collection.mutable.ArrayBuffer<Filter> filtersAsArrayBuf =  new ArrayBuffer(processedFilters.length);
+    for (Filter f : processedFilters) {
+      filtersAsArrayBuf.$plus$eq(f);
+    }
+    Seq<Filter> filterAsSeq = filtersAsArrayBuf.toSeq();
+    // prepare hadoopconf
+    hadoopConf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key(), "true");
+    hadoopConf.set(SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key(),
+        Integer.toString(this.numRecordsPerBatch));
+    hadoopConf.set(SQLConf.WHOLESTAGE_MAX_NUM_FIELDS().key(),
+        Integer.toString(maxNumVectorizedFields));
+    sparkSession.sessionState().conf().setConfString(SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key(), "true");
+    sparkSession.sessionState().conf().setConfString(SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key(),
+        Integer.toString(this.numRecordsPerBatch));
+    sparkSession.sessionState().conf().setConfString(SQLConf.WHOLESTAGE_MAX_NUM_FIELDS().key(),
+        Integer.toString(maxNumVectorizedFields));
+
+    // prepare sparkReadSchema
+    StructType sparkReadSchema = SparkSchemaUtil.convert(lazySchema());
+    // Build function for V1 Partition Reader which is passed over from Driver to Executors
+    ParquetFileFormat fileFormatInstance = new ParquetFileFormat();
+    scala.Function1<PartitionedFile, scala.collection.Iterator<InternalRow>> partitionFunction =
+        fileFormatInstance.buildReaderWithPartitionValues(sparkSession,
+          sparkReadSchema,
+          new StructType(),
+          sparkReadSchema,
+          filterAsSeq, // List$.MODULE$.empty(),
+          null, hadoopConf);
+
+    List<InputPartition<ColumnarBatch>> readTasks = Lists.newArrayList();
+    for (CombinedScanTask task : tasks()) {
+      long readTaskStart = System.currentTimeMillis();
+      readTasks.add(
+          new ReadTask(task, tableSchemaString, expectedSchemaString, fileIo, encryptionManager, caseSensitive,
+              numRecordsPerBatch, processedFilters, partitionFunction));
+      LOG.debug("=> ReadTask creating time took {} ms.", System.currentTimeMillis() - readTaskStart);
+    }
+    LOG.debug("=> Input Task planning took {} seconds.", (System.currentTimeMillis() - start) / 1000.0f);
+    LOG.debug("=> Spark Schema: {}", sparkReadSchema);
+
+    return readTasks;
+  }
+
+  @Override
+  public Filter[] pushFilters(Filter[] filters) {
+    this.tasks = null; // invalidate cached tasks, if present
+
+    List<Expression> expressions = Lists.newArrayListWithExpectedSize(filters.length);
+    List<Filter> pushed = Lists.newArrayListWithExpectedSize(filters.length);
+
+    for (Filter filter : filters) {
+      Expression expr = SparkFilters.convert(filter);
+      if (expr != null) {
+        expressions.add(expr);
+        pushed.add(filter);
+      }
+    }
+
+    this.filterExpressions = expressions;
+    this.pushedFilters = pushed.toArray(new Filter[0]);
+
+    // invalidate the schema that will be projected
+    this.schema = null;
+    this.type = null;
+
+    // Spark doesn't support residuals per task, so return all filters
+    // to get Spark to handle record-level filtering
+    return filters;
+  }
+
+  @Override
+  public Filter[] pushedFilters() {
+    return pushedFilters;
+  }
+
+  @Override
+  public void pruneColumns(StructType newRequestedSchema) {
+    this.requestedSchema = newRequestedSchema;
+
+    LOG.debug("=> Prune columns : {}", newRequestedSchema.prettyJson());
+    // invalidate the schema that will be projected
+    this.schema = null;
+    this.type = null;
+  }
+
+  @Override
+  public Statistics estimateStatistics() {
+    long sizeInBytes = 0L;
+    long numRows = 0L;
+
+    for (CombinedScanTask task : tasks()) {
+      for (FileScanTask file : task.files()) {
+        sizeInBytes += file.length();
+        numRows += file.file().recordCount();
+      }
+    }
+
+    return new Stats(sizeInBytes, numRows);
+  }
+
+  private List<CombinedScanTask> tasks() {
+    if (tasks == null) {
+      TableScan scan = table
+          .newScan()
+          .caseSensitive(caseSensitive)
+          .project(lazySchema());
+
+      if (snapshotId != null) {
+        scan = scan.useSnapshot(snapshotId);
+      }
+
+      if (asOfTimestamp != null) {
+        scan = scan.asOfTime(asOfTimestamp);
+      }
+
+      if (splitSize != null) {
+        scan = scan.option(TableProperties.SPLIT_SIZE, splitSize.toString());
+      }
+
+      if (splitLookback != null) {
+        scan = scan.option(TableProperties.SPLIT_LOOKBACK, splitLookback.toString());
+      }
+
+      if (splitOpenFileCost != null) {
+        scan = scan.option(TableProperties.SPLIT_OPEN_FILE_COST, splitOpenFileCost.toString());
+      }
+
+      if (filterExpressions != null) {
+        for (Expression filter : filterExpressions) {
+          scan = scan.filter(filter);
+        }
+      }
+
+      try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
+        this.tasks = Lists.newArrayList(tasksIterable);
+      }  catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to close table scan: %s", scan);
+      }
+    }
+
+    return tasks;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "V1VectorizedIcebergScan(numPerBatch=%s, table=%s, type=%s, filters=%s, caseSensitive=%s)",
+        numRecordsPerBatch, table, lazySchema().asStruct(), filterExpressions, caseSensitive);
+  }
+
+  private static class ReadTask implements InputPartition<ColumnarBatch>, Serializable {
+    private final CombinedScanTask task;
+    private final String tableSchemaString;
+    private final String expectedSchemaString;
+    private final FileIO fileIo;
+    private final EncryptionManager encryptionManager;
+    private final boolean caseSensitive;
+    private final int numRecordsPerBatch;
+    private final Filter[] filters;
+    private final scala.Function1<PartitionedFile, scala.collection.Iterator<InternalRow>> buildReaderFunc;
+
+    private transient Schema tableSchema = null;
+    private transient Schema expectedSchema = null;
+
+    private ReadTask(
+        CombinedScanTask task, String tableSchemaString, String expectedSchemaString, FileIO fileIo,
+        EncryptionManager encryptionManager, boolean caseSensitive, int numRecordsPerBatch,
+        Filter[] filters, scala.Function1<PartitionedFile, scala.collection.Iterator<InternalRow>> partitionFunction) {
+      this.task = task;
+      this.tableSchemaString = tableSchemaString;
+      this.expectedSchemaString = expectedSchemaString;
+      this.fileIo = fileIo;
+      this.encryptionManager = encryptionManager;
+      this.caseSensitive = caseSensitive;
+      this.numRecordsPerBatch = numRecordsPerBatch;
+      this.filters = filters;
+
+      LOG.debug("=> Build partition reader function ");
+      this.buildReaderFunc = partitionFunction;
+    }
+
+    @Override
+    public InputPartitionReader<ColumnarBatch> createPartitionReader() {
+
+      LOG.debug("=> Create Partition Reader");
+      return new V1VectorizedTaskDataReader(task, lazyTableSchema(), lazyExpectedSchema(), fileIo,
+            encryptionManager, caseSensitive, buildReaderFunc);
+    }
+
+    private Schema lazyTableSchema() {
+      if (tableSchema == null) {
+        this.tableSchema = SchemaParser.fromJson(tableSchemaString);
+      }
+      return tableSchema;
+    }
+
+    private Schema lazyExpectedSchema() {
+      if (expectedSchema == null) {
+        this.expectedSchema = SchemaParser.fromJson(expectedSchemaString);
+      }
+      return expectedSchema;
+    }
+  }
+
+  private static class PartitionRowConverter implements Function<StructLike, InternalRow> {
+    private final DataType[] types;
+    private final int[] positions;
+    private final Class<?>[] javaTypes;
+    private final GenericInternalRow reusedRow;
+
+    PartitionRowConverter(Schema partitionSchema, PartitionSpec spec) {
+      StructType partitionType = SparkSchemaUtil.convert(partitionSchema);
+      StructField[] fields = partitionType.fields();
+
+      this.types = new DataType[fields.length];
+      this.positions = new int[types.length];
+      this.javaTypes = new Class<?>[types.length];
+      this.reusedRow = new GenericInternalRow(types.length);
+
+      List<PartitionField> partitionFields = spec.fields();
+      for (int rowIndex = 0; rowIndex < fields.length; rowIndex += 1) {
+        this.types[rowIndex] = fields[rowIndex].dataType();
+
+        int sourceId = partitionSchema.columns().get(rowIndex).fieldId();
+        for (int specIndex = 0; specIndex < partitionFields.size(); specIndex += 1) {
+          PartitionField field = spec.fields().get(specIndex);
+          if (field.sourceId() == sourceId && "identity".equals(field.transform().toString())) {
+            positions[rowIndex] = specIndex;
+            javaTypes[rowIndex] = spec.javaClasses()[specIndex];
+            break;
+          }
+        }
+      }
+    }
+
+    @Override
+    public InternalRow apply(StructLike tuple) {
+      for (int i = 0; i < types.length; i += 1) {
+        Object value = tuple.get(positions[i], javaTypes[i]);
+        if (value != null) {
+          reusedRow.update(i, convert(value, types[i]));
+        } else {
+          reusedRow.setNullAt(i);
+        }
+      }
+
+      return reusedRow;
+    }
+
+    /**
+     * Converts the objects into instances used by Spark's InternalRow.
+     *
+     * @param value a data value
+     * @param type the Spark data type
+     * @return the value converted to the representation expected by Spark's InternalRow.
+     */
+    private static Object convert(Object value, DataType type) {
+      if (type instanceof StringType) {
+        return UTF8String.fromString(value.toString());
+      } else if (type instanceof BinaryType) {
+        return ByteBuffers.toByteArray((ByteBuffer) value);
+      } else if (type instanceof DecimalType) {
+        return Decimal.fromDecimal(value);
+      }
+      return value;
+    }
+  }
+
+  private static class StructLikeInternalRow implements StructLike {
+    private final DataType[] types;
+    private InternalRow row = null;
+
+    StructLikeInternalRow(StructType struct) {
+      this.types = new DataType[struct.size()];
+      StructField[] fields = struct.fields();
+      for (int i = 0; i < fields.length; i += 1) {
+        types[i] = fields[i].dataType();
+      }
+    }
+
+    public StructLikeInternalRow setRow(InternalRow row) {
+      this.row = row;
+      return this;
+    }
+
+    @Override
+    public int size() {
+      return types.length;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(row.get(pos, types[pos]));
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("Not implemented: set");
+    }
+  }
+
+  private static class SerializableHadoopConfiguration implements Serializable {
+
+    private Configuration conf;
+
+    SerializableHadoopConfiguration(Configuration hadoopConf) {
+      this.conf = hadoopConf;
+
+      if (this.conf == null) {
+        this.conf = new Configuration();
+      }
+    }
+
+    SerializableHadoopConfiguration() {
+      this.conf = new Configuration();
+    }
+
+    public Configuration get() {
+      return this.conf;
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+      this.conf.write(out);
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException {
+      this.conf = new Configuration();
+      this.conf.readFields(in);
+    }
+  }
+
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/V1VectorizedTaskDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/V1VectorizedTaskDataReader.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.execution.vectorized.MutableColumnarRow;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
+
+class V1VectorizedTaskDataReader implements InputPartitionReader<ColumnarBatch> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(V1VectorizedTaskDataReader.class);
+
+  private final Iterator<FileScanTask> tasks;
+  private final Schema tableSchema;
+  private final Schema expectedSchema;
+  private final FileIO fileIo;
+  private final Map<String, InputFile> inputFiles;
+  private final boolean caseSensitive;
+  private final scala.Function1<PartitionedFile, scala.collection.Iterator<InternalRow>> buildReaderFunc;
+
+  private Iterator<ColumnarBatch> currentIterator = null;
+  private Closeable currentCloseable = null;
+  private ColumnarBatch current = null;
+
+  V1VectorizedTaskDataReader(
+      CombinedScanTask task, Schema tableSchema, Schema expectedSchema, FileIO fileIo,
+      EncryptionManager encryptionManager, boolean caseSensitive,
+      scala.Function1<PartitionedFile,
+      scala.collection.Iterator<InternalRow>> buildReaderFunc) {
+
+    this.fileIo = fileIo;
+    this.tasks = task.files().iterator();
+    this.tableSchema = tableSchema;
+    this.expectedSchema = expectedSchema;
+    Iterable<InputFile> decryptedFiles = encryptionManager.decrypt(Iterables.transform(task.files(),
+        fileScanTask ->
+            EncryptedFiles.encryptedInput(
+                this.fileIo.newInputFile(fileScanTask.file().path().toString()),
+                fileScanTask.file().keyMetadata())));
+    ImmutableMap.Builder<String, InputFile> inputFileBuilder = ImmutableMap.builder();
+    decryptedFiles.forEach(decrypted -> inputFileBuilder.put(decrypted.location(), decrypted));
+    this.inputFiles = inputFileBuilder.build();
+    // open last because the schemas and fileIo must be set
+    this.caseSensitive = caseSensitive;
+    this.buildReaderFunc = buildReaderFunc;
+
+    // open after initializing everything
+    this.currentIterator = open(tasks.next());
+    LOG.warn("V1VectorizedTaskDataReader initialized.");
+  }
+
+  @Override
+  public boolean next() throws IOException {
+    while (true) {
+      if (currentIterator.hasNext()) {
+        this.current = currentIterator.next();
+        return true;
+
+      } else if (tasks.hasNext()) {
+        this.currentCloseable.close();
+        this.currentIterator = open(tasks.next());
+
+      } else {
+        return false;
+      }
+    }
+  }
+
+  @Override
+  public ColumnarBatch get() {
+    return current;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // close the current iterator
+    this.currentCloseable.close();
+
+    // exhaust the task iterator
+    while (tasks.hasNext()) {
+      tasks.next();
+    }
+  }
+
+  private Iterator<ColumnarBatch> open(FileScanTask task) {
+    DataFile file = task.file();
+
+    // schema or rows returned by readers
+    Schema finalSchema = expectedSchema;
+    PartitionSpec spec = task.spec();
+    Set<Integer> idColumns = spec.identitySourceIds();
+
+    // schema needed for the projection and filtering
+    StructType sparkType = SparkSchemaUtil.convert(finalSchema);
+    Schema requiredSchema = SparkSchemaUtil.prune(tableSchema, sparkType, task.residual(), caseSensitive);
+    boolean hasExtraFilterColumns = requiredSchema.columns().size() != finalSchema.columns().size();
+
+    Iterator<ColumnarBatch> iter;
+
+    if (hasExtraFilterColumns) {
+      // add projection to the final schema
+      iter = open(task, requiredSchema);
+
+    } else {
+      // return the base iterator
+      iter = open(task, finalSchema);
+    }
+
+    return iter;
+  }
+
+  private Iterator<ColumnarBatch> open(FileScanTask task, Schema readSchema) {
+    // CloseableIterable<InternalRow> iter;
+    BatchOverRowIterator batchOverRowIter = null;
+
+    InputFile location = inputFiles.get(task.file().path().toString());
+    Preconditions.checkNotNull(location, "Could not find InputFile associated with FileScanTask");
+
+
+    switch (task.file().format()) {
+      case PARQUET:
+        // V1 Vectorized reading
+        scala.collection.Iterator<InternalRow> internalRowIter =
+            buildV1VectorizedBatchReader(task);
+
+        batchOverRowIter = new BatchOverRowIterator(JavaConverters.asJavaIteratorConverter(internalRowIter).asJava());
+        break;
+
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot read unknown format: " + task.file().format());
+    }
+
+    this.currentCloseable = batchOverRowIter;
+
+    return batchOverRowIter;
+  }
+
+
+  private scala.collection.Iterator<InternalRow> buildV1VectorizedBatchReader(FileScanTask task) {
+
+    Class<?> clazz = PartitionedFile.class;
+    Constructor<?> ctor = clazz.getConstructors()[0]; // we know PartitionedFile has only one constructor
+    PartitionedFile partitionedFile;
+    try {
+      // Pick partition fields
+      partitionedFile = (PartitionedFile)
+          ctor.newInstance(InternalRow.empty(),   task.file().path().toString(),
+              task.start(), task.length(), null);
+    } catch (Throwable t) {
+      throw new RuntimeException("Could not instantiate PartitionedFile", t);
+    }
+
+    return buildReaderFunc.apply(partitionedFile);
+  }
+
+  private static class BatchOverRowIterator implements Iterator<ColumnarBatch>, Closeable {
+
+    private Iterator<InternalRow> rowIterator;
+
+    BatchOverRowIterator(Iterator<InternalRow> rowIterator) {
+
+      this.rowIterator = rowIterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return rowIterator.hasNext();
+    }
+
+    @Override
+    public ColumnarBatch next() {
+
+      Object object = rowIterator.next();
+
+      if (object instanceof ColumnarBatch) {
+
+        ColumnarBatch batch = (ColumnarBatch) object;
+        return batch;
+      } else {
+
+        MutableColumnarRow columnarRow = (MutableColumnarRow) object;
+      }
+
+      throw new RuntimeException("Object not of [ColumnarBatch] type, " +
+          "found [" + object.getClass().getCanonicalName() + "]");
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredV1VectorizedScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredV1VectorizedScan.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.spark.data.TestHelpers;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.sources.And;
+import org.apache.spark.sql.sources.EqualTo;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.sources.GreaterThan;
+import org.apache.spark.sql.sources.LessThan;
+import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
+import org.apache.spark.sql.sources.v2.reader.InputPartition;
+import org.apache.spark.sql.sources.v2.reader.SupportsPushDownFilters;
+import org.apache.spark.sql.sources.v2.reader.SupportsScanColumnarBatch;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.Files.localOutput;
+import static org.apache.spark.sql.catalyst.util.DateTimeUtils.fromJavaTimestamp;
+import static org.apache.spark.sql.functions.callUDF;
+import static org.apache.spark.sql.functions.column;
+
+@RunWith(Parameterized.class)
+public class TestFilteredV1VectorizedScan {
+
+  private static final Configuration CONF = new Configuration();
+  private static final HadoopTables TABLES = new HadoopTables(CONF);
+
+  private static final Schema SCHEMA = new Schema(
+      Types.NestedField.required(1, "id", Types.LongType.get()),
+      Types.NestedField.optional(2, "ts", Types.TimestampType.withZone()),
+      Types.NestedField.optional(3, "data", Types.StringType.get())
+  );
+
+  private static final PartitionSpec BUCKET_BY_ID = PartitionSpec.builderFor(SCHEMA)
+      .bucket("id", 4)
+      .build();
+
+  private static final PartitionSpec PARTITION_BY_DAY = PartitionSpec.builderFor(SCHEMA)
+      .day("ts")
+      .build();
+
+  private static final PartitionSpec PARTITION_BY_HOUR = PartitionSpec.builderFor(SCHEMA)
+      .hour("ts")
+      .build();
+
+  private static SparkSession spark = null;
+
+  @BeforeClass
+  public static void startSpark() {
+    TestFilteredV1VectorizedScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
+
+    // define UDFs used by partition tests
+    Transform<Long, Integer> bucket4 = Transforms.bucket(Types.LongType.get(), 4);
+    spark.udf().register("bucket4", (UDF1<Long, Integer>) bucket4::apply, IntegerType$.MODULE$);
+
+    Transform<Long, Integer> day = Transforms.day(Types.TimestampType.withZone());
+    spark.udf().register("ts_day",
+        (UDF1<Timestamp, Integer>) timestamp -> day.apply((Long) fromJavaTimestamp(timestamp)),
+        IntegerType$.MODULE$);
+
+    Transform<Long, Integer> hour = Transforms.hour(Types.TimestampType.withZone());
+    spark.udf().register("ts_hour",
+        (UDF1<Timestamp, Integer>) timestamp -> hour.apply((Long) fromJavaTimestamp(timestamp)),
+        IntegerType$.MODULE$);
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestFilteredV1VectorizedScan.spark;
+    TestFilteredV1VectorizedScan.spark = null;
+    currentSpark.stop();
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private final String format;
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { "parquet" },
+        new Object[] { "avro" }
+    };
+  }
+
+  public TestFilteredV1VectorizedScan(String format) {
+    this.format = format;
+  }
+
+  private File parent = null;
+  private File unpartitioned = null;
+  private List<GenericData.Record> records = null;
+
+  @Before
+  public void writeUnpartitionedTable() throws IOException {
+    this.parent = temp.newFolder("TestFilteredV1VectorizedScan");
+    this.unpartitioned = new File(parent, "unpartitioned");
+    File dataFolder = new File(unpartitioned, "data");
+    Assert.assertTrue("Mkdir should succeed", dataFolder.mkdirs());
+
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), unpartitioned.toString());
+    Schema tableSchema = table.schema(); // use the table schema because ids are reassigned
+
+    FileFormat fileFormat = FileFormat.valueOf(format.toUpperCase(Locale.ENGLISH));
+
+    File testFile = new File(dataFolder, fileFormat.addExtension(UUID.randomUUID().toString()));
+
+    // create records using the table's schema
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(tableSchema, "test");
+    this.records = testRecords(avroSchema);
+
+    switch (fileFormat) {
+      case AVRO:
+        try (FileAppender<GenericData.Record> writer = Avro.write(localOutput(testFile))
+            .schema(tableSchema)
+            .build()) {
+          writer.addAll(records);
+        }
+        break;
+
+      case PARQUET:
+        try (FileAppender<GenericData.Record> writer = Parquet.write(localOutput(testFile))
+            .schema(tableSchema)
+            .build()) {
+          writer.addAll(records);
+        }
+        break;
+    }
+
+    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+        .withRecordCount(records.size())
+        .withFileSizeInBytes(testFile.length())
+        .withPath(testFile.toString())
+        .build();
+
+    table.newAppend().appendFile(file).commit();
+  }
+
+  @Test
+  public void testUnpartitionedIDFilters() {
+    DataSourceOptions options = new DataSourceOptions(ImmutableMap.of(
+        "path", unpartitioned.toString(),
+        IcebergSource.ICEBERG_READ_ENABLE_V1_VECTORIZATION_CONF, "true")
+    );
+
+    IcebergSource source = new IcebergSource();
+
+    for (int i = 0; i < 10; i += 1) {
+      SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+      pushFilters(reader, EqualTo.apply("id", i));
+
+      List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+      Assert.assertEquals("Should only create one task for a small file", 1, tasks.size());
+
+      // validate row filtering
+      assertEqualsSafe(SCHEMA.asStruct(), expected(i),
+          read(unpartitioned.toString(), "id = " + i));
+    }
+  }
+
+  @Test
+  public void testUnpartitionedCaseInsensitiveIDFilters() {
+    DataSourceOptions options = new DataSourceOptions(ImmutableMap.of(
+        "path", unpartitioned.toString(),
+        IcebergSource.ICEBERG_READ_ENABLE_V1_VECTORIZATION_CONF, "true")
+    );
+
+    // set spark.sql.caseSensitive to false
+    String caseSensitivityBeforeTest = TestFilteredV1VectorizedScan.spark.conf().get("spark.sql.caseSensitive");
+    TestFilteredV1VectorizedScan.spark.conf().set("spark.sql.caseSensitive", "false");
+
+    try {
+      IcebergSource source = new IcebergSource();
+
+      for (int i = 0; i < 10; i += 1) {
+        SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+        pushFilters(reader, EqualTo.apply("ID", i)); // note lower(ID) == lower(id), so there must be a match
+
+        List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+        Assert.assertEquals("Should only create one task for a small file", 1, tasks.size());
+
+        // validate row filtering
+        assertEqualsSafe(SCHEMA.asStruct(), expected(i),
+            read(unpartitioned.toString(), "id = " + i));
+      }
+    } finally {
+      // return global conf to previous state
+      TestFilteredV1VectorizedScan.spark.conf().set("spark.sql.caseSensitive", caseSensitivityBeforeTest);
+    }
+  }
+
+  @Test
+  public void testUnpartitionedTimestampFilter() {
+    DataSourceOptions options = new DataSourceOptions(ImmutableMap.of(
+        "path", unpartitioned.toString(),
+        IcebergSource.ICEBERG_READ_ENABLE_V1_VECTORIZATION_CONF, "true")
+    );
+
+    IcebergSource source = new IcebergSource();
+
+    SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+    pushFilters(reader, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+
+    List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+    Assert.assertEquals("Should only create one task for a small file", 1, tasks.size());
+
+    assertEqualsSafe(SCHEMA.asStruct(), expected(5, 6, 7, 8, 9),
+        read(unpartitioned.toString(), "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
+  }
+
+  @Test
+  public void testBucketPartitionedIDFilters() {
+    File location = buildPartitionedTable("bucketed_by_id", BUCKET_BY_ID, "bucket4", "id");
+
+    DataSourceOptions options = new DataSourceOptions(ImmutableMap.of(
+        "path", location.toString(),
+        IcebergSource.ICEBERG_READ_ENABLE_V1_VECTORIZATION_CONF, "true")
+    );
+
+    IcebergSource source = new IcebergSource();
+    SupportsScanColumnarBatch unfiltered = (SupportsScanColumnarBatch) source.createReader(options);
+    Assert.assertEquals("Unfiltered table should created 4 read tasks",
+        4, unfiltered.planBatchInputPartitions().size());
+
+    for (int i = 0; i < 10; i += 1) {
+      SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+      pushFilters(reader, EqualTo.apply("id", i));
+
+      List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+
+      // validate predicate push-down
+      Assert.assertEquals("Should create one task for a single bucket", 1, tasks.size());
+
+      // validate row filtering
+      assertEqualsSafe(SCHEMA.asStruct(), expected(i), read(location.toString(), "id = " + i));
+    }
+  }
+
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+  @Test
+  public void testDayPartitionedTimestampFilters() {
+    File location = buildPartitionedTable("partitioned_by_day", PARTITION_BY_DAY, "ts_day", "ts");
+
+    DataSourceOptions options = new DataSourceOptions(ImmutableMap.of(
+        "path", location.toString(),
+        IcebergSource.ICEBERG_READ_ENABLE_V1_VECTORIZATION_CONF, "true")
+    );
+
+    IcebergSource source = new IcebergSource();
+    SupportsScanColumnarBatch unfiltered = (SupportsScanColumnarBatch) source.createReader(options);
+    Assert.assertEquals("Unfiltered table should created 2 read tasks",
+        2, unfiltered.planBatchInputPartitions().size());
+
+    {
+      SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+      pushFilters(reader, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+
+      List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+      Assert.assertEquals("Should create one task for 2017-12-21", 1, tasks.size());
+
+      assertEqualsSafe(SCHEMA.asStruct(), expected(5, 6, 7, 8, 9),
+          read(location.toString(), "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
+    }
+
+    {
+      SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+      pushFilters(reader, And.apply(
+          GreaterThan.apply("ts", "2017-12-22T06:00:00+00:00"),
+          LessThan.apply("ts", "2017-12-22T08:00:00+00:00")));
+
+      List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+      Assert.assertEquals("Should create one task for 2017-12-22", 1, tasks.size());
+
+      assertEqualsSafe(SCHEMA.asStruct(), expected(1, 2), read(location.toString(),
+          "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and " +
+              "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)"));
+    }
+  }
+
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+  @Test
+  public void testHourPartitionedTimestampFilters() {
+    File location = buildPartitionedTable("partitioned_by_hour", PARTITION_BY_HOUR, "ts_hour", "ts");
+
+    DataSourceOptions options = new DataSourceOptions(ImmutableMap.of(
+        "path", location.toString(),
+        IcebergSource.ICEBERG_READ_ENABLE_V1_VECTORIZATION_CONF, "true")
+    );
+
+    IcebergSource source = new IcebergSource();
+    SupportsScanColumnarBatch unfiltered = (SupportsScanColumnarBatch) source.createReader(options);
+    Assert.assertEquals("Unfiltered table should created 9 read tasks",
+        9, unfiltered.planBatchInputPartitions().size());
+
+    {
+      SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+      pushFilters(reader, LessThan.apply("ts", "2017-12-22T00:00:00+00:00"));
+
+      List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+      Assert.assertEquals("Should create 4 tasks for 2017-12-21: 15, 17, 21, 22", 4, tasks.size());
+
+      assertEqualsSafe(SCHEMA.asStruct(), expected(8, 9, 7, 6, 5),
+          read(location.toString(), "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
+    }
+
+    {
+      SupportsScanColumnarBatch reader = (SupportsScanColumnarBatch) source.createReader(options);
+
+      pushFilters(reader, And.apply(
+          GreaterThan.apply("ts", "2017-12-22T06:00:00+00:00"),
+          LessThan.apply("ts", "2017-12-22T08:00:00+00:00")));
+
+      List<InputPartition<ColumnarBatch>> tasks = reader.planBatchInputPartitions();
+      Assert.assertEquals("Should create 2 tasks for 2017-12-22: 6, 7", 2, tasks.size());
+
+      assertEqualsSafe(SCHEMA.asStruct(), expected(2, 1), read(location.toString(),
+          "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and " +
+              "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)"));
+    }
+  }
+
+  @SuppressWarnings("checkstyle:AvoidNestedBlocks")
+  @Test
+  public void testFilterByNonProjectedColumn() {
+    {
+      Schema actualProjection = SCHEMA.select("id", "data");
+      List<GenericData.Record> expected = Lists.newArrayList();
+      for (GenericData.Record rec : expected(5, 6, 7, 8, 9)) {
+        expected.add(projectFlat(actualProjection, rec));
+      }
+
+      assertEqualsSafe(actualProjection.asStruct(), expected, read(
+          unpartitioned.toString(),
+          "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)",
+          "id", "data"));
+    }
+
+    {
+      // only project id: ts will be projected because of the filter, but data will not be included
+
+      Schema actualProjection = SCHEMA.select("id");
+      List<GenericData.Record> expected = Lists.newArrayList();
+      for (GenericData.Record rec : expected(1, 2)) {
+        expected.add(projectFlat(actualProjection, rec));
+      }
+
+      assertEqualsSafe(actualProjection.asStruct(), expected, read(
+          unpartitioned.toString(),
+          "ts > cast('2017-12-22 06:00:00+00:00' as timestamp) and " +
+              "ts < cast('2017-12-22 08:00:00+00:00' as timestamp)",
+          "id"));
+    }
+  }
+
+  private static GenericData.Record projectFlat(Schema projection, GenericData.Record record) {
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(projection, "test");
+    GenericData.Record result = new GenericData.Record(avroSchema);
+    List<Types.NestedField> fields = projection.asStruct().fields();
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+      result.put(i, record.get(field.name()));
+    }
+    return result;
+  }
+
+  public static void assertEqualsUnsafe(Types.StructType struct,
+      List<GenericData.Record> expected, List<UnsafeRow> actual) {
+    // TODO: match records by ID
+    int numRecords = Math.min(expected.size(), actual.size());
+    for (int i = 0; i < numRecords; i += 1) {
+      TestHelpers.assertEqualsUnsafe(struct, expected.get(i), actual.get(i));
+    }
+    Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
+  }
+
+  public static void assertEqualsSafe(Types.StructType struct,
+      List<GenericData.Record> expected, List<Row> actual) {
+    // TODO: match records by ID
+    int numRecords = Math.min(expected.size(), actual.size());
+    for (int i = 0; i < numRecords; i += 1) {
+      TestHelpers.assertEqualsSafe(struct, expected.get(i), actual.get(i));
+    }
+    Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
+  }
+
+  private List<GenericData.Record> expected(int... ordinals) {
+    List<GenericData.Record> expected = Lists.newArrayListWithExpectedSize(ordinals.length);
+    for (int ord : ordinals) {
+      expected.add(records.get(ord));
+    }
+    return expected;
+  }
+
+  private void pushFilters(DataSourceReader reader, Filter... filters) {
+    Assert.assertTrue(reader instanceof SupportsPushDownFilters);
+    SupportsPushDownFilters filterable = (SupportsPushDownFilters) reader;
+    filterable.pushFilters(filters);
+  }
+
+  private File buildPartitionedTable(String desc, PartitionSpec spec, String udf, String partitionColumn) {
+    File location = new File(parent, desc);
+    Table byId = TABLES.create(SCHEMA, spec, location.toString());
+
+    // Do not combine or split files because the tests expect a split per partition.
+    // A target split size of 2048 helps us achieve that.
+    byId.updateProperties().set("read.split.target-size", "2048").commit();
+
+    // copy the unpartitioned table into the partitioned table to produce the partitioned data
+    Dataset<Row> allRows = spark.read()
+        .format("iceberg")
+        .load(unpartitioned.toString());
+
+    allRows
+        .coalesce(1) // ensure only 1 file per partition is written
+        .withColumn("part", callUDF(udf, column(partitionColumn)))
+        .sortWithinPartitions("part")
+        .drop("part")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(byId.location());
+
+    return location;
+  }
+
+  private List<GenericData.Record> testRecords(org.apache.avro.Schema avroSchema) {
+    return Lists.newArrayList(
+        record(avroSchema, 0L, timestamp("2017-12-22T09:20:44.294658+00:00"), "junction"),
+        record(avroSchema, 1L, timestamp("2017-12-22T07:15:34.582910+00:00"), "alligator"),
+        record(avroSchema, 2L, timestamp("2017-12-22T06:02:09.243857+00:00"), "forrest"),
+        record(avroSchema, 3L, timestamp("2017-12-22T03:10:11.134509+00:00"), "clapping"),
+        record(avroSchema, 4L, timestamp("2017-12-22T00:34:00.184671+00:00"), "brush"),
+        record(avroSchema, 5L, timestamp("2017-12-21T22:20:08.935889+00:00"), "trap"),
+        record(avroSchema, 6L, timestamp("2017-12-21T21:55:30.589712+00:00"), "element"),
+        record(avroSchema, 7L, timestamp("2017-12-21T17:31:14.532797+00:00"), "limited"),
+        record(avroSchema, 8L, timestamp("2017-12-21T15:21:51.237521+00:00"), "global"),
+        record(avroSchema, 9L, timestamp("2017-12-21T15:02:15.230570+00:00"), "goldfish")
+    );
+  }
+
+  private static List<Row> read(String table, String expr) {
+    return read(table, expr, "*");
+  }
+
+  private static List<Row> read(String table, String expr, String select0, String... selectN) {
+    Dataset<Row> dataset = spark.read().format("iceberg").load(table).filter(expr)
+        .select(select0, selectN);
+    return dataset.collectAsList();
+  }
+
+  private static long timestamp(String timestamp) {
+    return Literal.of(timestamp).<Long>to(Types.TimestampType.withZone()).value();
+  }
+
+  private static GenericData.Record record(org.apache.avro.Schema schema, Object... values) {
+    GenericData.Record rec = new GenericData.Record(schema);
+    for (int i = 0; i < values.length; i += 1) {
+      rec.put(i, values[i]);
+    }
+    return rec;
+  }
+
+}


### PR DESCRIPTION
Co-authored-by: Xabriel J Collazo Mojica <xcollazo@adobe.com>


**Changes:**
- Added a new reader viz. V1VectorizedReader that internally short circuits to using the V1 codepath [1]  which does most of the setup and work to perform vectorization. it's exactly what Vanilla Spark's reader does underneath the DSV1 implementation.
- It builds an iterator which expects ColumnarBatches from the Objects returned by the resolving iterator.
- We re-organized and optimized code while building ReadTask instances which considerably improved task initiation and planning time.
- Setting `iceberg.read.enableV1VectorizedReader` to true enables this reader in IcebergSource.
- The V1Vectorized reader is an independent class with copied code in some methods as we didn't want to degrade perf due to inheritance/virtual method calls (we noticed degradation when we did try to re-use code). 
- I'v pushed this code to a separate branch [2] in case others want to give this a try. 



**The Numbers:**


Flat Data 10 files 10M rows each

```
Benchmark                                                                            Mode  Cnt   Score   Error  Units
IcebergSourceFlatParquetDataReadBenchmark.readFileSourceNonVectorized                  ss    5  63.631 ± 1.300   s/op
IcebergSourceFlatParquetDataReadBenchmark.readFileSourceVectorized                     ss    5  28.322 ± 2.400   s/op
IcebergSourceFlatParquetDataReadBenchmark.readIceberg                                  ss    5  65.862 ± 2.480   s/op
IcebergSourceFlatParquetDataReadBenchmark.readIcebergV1Vectorized10k                   ss    5  28.199 ± 1.255   s/op
IcebergSourceFlatParquetDataReadBenchmark.readIcebergV1Vectorized20k                   ss    5  29.822 ± 2.848   s/op
IcebergSourceFlatParquetDataReadBenchmark.readIcebergV1Vectorized5k                    ss    5  27.953 ± 0.949   s/op
```






Flat Data Projections 10 files 10M rows each

```
Benchmark                                                                            Mode  Cnt   Score   Error  Units
IcebergSourceFlatParquetDataReadBenchmark.readWithProjectionFileSourceNonVectorized    ss    5  11.307 ± 1.791   s/op
IcebergSourceFlatParquetDataReadBenchmark.readWithProjectionFileSourceVectorized       ss    5   3.480 ± 0.087   s/op
IcebergSourceFlatParquetDataReadBenchmark.readWithProjectionIceberg                    ss    5  11.057 ± 0.236   s/op
IcebergSourceFlatParquetDataReadBenchmark.readWithProjectionIcebergV1Vectorized10k     ss    5   3.953 ± 1.592   s/op
IcebergSourceFlatParquetDataReadBenchmark.readWithProjectionIcebergV1Vectorized20k     ss    5   3.619 ± 1.305   s/op
IcebergSourceFlatParquetDataReadBenchmark.readWithProjectionIcebergV1Vectorized5k      ss    5   4.109 ± 1.734   s/op
```


Filtered Data 500 files 10k rows each 

```
Benchmark                                                                          Mode  Cnt  Score   Error  Units
IcebergSourceFlatParquetDataFilterBenchmark.readWithFilterFileSourceNonVectorized    ss    5  2.139 ± 0.719   s/op
IcebergSourceFlatParquetDataFilterBenchmark.readWithFilterFileSourceVectorized       ss    5  2.213 ± 0.598   s/op
IcebergSourceFlatParquetDataFilterBenchmark.readWithFilterIcebergNonVectorized       ss    5  0.144 ± 0.029   s/op
IcebergSourceFlatParquetDataFilterBenchmark.readWithFilterIcebergV1Vectorized100k    ss    5  0.179 ± 0.019   s/op
IcebergSourceFlatParquetDataFilterBenchmark.readWithFilterIcebergV1Vectorized10k     ss    5  0.189 ± 0.046   s/op
IcebergSourceFlatParquetDataFilterBenchmark.readWithFilterIcebergV1Vectorized5k      ss    5  0.195 ± 0.137   s/op


```

**Perf Notes:**
- Iceberg V1 Vectorization's real gain (over current Iceberg impl) is in flat data scans. Notice how it's almost exactly same as vanilla spark vectorization.
- Projections work equally well. Although we see Nested column projections are still not performing as well as we need to be able to push nested column projections down to Iceberg.
- We saw a slight overhead with Iceberg V1 Vectorization over smaller workloads, but this goes away with larger data files.



Footnotes: 
[1] - https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala#L197
[2] - https://github.com/prodeezy/incubator-iceberg/tree/v1-vectorized-reader