### PR TITLE
Add key_metadata to DataTableScan SCAN_COLUMNS

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -40,7 +40,7 @@ public class DataTableScan extends BaseTableScan {
 
   private static final List<String> SCAN_COLUMNS = ImmutableList.of(
       "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
-      "file_size_in_bytes", "record_count", "partition"
+      "file_size_in_bytes", "record_count", "partition", "key_metadata"
   );
   private static final List<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.<String>builder()
       .addAll(SCAN_COLUMNS)


### PR DESCRIPTION
This ensures the key_metadata field is populated when manifest files are read. Otherwise the EncryptionManager will receive an empty EncryptionKeyMetadata and decryption will be impossible.