### PR TITLE
Remove comment handling in Schema because field handles it

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -306,7 +306,7 @@ public class Schema implements Serializable {
   public String toString() {
     return String.format("table {\n%s\n}",
         NEWLINE.join(struct.fields().stream()
-            .map(f -> "  " + f + (f.doc() == null ? "" : " COMMENT '" + f.doc() + "'"))
+            .map(f -> "  " + f)
             .collect(Collectors.toList())));
   }
 }


### PR DESCRIPTION
Field's toString method adds comments, so adding comments in schema's toString causes duplication.