### PR TITLE
[python] adding Hive package to wrap BaseMetastoreTables/TableOperations

### DIFF
--- a/python/iceberg/hive/__init__.py
+++ b/python/iceberg/hive/__init__.py
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+__all__ = ["HiveTableOperations", "HiveTables"]
+
+
+from .hive_table_operations import HiveTableOperations
+from .hive_tables import HiveTables

--- a/python/iceberg/hive/hive_table_operations.py
+++ b/python/iceberg/hive/hive_table_operations.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+from iceberg.core import BaseMetastoreTableOperations
+
+
+class HiveTableOperations(BaseMetastoreTableOperations):
+
+    def __init__(self, conf, client, database, table):
+        super(HiveTableOperations, self).__init__(conf)
+        self._client = client
+        self.database = database
+        self.table = table
+        self.refresh()
+
+    def refresh(self):
+        with self._client as open_client:
+            tbl_info = open_client.get_table(self.database, self.table)
+
+        table_type = tbl_info.parameters.get(BaseMetastoreTableOperations.TABLE_TYPE_PROP)
+
+        if table_type is None or table_type.lower() != BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE:
+            raise RuntimeError("Invalid table, not Iceberg: %s.%s" % (self.database,
+                                                                      self.table))
+
+        metadata_location = tbl_info.parameters.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
+        if metadata_location is None:
+            raise RuntimeError("Invalid table, missing metadata_location: %s.%s" % (self.database,
+                                                                                    self.table))
+
+        self.refresh_from_metadata_location(metadata_location)
+
+        return self.current()
+
+    def commit(self, base, metadata):
+        raise NotImplementedError()
+
+    def io(self):
+        raise NotImplementedError()
+
+    def close(self):
+        self._client.close()

