### PR TITLE
Fix IllegalArgumentException in DataFiles.Builder.withPartitionPath

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -289,7 +289,9 @@ public class DataFiles {
     public Builder withPartitionPath(String newPartitionPath) {
       Preconditions.checkArgument(isPartitioned || newPartitionPath.isEmpty(),
           "Cannot add partition data for an unpartitioned table");
-      this.partitionData = fillFromPath(spec, newPartitionPath, partitionData);
+      if (!newPartitionPath.isEmpty()) {
+        this.partitionData = fillFromPath(spec, newPartitionPath, partitionData);
+      }
       return this;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -240,4 +240,10 @@ public class TestReplacePartitions extends TableTestBase {
         files(FILE_A, FILE_B),
         statuses(Status.ADDED, Status.ADDED));
   }
+
+  @Test
+  public void testEmptyPartitionPathWithUnpartitionedTable() {
+    DataFiles.builder(PartitionSpec.unpartitioned())
+        .withPartitionPath("");
+  }
 }

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -136,7 +136,7 @@ object SparkTableUtil {
         s"$name=${partition(name)}"
       }.mkString("/")
 
-      var builder = DataFiles.builder(spec)
+      DataFiles.builder(spec)
         .withPath(path)
         .withFormat(format)
         .withFileSizeInBytes(fileSize)
@@ -146,12 +146,8 @@ object SparkTableUtil {
           arrayToMap(nullValueCounts),
           arrayToMap(lowerBounds),
           arrayToMap(upperBounds)))
-
-      if (partitionKey.isEmpty) {
-        builder.build()
-      } else {
-        builder.withPartitionPath(partitionKey).build()
-      }
+        .withPartitionPath(partitionKey)
+        .build()
     }
   }
 


### PR DESCRIPTION
DataFiles.fillFromPath threw "Invalid partition data, too many fields (expecting 0)" when the path is empty.

The ugly `var` code can be removed from SparkDataFile.toDataFile.