### PR TITLE
WIP: Not throw exception if table is not found

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -78,7 +78,6 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
       currentMetadataLocation = null;
       version = -1;
       shouldRefresh = false;
-      throw e;
     }
     return current();
   }


### PR DESCRIPTION
The call stack from create table looks like the following

```at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:74)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreCatalog.createTable(BaseMetastoreCatalog.java:70)
	at org.apache.iceberg.catalog.Catalog.createTable(Catalog.java:84)
```

Now if the `doRefresh` throws a `NoSuchTableException` which it should when a new table does not exist yet, then the job would throw this exception and would crash.

On the other hand say `doRefresh` swallows the exception, then the call stack basically becomes a loop since `shouldRefresh` is not set to `false` and looks something like

```at com.stripe.mugatu.iceberg.custom_metastore.StripeTableOperations.doRefresh(StripeIcebergSource.scala:71)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:74)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:83)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:83)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:83)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:83)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:83)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:83)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:58)
	at org.apache.iceberg.BaseMetastoreCatalog.createTable(BaseMetastoreCatalog.java:70)
```

@rdblue @aokolnychyi thoughts?