### PR TITLE
Adding partition transform builder methods to set custom target field names 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -341,7 +341,7 @@ public class PartitionSpec implements Serializable {
         // for identity transform case we allow  conflicts between partition and schema field name as
         //   long as they are sourced from the same schema field
         Preconditions.checkArgument(schemaField == null || schemaField.fieldId() == identitySourceColumnId,
-            "Cannot create identity partition not sourced from same field in schema: %s", name);
+            "Cannot create identity partition sourced from different field in schema: %s", name);
       } else {
         // for all other transforms we don't allow conflicts between partition name and schema field name
         Preconditions.checkArgument(schemaField == null,

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -331,7 +331,11 @@ public class PartitionSpec implements Serializable {
       this.schema = schema;
     }
 
-    private void checkAndAddPartitionName(String name) {
+    private void checkAndAddPartitionName(String name, String transform) {
+      if (!transform.equalsIgnoreCase("identity")) {
+        Preconditions.checkArgument(schema.findField(name) == null,
+            "Cannot create partition from name that exists in schema: %s", name);
+      }
       Preconditions.checkArgument(name != null && !name.isEmpty(),
           "Cannot use empty or null partition name: %s", name);
       Preconditions.checkArgument(!partitionNames.contains(name),
@@ -357,9 +361,8 @@ public class PartitionSpec implements Serializable {
       return sourceColumn;
     }
 
-
-    public Builder identity(String sourceName, String targetName) {
-      checkAndAddPartitionName(targetName);
+    Builder identity(String sourceName, String targetName) {
+      checkAndAddPartitionName(targetName, "identity");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.identity(sourceColumn.type())));
@@ -371,8 +374,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder year(String sourceName, String targetName) {
-
-      checkAndAddPartitionName(targetName);
+      checkAndAddPartitionName(targetName, "year");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.year(sourceColumn.type()));
@@ -386,7 +388,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder month(String sourceName, String targetName) {
-      checkAndAddPartitionName(targetName);
+      checkAndAddPartitionName(targetName, "month");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.month(sourceColumn.type()));
@@ -400,7 +402,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder day(String sourceName, String targetName) {
-      checkAndAddPartitionName(targetName);
+      checkAndAddPartitionName(targetName, "day");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.day(sourceColumn.type()));
@@ -414,7 +416,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder hour(String sourceName, String targetName) {
-      checkAndAddPartitionName(targetName);
+      checkAndAddPartitionName(targetName, "hour");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.hour(sourceColumn.type()));
@@ -428,7 +430,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder bucket(String sourceName, int numBuckets, String targetName) {
-      checkAndAddPartitionName(targetName);
+      checkAndAddPartitionName(targetName, "bucket");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.bucket(sourceColumn.type(), numBuckets)));
@@ -440,7 +442,7 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder truncate(String sourceName, int width, String targetName) {
-      checkAndAddPartitionName(targetName);
+      checkAndAddPartitionName(targetName, "truncate");
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(new PartitionField(
           sourceColumn.fieldId(), targetName, Transforms.truncate(sourceColumn.type(), width)));
@@ -452,7 +454,7 @@ public class PartitionSpec implements Serializable {
     }
 
     Builder add(int sourceId, String name, String transform) {
-      checkAndAddPartitionName(name);
+      checkAndAddPartitionName(name, transform);
       Types.NestedField column = schema.findField(sourceId);
       Preconditions.checkNotNull(column, "Cannot find source column: %d", sourceId);
       fields.add(new PartitionField(sourceId, name, Transforms.fromString(column.type(), transform)));

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -357,74 +357,98 @@ public class PartitionSpec implements Serializable {
       return sourceColumn;
     }
 
-    public Builder identity(String sourceName) {
-      checkAndAddPartitionName(sourceName);
+
+    public Builder identity(String sourceName, String targetName) {
+      checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(new PartitionField(
-          sourceColumn.fieldId(), sourceName, Transforms.identity(sourceColumn.type())));
+          sourceColumn.fieldId(), targetName, Transforms.identity(sourceColumn.type())));
+      return this;
+    }
+
+    public Builder identity(String sourceName) {
+      return identity(sourceName, sourceName);
+    }
+
+    public Builder year(String sourceName, String targetName) {
+
+      checkAndAddPartitionName(targetName);
+      Types.NestedField sourceColumn = findSourceColumn(sourceName);
+      PartitionField field = new PartitionField(
+          sourceColumn.fieldId(), targetName, Transforms.year(sourceColumn.type()));
+      checkForRedundantPartitions(field);
+      fields.add(field);
       return this;
     }
 
     public Builder year(String sourceName) {
-      String name = sourceName + "_year";
-      checkAndAddPartitionName(name);
+      return year(sourceName, sourceName + "_year");
+    }
+
+    public Builder month(String sourceName, String targetName) {
+      checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
-          sourceColumn.fieldId(), name, Transforms.year(sourceColumn.type()));
+          sourceColumn.fieldId(), targetName, Transforms.month(sourceColumn.type()));
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
     }
 
     public Builder month(String sourceName) {
-      String name = sourceName + "_month";
-      checkAndAddPartitionName(name);
+      return month(sourceName, sourceName + "_month");
+    }
+
+    public Builder day(String sourceName, String targetName) {
+      checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
-          sourceColumn.fieldId(), name, Transforms.month(sourceColumn.type()));
+          sourceColumn.fieldId(), targetName, Transforms.day(sourceColumn.type()));
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
     }
 
     public Builder day(String sourceName) {
-      String name = sourceName + "_day";
-      checkAndAddPartitionName(name);
+      return day(sourceName, sourceName + "_day");
+    }
+
+    public Builder hour(String sourceName, String targetName) {
+      checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field = new PartitionField(
-          sourceColumn.fieldId(), name, Transforms.day(sourceColumn.type()));
+          sourceColumn.fieldId(), targetName, Transforms.hour(sourceColumn.type()));
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
     }
 
     public Builder hour(String sourceName) {
-      String name = sourceName + "_hour";
-      checkAndAddPartitionName(name);
+      return hour(sourceName, sourceName + "_hour");
+    }
+
+    public Builder bucket(String sourceName, int numBuckets, String targetName) {
+      checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
-      PartitionField field = new PartitionField(
-          sourceColumn.fieldId(), name, Transforms.hour(sourceColumn.type()));
-      checkForRedundantPartitions(field);
-      fields.add(field);
+      fields.add(new PartitionField(
+          sourceColumn.fieldId(), targetName, Transforms.bucket(sourceColumn.type(), numBuckets)));
       return this;
     }
 
     public Builder bucket(String sourceName, int numBuckets) {
-      String name = sourceName + "_bucket";
-      checkAndAddPartitionName(name);
+      return bucket(sourceName, numBuckets, sourceName + "_bucket");
+    }
+
+    public Builder truncate(String sourceName, int width, String targetName) {
+      checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(new PartitionField(
-          sourceColumn.fieldId(), name, Transforms.bucket(sourceColumn.type(), numBuckets)));
+          sourceColumn.fieldId(), targetName, Transforms.truncate(sourceColumn.type(), width)));
       return this;
     }
 
     public Builder truncate(String sourceName, int width) {
-      String name = sourceName + "_trunc";
-      checkAndAddPartitionName(name);
-      Types.NestedField sourceColumn = findSourceColumn(sourceName);
-      fields.add(new PartitionField(
-          sourceColumn.fieldId(), name, Transforms.truncate(sourceColumn.type(), width)));
-      return this;
+      return truncate(sourceName, width, sourceName + "_trunc");
     }
 
     Builder add(int sourceId, String name, String transform) {

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -175,10 +175,9 @@ public class TestPartitionSpecValidation {
         "Cannot create partition from name that exists in schema: another_ts",
         () -> PartitionSpec.builderFor(SCHEMA).bucket("ts", 4, "another_ts"));
 
-    // allows for identity
     AssertHelpers.assertThrows("Should not allow target column name sourced from a different column",
         IllegalArgumentException.class,
-        "Cannot create identity partition not sourced from same field in schema: another_ts",
+        "Cannot create identity partition sourced from different field in schema: another_ts",
         () -> PartitionSpec.builderFor(SCHEMA).identity("ts", "another_ts"));
   }
 

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestPartitionSpecValidation {
@@ -29,7 +30,8 @@ public class TestPartitionSpecValidation {
       NestedField.required(2, "ts", Types.TimestampType.withZone()),
       NestedField.required(3, "another_ts", Types.TimestampType.withZone()),
       NestedField.required(4, "d", Types.TimestampType.withZone()),
-      NestedField.required(5, "another_d", Types.TimestampType.withZone())
+      NestedField.required(5, "another_d", Types.TimestampType.withZone()),
+      NestedField.required(6, "s", Types.StringType.get())
   );
 
   @Test
@@ -119,6 +121,27 @@ public class TestPartitionSpecValidation {
     PartitionSpec.builderFor(SCHEMA).day("d").day("another_d").build();
     PartitionSpec.builderFor(SCHEMA).day("d").hour("another_d").build();
     PartitionSpec.builderFor(SCHEMA).hour("d").hour("another_d").build();
+  }
+
+
+  @Test
+  public void testSettingPartitionTransformsWithCutomTargetNames() {
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).identity("ts", "timestamp")
+        .build().fields().get(0).name(), "timestamp");
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).year("ts", "custom_year")
+        .build().fields().get(0).name(), "custom_year");
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).month("ts", "custom_month")
+        .build().fields().get(0).name(), "custom_month");
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).day("ts", "custom_day")
+        .build().fields().get(0).name(), "custom_day");
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).hour("ts", "custom_hour")
+        .build().fields().get(0).name(), "custom_hour");
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA)
+        .bucket("ts", 4, "custom_bucket")
+        .build().fields().get(0).name(), "custom_bucket");
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA)
+        .truncate("s", 1, "custom_truncate")
+        .build().fields().get(0).name(), "custom_truncate");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -125,7 +125,7 @@ public class TestPartitionSpecValidation {
 
 
   @Test
-  public void testSettingPartitionTransformsWithCutomTargetNames() {
+  public void testSettingPartitionTransformsWithCustomTargetNames() {
     Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).identity("ts", "timestamp")
         .build().fields().get(0).name(), "timestamp");
     Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).year("ts", "custom_year")
