### PR TITLE
[python] First add to docs, addresses #323 and #363

### DIFF
--- a/site/docs/python-api-intro.md
+++ b/site/docs/python-api-intro.md
@@ -1,0 +1,143 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+# Iceberg Python API
+
+Much of the python api conforms to the java api. You can get more info about the java api [here](https://iceberg.apache.org/api/).
+
+
+## Tables
+
+The Table interface provides access to table metadata
+
++ schema returns the current table `Schema`
++ spec returns the current table `PartitonSpec`
++ properties returns a map of key-value `TableProperties`
++ currentSnapshot returns the current table `Snapshot`
++ snapshots returns all valid snapshots for the table
++ snapshot(id) returns a specific snapshot by ID
++ location returns the table’s base location
+
+Tables also provide refresh to update the table to the latest version.
+
+### Scanning
+Iceberg table scans start by creating a `TableScan` object with `newScan`.
+
+``` python
+scan = table.new_scan();
+```
+
+To configure a scan, call filter and select on the `TableScan` to get a new `TableScan` with those changes.
+
+``` python
+filtered_scan = scan.filter(Expressions.equal("id", 5))
+```
+
+String expressions can also be passed to the filter method.
+
+``` python
+filtered_scan = scan.filter("id=5")
+```
+
+`Schema` projections can be applied against a `TableScan` by passing a list of column names.
+
+``` python
+filtered_scan = scan.select(["col_1", "col_2", "col_3"])
+```
+
+Because some data types cannot be read using the python library, a convenience method for excluding columns from projection is provided.
+
+``` python
+filtered_scan = scan.select_except(["unsupported_col_1", "unsupported_col_2"])
+```
+
+
+Calls to configuration methods create a new `TableScan` so that each `TableScan` is immutable.
+
+When a scan is configured, `planFiles`, `planTasks`, and `Schema` are used to return files, tasks, and the read projection.
+
+``` python
+scan = table.new_scan() \
+    .filter("id=5") \
+    .select(["id", "data"])
+
+projection = scan.schema
+for task in scan.plan_tasks():
+    print(task)
+```
+
+## Types
+
+Iceberg data types are located in `iceberg.api.types.types`
+
+### Primitives
+
+Primitive type instances are available from static methods in each type class. Types without parameters use `get`, and types like `DecimalType` use factory methods:
+
+```python
+IntegerType.get()    # int
+DoubleType.get()     # double
+DecimalType.of(9, 2) # decimal(9, 2)
+```
+
+### Nested types
+Structs, maps, and lists are created using factory methods in type classes.
+
+Like struct fields, map keys or values and list elements are tracked as nested fields. Nested fields track [field IDs](https://iceberg.apache.org/evolution/#correctness) and nullability.
+
+Struct fields are created using `NestedField.optional` or `NestedField.required`. Map value and list element nullability is set in the map and list factory methods.
+
+```python
+# struct<1 id: int, 2 data: optional string>
+struct = StructType.of([NestedField.required(1, "id", IntegerType.get()),
+                        NestedField.optional(2, "data", StringType.get()])
+  )
+```
+```python
+# map<1 key: int, 2 value: optional string>
+map_var = MapType.of_optional(1, IntegerType.get(),
+                          2, StringType.get())
+```
+```python
+# array<1 element: int>
+list_var = ListType.of_required(1, IntegerType.get());
+```
+
+## Expressions
+Iceberg’s `Expressions` are used to configure table scans. To create Expressions`, use the factory methods in `Expressions`.
+
+Supported `Predicate` expressions are:
+
++ `is_null`
++ `not_null`
++ `equal`
++ `not_equal`
++ `less_than`
++ `less_than_or_equal`
++ `greater_than`
++ `greater_than_or_equal`
+
+Supported expression `Operations`are:
+
++ `and`
++ `or`
++ `not`
+
+Constant expressions are:
+
++ `always_true`
++ `always_false`

--- a/site/docs/python-feature-support.md
+++ b/site/docs/python-feature-support.md
@@ -1,0 +1,72 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+# Feature Support
+
+The goal is that the python library will provide a functional, performant subset of the java library. The initial focus has been on reading table metadata as well as providing the capability to both plan and execute a scan.
+
+## Feature Comparison
+
+### Metadata
+
+| Operation               | Java  | Python |
+|:------------------------|:-----:|:------:|
+| Get Schema              |    X  |    X   |
+| Get Snapshots           |    X  |    X   |
+| Plan Scan               |    X  |    X   |
+| Plan Scan for Snapshot  |    X  |    X   |
+| Update Current Snapshot |    X  |        |
+| Set Table Properties    |    X  |        |
+| Create Table            |    X  |        |
+| Drop Table              |    X  |        |
+| Alter Table             |    X  |        |
+
+
+### Read Support
+
+Pyarrow is used for reading parquet files, so read support is limited to what is currently supported in the pyarrow.parquet package.
+
+There is a [gap](https://issues.apache.org/jira/browse/ARROW-1644) in the current implementation that nested fields are only supported if they are:
+> all repeated all repeated (lists) or all groups (structs) vs. a mix (structs and lists/repeated fields) then we can read and write them(otherwise we cannot)
+
+#### Primitive Types
+
+
+| Data Type               | Java | Python |
+|:------------------------|:----:|:------:|
+| BooleanType             |   X  |    X   |
+| DateType                |   X  |    X   |
+| DecimalType             |   X  |    X   |
+| FloatType               |   X  |    X   |
+| IntegerType             |   X  |    X   |
+| LongType                |   X  |    X   |
+| TimeType                |   X  |    X   |
+| TimestampType           |   X  |    X   |
+
+#### Nested Types
+
+| Data Type               | Java | Python |
+|:------------------------|:----:|:------:|
+| ListType of primitives  |   X  |    X   |
+| MapType of primitives   |   X  |    X   |
+| StructType of primitives|   X  |    X   |
+| ListType of Nested Types|   X  |        |
+| MapType of Nested Types |   X  |        |
+
+### Write Support
+
+The python client does not currently support write capability

--- a/site/docs/python-quickstart.md
+++ b/site/docs/python-quickstart.md
@@ -15,14 +15,12 @@
  - limitations under the License.
  -->
 
-# Iceberg Python
 
-Iceberg is a python library for programatic access to iceberg table metadata as well as data access. The intention is to provide a functional subset of the java library.
+# Getting Started
 
-## Getting Started
+## Installation
 
 Iceberg python is currently in development, for development and testing purposes the best way to install the library is to perform the following steps:
-
 ```
 git clone https://github.com/apache/incubator-iceberg.git
 cd incubator-iceberg/python
@@ -37,11 +35,26 @@ Testing is done using tox. The config can be found in `tox.ini` within the pytho
 tox
 ```
 
-## Get in Touch
+# Examples
 
-- Email:
-    * [dev@iceberg.apache.org](mailto:dev@iceberg.apache.org)
+## Inspect Table Metadata
+``` python
 
-- Issues
-    * [File a github incident](https://github.com/apache/incubator-iceberg/issues)
+from iceberg.hive import HiveTables
 
+# instantiate Hive Tables
+conf = {"hive.metastore.uris": 'thrift://{hms_host}:{hms_port}'}
+tables = HiveTables(conf)
+
+# load table
+tbl = tables.load("iceberg_db.iceberg_test_table")
+
+# inspect metadata
+print(tbl.schema())
+print(tbl.spec())
+print(tbl.location())
+
+# get table level record count
+from pprint import pprint
+pprint(int(tbl.current_snapshot().summary.get("total-records")))
+```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -62,6 +62,9 @@ nav:
     - Custom Catalog: custom-catalog.md
   - Python:
     - Git Repo: https://github.com/apache/incubator-iceberg/tree/master/python
+    - Quickstart: python-quickstart.md
+    - API intro: python-api-intro.md
+    - Feature Support: python-feature-support.md
   - Format:
     - Definitions: terms.md
     - Spec: spec.md


### PR DESCRIPTION
This adds .md files to the site docs for python quickstart, api-intro and feature support.  Also updates the python folder's readme to have install instructions.