### PR TITLE
Fix typo in the message for refreshing table metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -135,7 +135,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
                                              int numRetries) {
     // use null-safe equality check because new tables have a null metadata location
     if (!Objects.equal(currentMetadataLocation, newLocation)) {
-      LOG.info("Refreshing table metadata from new version: {}", newLocation);
+      LOG.info("Refreshing table metadata to new version: {}", newLocation);
 
       AtomicReference<TableMetadata> newMetadata = new AtomicReference<>();
       Tasks.foreach(newLocation)

--- a/python/iceberg/core/base_metastore_table_operations.py
+++ b/python/iceberg/core/base_metastore_table_operations.py
@@ -76,7 +76,7 @@ class BaseMetastoreTableOperations(TableOperations):
 
     def refresh_from_metadata_location(self, new_location, num_retries=20):
         if not self.current_metadata_location == new_location:
-            _logger.info("Refreshing table metadata from new version: %s" % new_location)
+            _logger.info("Refreshing table metadata to new version: %s" % new_location)
             self.retryable_refresh(new_location)
 
         self.should_refresh = False


### PR DESCRIPTION
@rdblue , I think we need to change from "from new version" to "to new version". Please correct me if I get a wrong understanding here.