### PR TITLE
Support retaining last N snapshots

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -56,8 +56,14 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
   ExpireSnapshots expireOlderThan(long timestampMillis);
 
   /**
-   * Retains at least last N snapshots and expires all snapshots older than the given timestamp
-   * in {@link #expireOlderThan(long)}.
+   * Retains the most recent ancestors of the current snapshot.
+   * <p>
+   * If a snapshot would be expired becuase it is older than the expiration timestamp, but is one of
+   * the {@code numSnapshot} most recent ancestors of the current state, it will be retained. This
+   * will not cause snapshots explicitly identified by id from expiring.
+   * <p>
+   * This may keep more than {@code numSnapshot} ancestors if snapshots are added concurrently. This
+   * may keep less than {@numSnapshot} ancestors if the current table state does not have that many.
    *
    * @param numSnapshots the number of snapshots to retain
    * @return this for method chaining

--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -56,6 +56,14 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
   ExpireSnapshots expireOlderThan(long timestampMillis);
 
   /**
+   * Retains last N snapshots and expires all other older snapshots.
+   *
+   * @param numSnapshots int number of snapshots to retain
+   * @return this for method chaining
+   */
+  ExpireSnapshots retainLast(int numSnapshots);
+
+  /**
    * Passes an alternative delete implementation that will be used for manifests and data files.
    * <p>
    * Manifest files that are no longer used by valid snapshots will be deleted. Data files that were

--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -56,9 +56,10 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
   ExpireSnapshots expireOlderThan(long timestampMillis);
 
   /**
-   * Retains last N snapshots and expires all other older snapshots.
+   * Retains at least last N snapshots and expires all snapshots older than the given timestamp
+   * in {@link #expireOlderThan(long)}.
    *
-   * @param numSnapshots int number of snapshots to retain
+   * @param numSnapshots the number of snapshots to retain
    * @return this for method chaining
    */
   ExpireSnapshots retainLast(int numSnapshots);

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -324,6 +324,9 @@ class RemoveSnapshots implements ExpireSnapshots {
   }
 
   private Snapshot findNthSnapshot(int snapshotIndex) {
+    if (base.snapshots().size() < snapshotIndex) {
+      return null;
+    }
     Snapshot lastSnapshot = base.currentSnapshot();
     int snapshotCount = 1;
     while (lastSnapshot != null) {

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRemoveSnapshots extends TableTestBase {
+
+  @Test
+  public void testRetainNAvailableSnapshots() {
+    long t0 = System.currentTimeMillis();
+    table.newAppend()
+        .appendFile(FILE_A) // data_bucket=0
+        .commit();
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+    long t1 = System.currentTimeMillis();
+    while (t1 == t0) {
+      t1 = System.currentTimeMillis();
+    }
+
+    table.newAppend()
+        .appendFile(FILE_B) // data_bucket=1
+        .commit();
+
+    long t2 = System.currentTimeMillis();
+    while (t2 == t1) {
+      t2 = System.currentTimeMillis();
+    }
+
+    table.newAppend()
+        .appendFile(FILE_C) // data_bucket=2
+        .commit();
+
+    long t3 = System.currentTimeMillis();
+    while (t3 == t2) {
+      t3 = System.currentTimeMillis();
+    }
+
+    // Retain last 2 snapshots
+    table.expireSnapshots()
+        .retainLast(2)
+        .commit();
+
+    Assert.assertEquals("Should have one snapshot",
+        2, Lists.newArrayList(table.snapshots()).size());
+    Assert.assertEquals("First snapshot should not present",
+        null, table.snapshot(firstSnapshotId));
+
+  }
+
+  @Test
+  public void testRetainNUnAvailableSnapshots() {
+    long t0 = System.currentTimeMillis();
+    table.newAppend()
+        .appendFile(FILE_A) // data_bucket=0
+        .appendFile(FILE_B) // data_bucket=1
+        .commit();
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+
+    long t1 = System.currentTimeMillis();
+    while (t1 == t0) {
+      t1 = System.currentTimeMillis();
+    }
+
+    table.newAppend()
+        .appendFile(FILE_C) // data_bucket=2
+        .commit();
+
+    long t2 = System.currentTimeMillis();
+    while (t2 == t1) {
+      t2 = System.currentTimeMillis();
+    }
+
+    // Retain last 3 snapshots
+    table.expireSnapshots()
+        .retainLast(3)
+        .commit();
+
+    Assert.assertEquals("Should have two snapshots",
+        2, Lists.newArrayList(table.snapshots()).size());
+    Assert.assertEquals("First snapshot should still present",
+        firstSnapshotId, table.snapshot(firstSnapshotId).snapshotId());
+  }
+
+  @Test
+  public void testRetainZeroSnapshots() {
+    long t0 = System.currentTimeMillis();
+    table.newAppend()
+        .appendFile(FILE_A) // data_bucket=0
+        .appendFile(FILE_B) // data_bucket=1
+        .commit();
+
+    long t1 = System.currentTimeMillis();
+    while (t1 == t0) {
+      t1 = System.currentTimeMillis();
+    }
+
+    table.newAppend()
+        .appendFile(FILE_C) // data_bucket=2
+        .commit();
+
+    long t2 = System.currentTimeMillis();
+    while (t2 == t1) {
+      t2 = System.currentTimeMillis();
+    }
+
+    AssertHelpers.assertThrows("Should fail retain 0 snapshots " +
+            "because number of snapshots to retain cannot be zero",
+        IllegalArgumentException.class,
+        "Number of snapshots to retain must be at least 1, cannot be: 0",
+        () -> table.expireSnapshots().retainLast(0).commit());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -283,7 +283,7 @@ public class TestRemoveSnapshots extends TableTestBase {
   }
 
   @Test
-  public void table.currentSnapshot().timestampMillis()() {
+  public void testRetainLastMultipleCalls() {
     long t0 = System.currentTimeMillis();
     table.newAppend()
         .appendFile(FILE_A) // data_bucket=0


### PR DESCRIPTION
This PR adds `retainLast` method to `ExpireSnapshots`.

- find nth snapshot if it's available.
- if nth snapshot is not null, add nth snapshot's `timestampMillis` to `expireOlderThan`.