### PR TITLE
Avoid NullPointerException when a source column is missing

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -482,6 +482,8 @@ public class PartitionSpec implements Serializable {
   static void checkCompatibility(PartitionSpec spec, Schema schema) {
     for (PartitionField field : spec.fields) {
       Type sourceType = schema.findType(field.sourceId());
+      ValidationException.check(sourceType != null,
+          "Cannot find source column for partition field: %s", field);
       ValidationException.check(sourceType.isPrimitiveType(),
           "Cannot partition by non-primitive source field: %s", sourceType);
       ValidationException.check(


### PR DESCRIPTION
This adds a check for whether a source column was found for a given ID when validating a partition spec. Validation is already done when updating the schema or a spec, so an update that causes this situation would fail either way. With this change, the error message is helpful instead of a generic NPE.