### PR TITLE
Fix JitPack builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,9 +189,11 @@ subprojects {
     }
   }
 
-  signing {
-    useGpgCmd()
-    sign publishing.publications.apache
+  if (project.hasProperty('release')) {
+    signing {
+      useGpgCmd()
+      sign publishing.publications.apache
+    }
   }
 }
 


### PR DESCRIPTION
Configuring signing for the Apache release broke JitPack builds that some people use for testing and validation. This only configures signing if the "release" property is set.