### PR TITLE
Fix snapshot summary data for appended manifests.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -266,10 +266,10 @@ public class ScanSummary {
       return dataTimestampMillis;
     }
 
-    PartitionMetrics updateFromCounts(int fileCount, long recordCount, long filesSize,
+    PartitionMetrics updateFromCounts(int numFiles, long filesRecordCount, long filesSize,
                                       Long timestampMillis) {
-      this.fileCount += fileCount;
-      this.recordCount += recordCount;
+      this.fileCount += numFiles;
+      this.recordCount += filesRecordCount;
       this.totalSize += filesSize;
       if (timestampMillis != null && (dataTimestampMillis == null || dataTimestampMillis < timestampMillis)) {
         this.dataTimestampMillis = timestampMillis;

--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -266,6 +266,17 @@ public class ScanSummary {
       return dataTimestampMillis;
     }
 
+    PartitionMetrics updateFromCounts(int fileCount, long recordCount, long filesSize,
+                                      Long timestampMillis) {
+      this.fileCount += fileCount;
+      this.recordCount += recordCount;
+      this.totalSize += filesSize;
+      if (timestampMillis != null && (dataTimestampMillis == null || dataTimestampMillis < timestampMillis)) {
+        this.dataTimestampMillis = timestampMillis;
+      }
+      return this;
+    }
+
     private PartitionMetrics updateFromFile(DataFile file, Long timestampMillis) {
       this.fileCount += 1;
       this.recordCount += file.recordCount();

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -366,16 +366,18 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         long newTotal = Long.parseLong(totalStr);
 
         String addedStr = currentSummary.get(addedProperty);
-        if (addedStr != null) {
+        if (newTotal > 0 && addedStr != null) {
           newTotal += Long.parseLong(addedStr);
         }
 
         String deletedStr = currentSummary.get(deletedProperty);
-        if (deletedStr != null) {
+        if (newTotal > 0 && deletedStr != null) {
           newTotal -= Long.parseLong(deletedStr);
         }
 
-        summaryBuilder.put(totalProperty, String.valueOf(newTotal));
+        if (newTotal > 0) {
+          summaryBuilder.put(totalProperty, String.valueOf(newTotal));
+        }
 
       } catch (NumberFormatException e) {
         // ignore and do not add total

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -366,16 +366,16 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         long newTotal = Long.parseLong(totalStr);
 
         String addedStr = currentSummary.get(addedProperty);
-        if (newTotal > 0 && addedStr != null) {
+        if (newTotal >= 0 && addedStr != null) {
           newTotal += Long.parseLong(addedStr);
         }
 
         String deletedStr = currentSummary.get(deletedProperty);
-        if (newTotal > 0 && deletedStr != null) {
+        if (newTotal >= 0 && deletedStr != null) {
           newTotal -= Long.parseLong(deletedStr);
         }
 
-        if (newTotal > 0) {
+        if (newTotal >= 0) {
           summaryBuilder.put(totalProperty, String.valueOf(newTotal));
         }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -81,6 +81,16 @@ public class SnapshotSummary {
       properties.put(property, value);
     }
 
+    public void merge(SnapshotSummary.Builder builder) {
+      this.changedPartitions.addAll(builder.changedPartitions);
+      this.addedFiles += builder.addedFiles;
+      this.deletedFiles += builder.deletedFiles;
+      this.deletedDuplicateFiles += builder.deletedDuplicateFiles;
+      this.addedRecords += builder.addedRecords;
+      this.deletedRecords += builder.deletedRecords;
+      this.properties.putAll(builder.properties);
+    }
+
     public Map<String, String> build() {
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -59,6 +59,10 @@ public class TestFastAppend extends TableTestBase {
         .apply();
 
     validateSnapshot(base.currentSnapshot(), pending, FILE_A, FILE_B);
+
+    // validate that the metadata summary is correct when using appendManifest
+    Assert.assertEquals("Summary metadata should include 2 added files",
+        "2", pending.summary().get("added-data-files"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -65,6 +65,10 @@ public class TestMergeAppend extends TableTestBase {
         .apply();
 
     validateSnapshot(base.currentSnapshot(), pending, FILE_A, FILE_B);
+
+    // validate that the metadata summary is correct when using appendManifest
+    Assert.assertEquals("Summary metadata should include 2 added files",
+        "2", pending.summary().get("added-data-files"));
   }
 
   @Test


### PR DESCRIPTION
When appending manifests, stats were accumulated as manifests were rewritten. But, stats are cleared at the start of apply to ensure that stats are correct each time the commit retries, which discarded the stats for rewritten manifests that are only rewritten once.

This adds a SnapshotSummary builder for the appended manifests that is merged into the final summary in each attempt.

This will also discard negative totals in snapshot summaries caused by appended manifests adding 0 files.