### PR TITLE
Change method signature of ManifestReader::read (#459)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -173,7 +173,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
             } else {
               replacedManifests.add(manifest);
               try (ManifestReader reader =
-                     ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+                     ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
                 FilteredManifest filteredManifest = reader.select(Arrays.asList("*"));
                 filteredManifest.liveEntries().forEach(
                     entry -> appendEntry(entry, clusterByFunc.apply(entry.file()))

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -83,7 +83,9 @@ public class DataTableScan extends BaseTableScan {
     Iterable<CloseableIterable<FileScanTask>> readers = Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current()::spec);
+          ManifestReader reader = ManifestReader.read(
+              ops.io().newInputFile(manifest.path()),
+              ops.current().specsById());
           PartitionSpec spec = ops.current().spec(manifest.partitionSpecId());
           String schemaString = SchemaParser.toJson(spec.schema());
           String specString = PartitionSpecParser.toJson(spec);

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -83,7 +83,7 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   public FastAppend appendManifest(ManifestFile manifest) {
     // the manifest must be rewritten with this update's snapshot ID
     try (ManifestReader reader = ManifestReader.read(
-        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+        ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
       OutputFile newManifestPath = manifestPath(manifestCount.getAndIncrement());
       appendManifests.add(ManifestWriter.copyAppendManifest(reader, newManifestPath, snapshotId(), summaryBuilder));
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -165,7 +165,7 @@ class ManifestGroup {
         manifest -> {
           ManifestReader reader = ManifestReader.read(
               ops.io().newInputFile(manifest.path()),
-              ops.current()::spec);
+              ops.current().specsById());
 
           FilteredManifest filtered = reader
               .filterRows(dataFilter)

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -204,7 +204,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   protected void add(ManifestFile manifest) {
     // the manifest must be rewritten with this update's snapshot ID
     try (ManifestReader reader = ManifestReader.read(
-        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+        ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
       appendManifests.add(ManifestWriter.copyAppendManifest(
           reader, manifestPath(manifestCount.getAndIncrement()), snapshotId(), appendedManifestsSummary));
     } catch (IOException e) {
@@ -441,7 +441,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     }
 
     try (ManifestReader reader = ManifestReader.read(
-        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+        ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
 
       // this is reused to compare file paths with the delete set
       CharSequenceWrapper pathWrapper = CharSequenceWrapper.wrap("");
@@ -618,7 +618,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     try {
       for (ManifestFile manifest : bin) {
         try (ManifestReader reader = ManifestReader.read(
-            ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+            ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
           for (ManifestEntry entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {
               // suppress deletes from previous snapshots. only files deleted by this snapshot

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -273,7 +273,7 @@ class RemoveSnapshots implements ExpireSnapshots {
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
           try (ManifestReader reader = ManifestReader.read(
-              ops.io().newInputFile(manifest), ops.current()::spec)) {
+              ops.io().newInputFile(manifest), ops.current().specsById())) {
             for (ManifestEntry entry : reader.entries()) {
               // if the snapshot ID of the DELETE entry is no longer valid, the data can be deleted
               if (entry.status() == ManifestEntry.Status.DELETED &&
@@ -294,7 +294,7 @@ class RemoveSnapshots implements ExpireSnapshots {
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
           try (ManifestReader reader = ManifestReader.read(
-              ops.io().newInputFile(manifest), ops.current()::spec)) {
+              ops.io().newInputFile(manifest), ops.current().specsById())) {
             for (ManifestEntry entry : reader.entries()) {
               // delete any ADDED file from manifests that were reverted
               if (entry.status() == ManifestEntry.Status.ADDED) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -309,7 +309,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   private static ManifestFile addMetadata(TableOperations ops, ManifestFile manifest) {
     try (ManifestReader reader = ManifestReader.read(
-        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+        ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
       PartitionSummary stats = new PartitionSummary(ops.current().spec(manifest.partitionSpecId()));
       int addedFiles = 0;
       int existingFiles = 0;


### PR DESCRIPTION
This commit is part of the efforts to decouple TableMetadataParser from
TableOperations.

#459 