### PR TITLE
Fix testImportAsHiveTable when create an unpartition table the spec mast unpartitioned

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -171,7 +171,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
     Table table = catalog.createTable(
             org.apache.iceberg.catalog.TableIdentifier.of(DB_NAME, "test_unpartitioned_table"),
             SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
-            SparkSchemaUtil.specForTable(spark, qualifiedTableName));
+            org.apache.iceberg.PartitionSpec.unpartitioned());
     SparkTableUtil.importSparkTable(source, "/tmp", table);
     long count1 = spark.read().format("iceberg").load(DB_NAME + ".test_unpartitioned_table").count();
     Assert.assertEquals("three values ", 3, count1);


### PR DESCRIPTION
@rdblue hi ,   When running  ```TestSparkTableUtil#testImportAsHiveTable```, the column 
 'data' in the table ```test_unpartitioned_table```   is null.  I think the spec should be set  to 'unpartitioned'.

without the fix the table is like that:
```
 spark.read().format("iceberg").load(DB_NAME + ".test_unpartitioned_table").show();
+---+----+
| id|data|
+---+----+
|  3|null|
|  2|null|
|  1|null|
+---+----+
```