### PR TITLE
Extend RewriteManifests with a way to add/delete manifests

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteManifests.java
@@ -29,6 +29,10 @@ import java.util.function.Predicate;
  * described only by the manifest files that were added, and commits that snapshot as the
  * current.
  * <p>
+ * This API can be used to rewrite matching manifests according to a clustering function as well as
+ * to replace specific manifests. Manifests that are deleted or added directly are ignored during
+ * the rewrite process. The set of active files in replaced manifests must be the same as in new manifests.
+ * <p>
  * When committing, these changes will be applied to the latest table snapshot. Commit conflicts
  * will be resolved by applying the changes to the new latest snapshot and reattempting the commit.
  */
@@ -37,7 +41,8 @@ public interface RewriteManifests extends SnapshotUpdate<RewriteManifests> {
    * Groups an existing {@link DataFile} by a cluster key produced by a function. The cluster key
    * will determine which data file will be associated with a particular manifest. All data files
    * with the same cluster key will be written to the same manifest (unless the file is large and
-   * split into multiple files).
+   * split into multiple files). Manifests deleted via {@link #deleteManifest(ManifestFile)} or
+   * added via {@link #addManifest(ManifestFile)} are ignored during the rewrite process.
    *
    * @param func Function used to cluster data files to manifests.
    * @return this for method chaining
@@ -54,4 +59,21 @@ public interface RewriteManifests extends SnapshotUpdate<RewriteManifests> {
    * @return this for method chaining
    */
   RewriteManifests rewriteIf(Predicate<ManifestFile> predicate);
+
+  /**
+   * Deletes a {@link ManifestFile manifest file} from the table.
+   *
+   * @param manifest a manifest to delete
+   * @return this for method chaining
+   */
+  RewriteManifests deleteManifest(ManifestFile manifest);
+
+  /**
+   * Adds a {@link ManifestFile manifest file} to the table. The added manifest cannot contain new
+   * or deleted files.
+   *
+   * @param manifest a manifest to add
+   * @return this for method chaining
+   */
+  RewriteManifests addManifest(ManifestFile manifest);
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -20,6 +20,8 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,7 +36,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 
@@ -43,27 +48,33 @@ import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFA
 
 
 public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> implements RewriteManifests {
+  private static final String KEPT_MANIFESTS_COUNT = "manifests-kept";
+  private static final String CREATED_MANIFESTS_COUNT = "manifests-created";
+  private static final String REPLACED_MANIFESTS_COUNT = "manifests-replaced";
+  private static final String PROCESSED_ENTRY_COUNT = "entries-processed";
+
+  private static final Set<ManifestEntry.Status> ALLOWED_ENTRY_STATUSES = ImmutableSet.of(
+      ManifestEntry.Status.EXISTING);
+
   private final TableOperations ops;
   private final PartitionSpec spec;
   private final long manifestTargetSizeBytes;
 
+  private final Set<ManifestFile> deletedManifests = Sets.newHashSet();
+  private final List<ManifestFile> addedManifests = Lists.newArrayList();
+
   private final List<ManifestFile> keptManifests = Collections.synchronizedList(new ArrayList<>());
   private final List<ManifestFile> newManifests = Collections.synchronizedList(new ArrayList<>());
-  private final Set<ManifestFile> replacedManifests = Collections.synchronizedSet(new HashSet<>());
+  private final Set<ManifestFile> rewrittenManifests = Collections.synchronizedSet(new HashSet<>());
   private final Map<Object, WriterWrapper> writers = Collections.synchronizedMap(new HashMap<>());
 
   private final AtomicInteger manifestSuffix = new AtomicInteger(0);
   private final AtomicLong entryCount = new AtomicLong(0);
 
-  private final Map<String, String> summaryProps = new HashMap<>();
-
   private Function<DataFile, Object> clusterByFunc;
   private Predicate<ManifestFile> predicate;
 
-  private static final String REPLACED_CNT = "manifests-replaced";
-  private static final String KEPT_CNT = "manifests-kept";
-  private static final String NEW_CNT = "manifests-created";
-  private static final String ENTRY_CNT = "entries-processed";
+  private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
 
   BaseRewriteManifests(TableOperations ops) {
     super(ops);
@@ -85,19 +96,17 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
 
   @Override
   public RewriteManifests set(String property, String value) {
-    summaryProps.put(property, value);
+    summaryBuilder.set(property, value);
     return this;
   }
 
   @Override
   protected Map<String, String> summary() {
-    Map<String, String> result = new HashMap<>();
-    result.putAll(summaryProps);
-    result.put(KEPT_CNT, Integer.toString(keptManifests.size()));
-    result.put(NEW_CNT, Integer.toString(newManifests.size()));
-    result.put(REPLACED_CNT, Integer.toString(replacedManifests.size()));
-    result.put(ENTRY_CNT, Long.toString(entryCount.get()));
-    return result;
+    summaryBuilder.set(KEPT_MANIFESTS_COUNT, String.valueOf(keptManifests.size()));
+    summaryBuilder.set(CREATED_MANIFESTS_COUNT, String.valueOf(newManifests.size() + addedManifests.size()));
+    summaryBuilder.set(REPLACED_MANIFESTS_COUNT, String.valueOf(rewrittenManifests.size() + deletedManifests.size()));
+    summaryBuilder.set(PROCESSED_ENTRY_COUNT, String.valueOf(entryCount.get()));
+    return summaryBuilder.build();
   }
 
   @Override
@@ -113,50 +122,84 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   }
 
   @Override
+  public RewriteManifests deleteManifest(ManifestFile manifest) {
+    deletedManifests.add(manifest);
+    return this;
+  }
+
+  @Override
+  public RewriteManifests addManifest(ManifestFile manifest) {
+    try {
+      // the appended manifest must be rewritten with this update's snapshot ID
+      addedManifests.add(copyManifest(manifest));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Cannot append manifest: " + e.getMessage());
+    }
+    return this;
+  }
+
+  private ManifestFile copyManifest(ManifestFile manifest) {
+    Map<Integer, PartitionSpec> specsById = ops.current().specsById();
+    try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()), specsById)) {
+      OutputFile newFile = manifestPath(manifestSuffix.getAndIncrement());
+      return ManifestWriter.copyManifest(reader, newFile, snapshotId(), summaryBuilder, ALLOWED_ENTRY_STATUSES);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
+    }
+  }
+
+  @Override
   public List<ManifestFile> apply(TableMetadata base) {
-    Preconditions.checkNotNull(clusterByFunc, "clusterBy function cannot be null");
-
     List<ManifestFile> currentManifests = base.currentSnapshot().manifests();
+    Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    if (requiresRewrite(currentManifests)) {
-      // run the rewrite process
+    validateDeletedManifests(currentManifestSet);
+
+    if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);
     } else {
-      // just keep any new manifests that were added since the last apply(), don't rerun
-      addExistingFromNewCommit(currentManifests);
+      keepActiveManifests(currentManifests);
     }
+
+    validateFilesCounts();
 
     // put new manifests at the beginning
     List<ManifestFile> apply = new ArrayList<>();
     apply.addAll(newManifests);
+    apply.addAll(addedManifests);
     apply.addAll(keptManifests);
 
     return apply;
   }
 