@@ -142,6 +142,45 @@ public class TestPartitionSpecValidation {
     Assert.assertEquals(PartitionSpec.builderFor(SCHEMA)
         .truncate("s", 1, "custom_truncate")
         .build().fields().get(0).name(), "custom_truncate");
+  }
+
+  @Test
+  public void testSettingPartitionTransformsWithCustomTargetNamesThatAlreadyExist() {
+
+    AssertHelpers.assertThrows("Should not allow target column name that exists in schema",
+        IllegalArgumentException.class,
+        "Cannot create partition from name that exists in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).year("ts", "another_ts"));
+
+    AssertHelpers.assertThrows("Should not allow target column name that exists in schema",
+        IllegalArgumentException.class,
+        "Cannot create partition from name that exists in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).month("ts", "another_ts"));
+
+    AssertHelpers.assertThrows("Should not allow target column name that exists in schema",
+        IllegalArgumentException.class,
+        "Cannot create partition from name that exists in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).day("ts", "another_ts"));
+
+    AssertHelpers.assertThrows("Should not allow target column name that exists in schema",
+        IllegalArgumentException.class,
+        "Cannot create partition from name that exists in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).hour("ts", "another_ts"));
+
+    AssertHelpers.assertThrows("Should not allow target column name that exists in schema",
+        IllegalArgumentException.class,
+        "Cannot create partition from name that exists in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).truncate("ts", 2, "another_ts"));
+
+    AssertHelpers.assertThrows("Should not allow target column name that exists in schema",
+        IllegalArgumentException.class,
+        "Cannot create partition from name that exists in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).bucket("ts", 4, "another_ts"));
+
+    // allows for identity
+    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).identity("ts", "another_ts")
+            .build().fields().get(0).name(),
+        "another_ts");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -126,8 +126,6 @@ public class TestPartitionSpecValidation {
 
   @Test
   public void testSettingPartitionTransformsWithCustomTargetNames() {
-    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).identity("ts", "timestamp")
-        .build().fields().get(0).name(), "timestamp");
     Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).year("ts", "custom_year")
         .build().fields().get(0).name(), "custom_year");
     Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).month("ts", "custom_month")
@@ -178,9 +176,10 @@ public class TestPartitionSpecValidation {
         () -> PartitionSpec.builderFor(SCHEMA).bucket("ts", 4, "another_ts"));
 
     // allows for identity
-    Assert.assertEquals(PartitionSpec.builderFor(SCHEMA).identity("ts", "another_ts")
-            .build().fields().get(0).name(),
-        "another_ts");
+    AssertHelpers.assertThrows("Should not allow target column name sourced from a different column",
+        IllegalArgumentException.class,
+        "Cannot create identity partition not sourced from same field in schema: another_ts",
+        () -> PartitionSpec.builderFor(SCHEMA).identity("ts", "another_ts"));
   }
 
   @Test


### PR DESCRIPTION
https://github.com/apache/incubator-iceberg/issues/495 Reports as issue where we currently don't have a way to set custom names when transforming partition fields. This ability went away with changes in https://github.com/apache/incubator-iceberg/pull/411/files.  Sample usecase is doing day(timestamp) needs to be set to something custom like c_date.

Sample usage:
```
PartitionSpec.builderFor(SCHEMA)
        .year("ts", "c_date_year")
        .month("ts", "c_date_month")
        .day("ts", "c_date_day")
        .build()

```