### PR TITLE
Fix concurrency issue in HiveTableOperations when Table is reused

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -151,11 +151,12 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       }
 
       tbl.setSd(storageDescriptor(metadata)); // set to pickup any schema changes
-      final String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
-      if (!Objects.equals(currentMetadataLocation(), metadataLocation)) {
-        String errMsg = String.format("metadataLocation = %s is not same as table metadataLocation %s for %s.%s",
-            currentMetadataLocation(), metadataLocation, database, tableName);
-        throw new CommitFailedException(errMsg);
+      String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
+      String baseMetadataLocation = base != null ? base.file().location() : null;
+      if (!Objects.equals(baseMetadataLocation, metadataLocation)) {
+        throw new CommitFailedException(
+            "Base metadata location '%s' is not same as the current table metadata location '%s' for %s.%s",
+            baseMetadataLocation, metadataLocation, database, tableName);
       }
 
       setParameters(newMetadataLocation, tbl);


### PR DESCRIPTION
The same `Table` instance can be shared by multiple jobs meaning that `TableOperations` can be reused. Right now, `doCommit` in `HiveTableOperations` does not check whether `base` is still valid. It checks whether the current metadata location is valid. As a result, if another thread/job that uses the same `HiveTableOperations` updates the current metadata location, this might lead to data corruption.