### PR TITLE
[FollowUp]: Throw NotFoundException from IO methods when file does not exist 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ sdist/
 .coverage
 coverage.xml
 .pytest_cache/
-spark/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ sdist/
 .coverage
 coverage.xml
 .pytest_cache/
+spark/tmp/

--- a/api/src/main/java/org/apache/iceberg/Files.java
+++ b/api/src/main/java/org/apache/iceberg/Files.java
@@ -67,7 +67,7 @@ public class Files {
       try {
         return new PositionFileOutputStream(file, new RandomAccessFile(file, "rw"));
       } catch (FileNotFoundException e) {
-        throw new RuntimeIOException(e, "Failed to create file: %s", file);
+        throw new NotFoundException(e, "Failed to create file: %s", file);
       }
     }
 

--- a/api/src/main/java/org/apache/iceberg/Files.java
+++ b/api/src/main/java/org/apache/iceberg/Files.java
@@ -67,7 +67,7 @@ public class Files {
       try {
         return new PositionFileOutputStream(file, new RandomAccessFile(file, "rw"));
       } catch (FileNotFoundException e) {
-        throw new NotFoundException(e, "Failed to create file: %s", file);
+        throw new RuntimeIOException(e, "Failed to create file: %s", file);
       }
     }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -135,7 +135,7 @@ public class TestIcebergSourceHiveTables {
       });
     }
   }
-  
+
   @Test
   public synchronized void testHiveEntriesTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -135,7 +135,6 @@ public class TestIcebergSourceHiveTables {
       });
     }
   }
-
   
   @Test
   public synchronized void testHiveEntriesTable() throws Exception {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -136,6 +136,7 @@ public class TestIcebergSourceHiveTables {
     }
   }
 
+  
   @Test
   public synchronized void testHiveEntriesTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");


### PR DESCRIPTION
Follow up PR #454 Throw NotFoundException for `return new PositionFileOutputStream(file, new RandomAccessFile(file, "rw"));`

After gradle build, `spark/tmp` folder is created. add `spark/tmp` to .gitignore file.