--- a/python/iceberg/hive/hive_tables.py
+++ b/python/iceberg/hive/hive_tables.py
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+from hmsclient import hmsclient
+from iceberg.core import BaseMetastoreTables
+
+from .hive_table_operations import HiveTableOperations
+
+
+class HiveTables(BaseMetastoreTables):
+    DOT = "."
+    THRIFT_URIS = "hive.metastore.uris"
+
+    def __init__(self, conf):
+        super(HiveTables, self).__init__(conf)
+
+    def create(self, schema, table_identifier=None, spec=None, properties=None, database=None, table=None):
+        raise NotImplementedError()
+
+    def load(self, table_identifier):
+        parts = table_identifier.split(HiveTables.DOT)
+        if len(parts) == 2:
+            return super(HiveTables, self).load(database=parts[0], table=parts[1])
+        elif len(parts) == 1:
+            return super(HiveTables, self).load("default", table=parts[1])
+        else:
+            raise RuntimeError("Could not parse table identifier: %s" % table_identifier)
+
+    def new_table_ops(self, conf, database, table):
+        return HiveTableOperations(conf, self.get_client(), database, table)
+
+    def drop(self, database, table):
+        raise RuntimeError("Not yet implemented")
+
+    def get_client(self):
+        from urllib.parse import urlparse
+        metastore_uri = urlparse(self.conf[HiveTables.THRIFT_URIS])
+
+        client = hmsclient.HMSClient(host=metastore_uri.hostname, port=metastore_uri.port)
+        return client

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,7 @@ setup(
                       'boto3',
                       'fastavro',
                       'fastparquet>=0.3.1',
+                      'hmsclient',
                       'mmh3',
                       'moz_sql_parser',
                       'pyparsing',

--- a/python/tests/api/expressions/test_str_to_expr.py
+++ b/python/tests/api/expressions/test_str_to_expr.py
@@ -34,7 +34,7 @@ def test_lt():
 def test_lte():
     expected_expr = Expressions.less_than_or_equal("col_a", 1)
     conv_expr = Expressions.convert_string_to_expr("col_a <= 1")
-    assert expected_expr == conv_expr\
+    assert expected_expr == conv_expr
 
 
 def test_and():

--- a/python/tests/hive/__init__.py
+++ b/python/tests/hive/__init__.py
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#

--- a/python/tests/hive/conftest.py
+++ b/python/tests/hive/conftest.py
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#

--- a/python/tests/hive/test_hive_tables.py
+++ b/python/tests/hive/test_hive_tables.py
@@ -1,0 +1,120 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from iceberg.hive import HiveTables
+import mock
+from pytest import raises
+
+
+class TestHMSTable(object):
+    def __init__(self, params):
+        self.parameters = params
+
+
+@mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
+@mock.patch("iceberg.hive.HiveTableOperations.current")
+@mock.patch("iceberg.hive.HiveTables.get_client")
+def test_load_tables_check_valid_props(client, current_call, refresh_call):
+    parameters = {"table_type": "ICEBERG",
+                  "partition_spec": [],
+                  "metadata_location": "s3://path/to/iceberg.metadata.json"}
+
+    client.return_value.__enter__.return_value.get_table.return_value = TestHMSTable(parameters)
+
+    conf = {"hive.metastore.uris": 'thrift://hms:port'}
+    tables = HiveTables(conf)
+    tables.load("test.test_123")
+
+
+@mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
+@mock.patch("iceberg.hive.HiveTableOperations.current")
+@mock.patch("iceberg.hive.HiveTables.get_client")
+def test_load_tables_check_missing_iceberg_type(client, current_call, refresh_call):
+    parameters = {"partition_spec": [],
+                  "metadata_location": "s3://path/to/iceberg.metdata.json"}
+
+    client.return_value.__enter__.return_value.get_table.return_value = TestHMSTable(parameters)
+
+    conf = {"hive.metastore.uris": 'thrift://hms:port'}
+    tables = HiveTables(conf)
+    with raises(RuntimeError):
+        tables.load("test.test_123")
+
+
+@mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
+@mock.patch("iceberg.hive.HiveTableOperations.current")
+@mock.patch("iceberg.hive.HiveTables.get_client")
+def test_load_tables_check_non_iceberg_type(client, current_call, refresh_call):
+    parameters = {"table_type": "HIVE",
+                  "partition_spec": [],
+                  "metadata_location": "s3://path/to/iceberg.metdata.json"}
+
+    client.return_value.__enter__.return_value.get_table.return_value = TestHMSTable(parameters)
+
+    conf = {"hive.metastore.uris": 'thrift://hms:port'}
+    tables = HiveTables(conf)
+    with raises(RuntimeError):
+        tables.load("test.test_123")
+
+
+@mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
+@mock.patch("iceberg.hive.HiveTableOperations.current")
+@mock.patch("iceberg.hive.HiveTables.get_client")
+def test_load_tables_check_none_table_type(client, current_call, refresh_call):
+    parameters = {"table_type": None,
+                  "partition_spec": [],
+                  "metadata_location": "s3://path/to/iceberg.metdata.json"}
+
+    client.return_value.__enter__.return_value.get_table.return_value = TestHMSTable(parameters)
+
+    conf = {"hive.metastore.uris": 'thrift://hms:port'}
+    tables = HiveTables(conf)
+    with raises(RuntimeError):
+        tables.load("test.test_123")
+
+
+@mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
+@mock.patch("iceberg.hive.HiveTableOperations.current")
+@mock.patch("iceberg.hive.HiveTables.get_client")
+def test_load_tables_check_no_location(client, current_call, refresh_call):
+    parameters = {"table_type": "ICEBERG",
+                  "partition_spec": []}
+
+    client.return_value.__enter__.return_value.get_table.return_value = TestHMSTable(parameters)
+
+    conf = {"hive.metastore.uris": 'thrift://hms:port'}
+    tables = HiveTables(conf)
+    with raises(RuntimeError):
+        tables.load("test.test_123")
+
+
+@mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
+@mock.patch("iceberg.hive.HiveTableOperations.current")
+@mock.patch("iceberg.hive.HiveTables.get_client")
+def test_load_tables_check_none_location(client, current_call, refresh_call):
+    parameters = {"table_type": "ICEBERG",
+                  "partition_spec": [],
+                  "metadata_location": None}
+
+    client.return_value.__enter__.return_value.get_table.return_value = TestHMSTable(parameters)
+
+    conf = {"hive.metastore.uris": 'thrift://hms:port'}
+    tables = HiveTables(conf)
+    with raises(RuntimeError):
+        tables.load("test.test_123")

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -4,6 +4,7 @@ envlist = py36,linters
 [testenv]
 deps =
     coverage
+    mock
     nose
     pytest
 setenv =


### PR DESCRIPTION
This adds a package for connecting to hive metastore to manage iceberg tables. Also, fixes one minor lint issue.