### PR TITLE
Expose partition spec info

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -59,6 +59,13 @@ public interface Table {
   PartitionSpec spec();
 
   /**
+   * Return a map of {@link PartitionSpec partition specs} for this table.
+   *
+   * @return this table's partition specs map
+   */
+  Map<Integer, PartitionSpec> specs();
+
+  /**
    * Return a map of string properties for this table.
    *
    * @return this table's properties map

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -27,6 +27,8 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
 abstract class BaseMetadataTable implements Table {
+  private PartitionSpec spec = PartitionSpec.unpartitioned();
+
   abstract Table table();
   abstract String metadataTableName();
 
@@ -52,7 +54,12 @@ abstract class BaseMetadataTable implements Table {
 
   @Override
   public PartitionSpec spec() {
-    return PartitionSpec.unpartitioned();
+    return spec;
+  }
+
+  @Override
+  public Map<Integer, PartitionSpec> specs() {
+    return ImmutableMap.of(spec.specId(), spec);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -65,6 +65,11 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public Map<Integer, PartitionSpec> specs() {
+    return ops.current().specsById();
+  }
+
+  @Override
   public Map<String, String> properties() {
     return ops.current().properties();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -491,6 +491,11 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public Map<Integer, PartitionSpec> specs() {
+      return current.specsById();
+    }
+
+    @Override
     public Map<String, String> properties() {
       return current.properties();
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -221,6 +221,10 @@ public class TableMetadata {
     return specs;
   }
 
+  public Map<Integer, PartitionSpec> specsById() {
+    return specsById;
+  }
+
   public int defaultSpecId() {
     return defaultSpecId;
   }

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import org.apache.iceberg.types.Types;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestPartitionSpecInfo {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private final Schema schema = new Schema(
+      required(1, "id", Types.IntegerType.get()),
+      required(2, "data", Types.StringType.get()));
+  private File tableDir = null;
+
+  @Before
+  public void setupTableDir() throws IOException {
+    this.tableDir = temp.newFolder();
+  }
+
+  @After
+  public void cleanupTables() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testSpecInfoUnpartitionedTable() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec);
+
+    Assert.assertEquals(spec, table.spec());
+    Assert.assertEquals(ImmutableMap.of(spec.specId(), spec), table.specs());
+    Assert.assertNull(table.specs().get(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testSpecInfoPartitionedTable() {
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("data").build();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec);
+
+    Assert.assertEquals(spec, table.spec());
+    Assert.assertEquals(ImmutableMap.of(spec.specId(), spec), table.specs());
+    Assert.assertNull(table.specs().get(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testSpecInfoPartitionSpecEvolution() {
+    PartitionSpec spec = PartitionSpec.builderFor(schema)
+        .bucket("data", 4)
+        .build();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", schema, spec);
+
+    Assert.assertEquals(spec, table.spec());
+
+    TableMetadata base = TestTables.readMetadata("test");
+    PartitionSpec newSpec = PartitionSpec.builderFor(table.schema())
+        .bucket("data", 10)
+        .withSpecId(1)
+        .build();
+    table.ops().commit(base, base.updatePartitionSpec(newSpec));
+
+    Assert.assertEquals(newSpec, table.spec());
+    Assert.assertEquals(newSpec, table.specs().get(newSpec.specId()));
+    Assert.assertEquals(spec, table.specs().get(spec.specId()));
+    Assert.assertEquals(ImmutableMap.of(spec.specId(), spec, newSpec.specId(), newSpec), table.specs());
+    Assert.assertNull(table.specs().get(Integer.MAX_VALUE));
+  }
+}


### PR DESCRIPTION
This PR exposes partition spec info from the `Table` API so that utilities can make use of that. For example, we are using this to build a `specLookup` and pass it to `ManifestWriter`.

As an alternative, utilities can cast `Table` to `HasTableOperations` and get current metadata from there. That seems to be more involved and I am not sure there is any harm exposing all partition specs from the `Table` API.

Open to considering other options.