### PR TITLE
Optimize StreamingDelete

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFiles.java
@@ -51,7 +51,10 @@ public interface DeleteFiles extends SnapshotUpdate<DeleteFiles> {
    * @param file a DataFile to remove from the table
    * @return this for method chaining
    */
-  DeleteFiles deleteFile(DataFile file);
+  default DeleteFiles deleteFile(DataFile file) {
+    deleteFile(file.path());
+    return this;
+  }
 
   /**
    * Delete files that match an {@link Expression} on data rows from the table.

--- a/api/src/main/java/org/apache/iceberg/DeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFiles.java
@@ -51,10 +51,7 @@ public interface DeleteFiles extends SnapshotUpdate<DeleteFiles> {
    * @param file a DataFile to remove from the table
    * @return this for method chaining
    */
-  default DeleteFiles deleteFile(DataFile file) {
-    deleteFile(file.path());
-    return this;
-  }
+  DeleteFiles deleteFile(DataFile file);
 
   /**
    * Delete files that match an {@link Expression} on data rows from the table.

--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -49,6 +49,12 @@ class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements De
   }
 
   @Override
+  public StreamingDelete deleteFile(DataFile file) {
+    delete(file);
+    return this;
+  }
+
+  @Override
   public StreamingDelete deleteFromRowFilter(Expression expr) {
     deleteByRowFilter(expr);
     return this;


### PR DESCRIPTION
Implement `delete(Datafile)` in `StreamingDelete`, to make use of optimized deletes from #387. 

This PR resolves #409.