-  private boolean requiresRewrite(List<ManifestFile> currentManifests) {
-    if (replacedManifests.size() == 0) {
+  private boolean requiresRewrite(Set<ManifestFile> currentManifests) {
+    if (clusterByFunc == null) {
+      // manifests are deleted and added directly so don't perform a rewrite
+      return false;
+    }
+
+    if (rewrittenManifests.size() == 0) {
       // nothing yet processed so perform a full rewrite
       return true;
     }
+
     // if any processed manifest is not in the current manifest list, perform a full rewrite
-    Set<ManifestFile> set = Sets.newHashSet(currentManifests);
-    return replacedManifests.stream().anyMatch(manifest -> !set.contains(manifest));
+    return rewrittenManifests.stream().anyMatch(manifest -> !currentManifests.contains(manifest));
   }
 
-  private void addExistingFromNewCommit(List<ManifestFile> currentManifests) {
+  private void keepActiveManifests(List<ManifestFile> currentManifests) {
     // keep any existing manifests as-is that were not processed
     keptManifests.clear();
     currentManifests.stream()
-      .filter(manifest -> !replacedManifests.contains(manifest))
+      .filter(manifest -> !rewrittenManifests.contains(manifest) && !deletedManifests.contains(manifest))
       .forEach(manifest -> keptManifests.add(manifest));
   }
 
   private void reset() {
-    cleanAll();
+    cleanUncommitted(newManifests, ImmutableSet.of());
     entryCount.set(0);
     keptManifests.clear();
-    replacedManifests.clear();
+    rewrittenManifests.clear();
     newManifests.clear();
     writers.clear();
   }
@@ -164,14 +207,18 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   private void performRewrite(List<ManifestFile> currentManifests) {
     reset();
 
+    List<ManifestFile> remainingManifests = currentManifests.stream()
+        .filter(manifest -> !deletedManifests.contains(manifest))
+        .collect(Collectors.toList());
+
     try {
-      Tasks.foreach(currentManifests)
+      Tasks.foreach(remainingManifests)
           .executeWith(ThreadPools.getWorkerPool())
           .run(manifest -> {
             if (predicate != null && !predicate.test(manifest)) {
               keptManifests.add(manifest);
             } else {
-              replacedManifests.add(manifest);
+              rewrittenManifests.add(manifest);
               try (ManifestReader reader =
                      ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
                 FilteredManifest filteredManifest = reader.select(Arrays.asList("*"));
@@ -187,6 +234,40 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     } finally {
       Tasks.foreach(writers.values()).executeWith(ThreadPools.getWorkerPool()).run(writer -> writer.close());
     }
+  }
+
+  private void validateDeletedManifests(Set<ManifestFile> currentManifests) {
+    // directly deleted manifests must be still present in the current snapshot
+    deletedManifests.stream()
+        .filter(manifest -> !currentManifests.contains(manifest))
+        .findAny()
+        .ifPresent(manifest -> {
+          throw new ValidationException("Manifest is missing: %s", manifest.path());
+        });
+  }
+
+  private void validateFilesCounts() {
+    int createdManifestsFilesCount = activeFilesCount(newManifests) + activeFilesCount(addedManifests);
+    int replacedManifestsFilesCount = activeFilesCount(rewrittenManifests) + activeFilesCount(deletedManifests);
+
+    if (createdManifestsFilesCount != replacedManifestsFilesCount) {
+      throw new ValidationException(
+          "Replaced and created manifests must have the same number of active files: %d (new), %d (old)",
+          createdManifestsFilesCount, replacedManifestsFilesCount);
+    }
+  }
+
+  private int activeFilesCount(Iterable<ManifestFile> manifests) {
+    int activeFilesCount = 0;
+
+    for (ManifestFile manifest : manifests) {
+      Preconditions.checkNotNull(manifest.addedFilesCount(), "Missing file counts in %s", manifest.path());
+      Preconditions.checkNotNull(manifest.existingFilesCount(), "Missing file counts in %s", manifest.path());
+      activeFilesCount += manifest.addedFilesCount();
+      activeFilesCount += manifest.existingFilesCount();
+    }
+
+    return activeFilesCount;
   }
 
   private void appendEntry(ManifestEntry entry, Object key) {
@@ -214,8 +295,13 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
 
   @Override
   protected void cleanUncommitted(Set<ManifestFile> committed) {
-    for (ManifestFile manifest : newManifests) {
-      if (!committed.contains(manifest)) {
+    cleanUncommitted(newManifests, committed);
+    cleanUncommitted(addedManifests, committed);
+  }
+
+  private void cleanUncommitted(Iterable<ManifestFile> manifests, Set<ManifestFile> committedManifests) {
+    for (ManifestFile manifest : manifests) {
+      if (!committedManifests.contains(manifest)) {
         deleteFile(manifest.path());
       }
     }


### PR DESCRIPTION
This PR extends `RewriteManifests` with a way to directly delete/add manifests, which enables us to rewrite manifests using an external process.