### PR TITLE
Fix testImportAsHiveTable when create a unpartition table the spec  should be to unpartitioned

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -170,8 +170,8 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
     TableIdentifier source = new TableIdentifier("unpartitioned_table");
     Table table = catalog.createTable(
             org.apache.iceberg.catalog.TableIdentifier.of(DB_NAME, "test_unpartitioned_table"),
-            SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
-            SparkSchemaUtil.specForTable(spark, qualifiedTableName));
+            SparkSchemaUtil.schemaForTable(spark, "unpartitioned_table"),
+            SparkSchemaUtil.specForTable(spark, "unpartitioned_table"));
     SparkTableUtil.importSparkTable(source, "/tmp", table);
     long count1 = spark.read().format("iceberg").load(DB_NAME + ".test_unpartitioned_table").count();
     Assert.assertEquals("three values ", 3, count1);
@@ -181,8 +181,8 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
     source = new TableIdentifier("partitioned_table");
     table = catalog.createTable(
             org.apache.iceberg.catalog.TableIdentifier.of(DB_NAME, "test_partitioned_table"),
-            SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
-            SparkSchemaUtil.specForTable(spark, qualifiedTableName));
+            SparkSchemaUtil.schemaForTable(spark, "partitioned_table"),
+            SparkSchemaUtil.specForTable(spark, "partitioned_table"));
 
     SparkTableUtil.importSparkTable(source, "/tmp", table);
     long count2 = spark.read().format("iceberg").load(DB_NAME + ".test_partitioned_table").count();


### PR DESCRIPTION
When running ```TestSparkTableUtil#testImportAsHiveTable```, the column
```data``` in the table ```test_unpartitioned_table``` is null. I think the spec should be set to ```unpartitioned```.

without the fix the table is like that:

```
 spark.read().format("iceberg").load(DB_NAME + ".test_unpartitioned_table").show();
+---+----+
| id|data|
+---+----+
|  3|null|
|  2|null|
|  1|null|
+---+----+
```