### PR TITLE
[python] Removing unused config options and fixing Status issue in ManifesEntry

### DIFF
--- a/python/iceberg/core/manifest_entry.py
+++ b/python/iceberg/core/manifest_entry.py
@@ -76,7 +76,7 @@ class ManifestEntry():
 
     def put(self, i, v):
         if i == 0:
-            self.status = Status.from_id(i)
+            self.status = Status.from_id(v)
         elif i == 1:
             self.snapshot_id = v
         elif i == 2:

--- a/python/iceberg/core/util/__init__.py
+++ b/python/iceberg/core/util/__init__.py
@@ -17,8 +17,6 @@
 
 
 __all__ = ["AtomicInteger",
-           "METAFLOW_ENABLED",
-           "METAFLOW_ROOTDIR",
            "PackingIterator",
            "PLANNER_THREAD_POOL_SIZE_PROP",
            "SCAN_THREAD_POOL_ENABLED",
@@ -32,8 +30,6 @@ from .bin_packing import PackingIterator
 PLANNER_THREAD_POOL_SIZE_PROP = "iceberg.planner.num-threads"
 WORKER_THREAD_POOL_SIZE_PROP = "iceberg.worker.num-threads"
 SCAN_THREAD_POOL_ENABLED = "iceberg.scan.plan-in-worker-pool"
-METAFLOW_ENABLED = "iceberg.s3.use-metaflow"
-METAFLOW_ROOTDIR = "iceberg.s3.metaflow-root-dir"
 
 
 def str_as_bool(str_var):


### PR DESCRIPTION
Fixing a couple of issues that I missed when transferring over from our internal repo:

- Some internal config options that aren't used in the open source repo are being removed
- There was a bug in the ManifestEntry implementation that I didn't port the fix over for.