### PR TITLE
Use location of OutputFile in HMS for metadata files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -120,7 +120,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     // always unique because it includes a UUID.
     TableMetadataParser.overwrite(metadata, newMetadataLocation);
 
-    return newTableMetadataFilePath;
+    return newMetadataLocation.location();
   }
 
   protected void refreshFromMetadataLocation(String newLocation) {


### PR DESCRIPTION
Right now, `BaseMetastoreTableOperations` generates new metadata locations by concatenating strings while `HiveTableOperations` uses `HadoopInputFile` to get the base metadata location. If we set the table location to `file:///`, then `HadoopInputFile` will make it as `file:/...` but that won't happen in `BaseMetastoreTableOperations`. Therefore, locations will never be equal and all commits will fail. Same applies to extra `/` in table metadata files.