### PR TITLE
Docs: use append mode for Spark append doc

### DIFF
--- a/site/docs/spark.md
+++ b/site/docs/spark.md
@@ -80,19 +80,20 @@ spark.sql("""select count(1) from table""").show()
 
 ### Appending data
 
-To append a dataframe to an Iceberg table, use the `iceberg` format with `DataFrameReader`:
+To append a dataframe to an Iceberg table, use the `iceberg` format with `append` mode in the `DataFrameWriter`:
 
 ```scala
 val data: DataFrame = ...
 data.write
     .format("iceberg")
+    .mode("append")
     .save("db.table")
 ```
 
 
 ### Overwriting data
 
-To overwrite values in an Iceberg table, use `overwrite` mode in the `DataFrameReader`:
+To overwrite values in an Iceberg table, use `overwrite` mode in the `DataFrameWriter`:
 
 ```scala
 val data: DataFrame = ...


### PR DESCRIPTION
This PR is to address 2 doc changes: 

1. To append a dataframe to an Iceberg table, mode of "append" must be explicitly specified, or the following error is reported:
```
Exception in thread "main" java.lang.IllegalArgumentException: Save mode ErrorIfExists is not supported
	at org.apache.iceberg.shaded.com.google.common.base.Preconditions.checkArgument(Preconditions.java:217)
	at org.apache.iceberg.spark.source.IcebergSource.createWriter(IcebergSource.java:77)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:255)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:229)
```
"ErrorIfExists" is the default mode defined in DataFrameWriter if mode is not specified.

2. Correct DataFrame**Reader** to DataFrame**Writer**
