### PR TITLE
Use broadcast variables in IcebergSource

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -27,13 +27,22 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.util.SerializableSupplier;
 
 public class HadoopFileIO implements FileIO {
 
-  private final SerializableConfiguration hadoopConf;
+  private final SerializableSupplier<Configuration> hadoopConf;
 
   public HadoopFileIO(Configuration hadoopConf) {
-    this.hadoopConf = new SerializableConfiguration(hadoopConf);
+    this(new SerializableConfiguration(hadoopConf)::get);
+  }
+
+  public HadoopFileIO(SerializableSupplier<Configuration> hadoopConf) {
+    this.hadoopConf = hadoopConf;
+  }
+
+  public Configuration conf() {
+    return hadoopConf.get();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/SerializableSupplier.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializableSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+public interface SerializableSupplier<T> extends Supplier<T>, Serializable {}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.spark.data.SparkParquetReaders;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
+import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
@@ -103,8 +104,8 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
   private final Long splitSize;
   private final Integer splitLookback;
   private final Long splitOpenFileCost;
-  private final FileIO fileIo;
-  private final EncryptionManager encryptionManager;
+  private final Broadcast<FileIO> io;
+  private final Broadcast<EncryptionManager> encryptionManager;
   private final boolean caseSensitive;
   private StructType requestedSchema = null;
   private List<Expression> filterExpressions = null;
@@ -115,7 +116,8 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
   private StructType type = null; // cached because Spark accesses it multiple times
   private List<CombinedScanTask> tasks = null; // lazy cache of tasks
 
-  Reader(Table table, boolean caseSensitive, DataSourceOptions options) {
+  Reader(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+         boolean caseSensitive, DataSourceOptions options) {
     this.table = table;
     this.snapshotId = options.get("snapshot-id").map(Long::parseLong).orElse(null);
     this.asOfTimestamp = options.get("as-of-timestamp").map(Long::parseLong).orElse(null);
@@ -130,8 +132,8 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
     this.splitOpenFileCost = options.get("file-open-cost").map(Long::parseLong).orElse(null);
 
     this.schema = table.schema();
-    this.fileIo = table.io();
-    this.encryptionManager = table.encryption();
+    this.io = io;
+    this.encryptionManager = encryptionManager;
     this.caseSensitive = caseSensitive;
   }
 
@@ -166,7 +168,7 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
     List<InputPartition<InternalRow>> readTasks = Lists.newArrayList();
     for (CombinedScanTask task : tasks()) {
       readTasks.add(
-          new ReadTask(task, tableSchemaString, expectedSchemaString, fileIo, encryptionManager, caseSensitive));
+          new ReadTask(task, tableSchemaString, expectedSchemaString, io, encryptionManager, caseSensitive));
     }
 
     return readTasks;
@@ -282,28 +284,28 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
     private final CombinedScanTask task;
     private final String tableSchemaString;
     private final String expectedSchemaString;
-    private final FileIO fileIo;
-    private final EncryptionManager encryptionManager;
+    private final Broadcast<FileIO> io;
+    private final Broadcast<EncryptionManager> encryptionManager;
     private final boolean caseSensitive;
 
     private transient Schema tableSchema = null;
     private transient Schema expectedSchema = null;
 
-    private ReadTask(
-        CombinedScanTask task, String tableSchemaString, String expectedSchemaString, FileIO fileIo,
-        EncryptionManager encryptionManager, boolean caseSensitive) {
+    private ReadTask(CombinedScanTask task, String tableSchemaString, String expectedSchemaString,
+                     Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+                     boolean caseSensitive) {
       this.task = task;
       this.tableSchemaString = tableSchemaString;
       this.expectedSchemaString = expectedSchemaString;
-      this.fileIo = fileIo;
+      this.io = io;
       this.encryptionManager = encryptionManager;
       this.caseSensitive = caseSensitive;
     }
 
     @Override
     public InputPartitionReader<InternalRow> createPartitionReader() {
-      return new TaskDataReader(task, lazyTableSchema(), lazyExpectedSchema(), fileIo,
-        encryptionManager, caseSensitive);
+      return new TaskDataReader(task, lazyTableSchema(), lazyExpectedSchema(), io.value(),
+        encryptionManager.value(), caseSensitive);
     }
 
     private Schema lazyTableSchema() {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
@@ -27,7 +27,10 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileIO;
+import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter;
@@ -44,9 +47,10 @@ public class StreamingWriter extends Writer implements StreamWriter {
   private final String queryId;
   private final OutputMode mode;
 
-  StreamingWriter(Table table, DataSourceOptions options, String queryId, OutputMode mode, String applicationId,
-      Schema dsSchema) {
-    super(table, options, false, applicationId, dsSchema);
+  StreamingWriter(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+                  DataSourceOptions options, String queryId, OutputMode mode, String applicationId,
+                  Schema dsSchema) {
+    super(table, io, encryptionManager, options, false, applicationId, dsSchema);
     this.queryId = queryId;
     this.mode = mode;
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.spark.data.SparkAvroWriter;
 import org.apache.iceberg.spark.data.SparkParquetWriters;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
@@ -84,24 +85,26 @@ class Writer implements DataSourceWriter {
 
   private final Table table;
   private final FileFormat format;
-  private final FileIO fileIo;
-  private final EncryptionManager encryptionManager;
+  private final Broadcast<FileIO> io;
+  private final Broadcast<EncryptionManager> encryptionManager;
   private final boolean replacePartitions;
   private final String applicationId;
   private final String wapId;
   private final long targetFileSize;
   private final Schema dsSchema;
 
-  Writer(Table table, DataSourceOptions options, boolean replacePartitions, String applicationId, Schema dsSchema) {
-    this(table, options, replacePartitions, applicationId, null, dsSchema);
+  Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+         DataSourceOptions options, boolean replacePartitions, String applicationId, Schema dsSchema) {
+    this(table, io, encryptionManager, options, replacePartitions, applicationId, null, dsSchema);
   }
 
-  Writer(Table table, DataSourceOptions options, boolean replacePartitions, String applicationId, String wapId,
-      Schema dsSchema) {
+  Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+         DataSourceOptions options, boolean replacePartitions, String applicationId, String wapId,
+         Schema dsSchema) {
     this.table = table;
     this.format = getFileFormat(table.properties(), options);
-    this.fileIo = table.io();
-    this.encryptionManager = table.encryption();
+    this.io = io;
+    this.encryptionManager = encryptionManager;
     this.replacePartitions = replacePartitions;
     this.applicationId = applicationId;
     this.wapId = wapId;
@@ -127,7 +130,7 @@ class Writer implements DataSourceWriter {
   @Override
   public DataWriterFactory<InternalRow> createWriterFactory() {
     return new WriterFactory(
-        table.spec(), format, table.locationProvider(), table.properties(), fileIo, encryptionManager, targetFileSize,
+        table.spec(), format, table.locationProvider(), table.properties(), io, encryptionManager, targetFileSize,
         dsSchema);
   }
 
@@ -194,7 +197,7 @@ class Writer implements DataSourceWriter {
             2.0 /* exponential */)
         .throwFailureWhenFinished()
         .run(file -> {
-          fileIo.deleteFile(file.path().toString());
+          io.value().deleteFile(file.path().toString());
         });
   }
 
@@ -251,19 +254,20 @@ class Writer implements DataSourceWriter {
     private final FileFormat format;
     private final LocationProvider locations;
     private final Map<String, String> properties;
-    private final FileIO fileIo;
-    private final EncryptionManager encryptionManager;
+    private final Broadcast<FileIO> io;
+    private final Broadcast<EncryptionManager> encryptionManager;
     private final long targetFileSize;
     private final Schema dsSchema;
 
     WriterFactory(PartitionSpec spec, FileFormat format, LocationProvider locations,
-                  Map<String, String> properties, FileIO fileIo, EncryptionManager encryptionManager,
-                  long targetFileSize, Schema dsSchema) {
+                  Map<String, String> properties, Broadcast<FileIO> io,
+                  Broadcast<EncryptionManager> encryptionManager, long targetFileSize,
+                  Schema dsSchema) {
       this.spec = spec;
       this.format = format;
       this.locations = locations;
       this.properties = properties;
-      this.fileIo = fileIo;
+      this.io = io;
       this.encryptionManager = encryptionManager;
       this.targetFileSize = targetFileSize;
       this.dsSchema = dsSchema;
@@ -275,9 +279,9 @@ class Writer implements DataSourceWriter {
       AppenderFactory<InternalRow> appenderFactory = new SparkAppenderFactory();
 
       if (spec.fields().isEmpty()) {
-        return new UnpartitionedWriter(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize);
+        return new UnpartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
       } else {
-        return new PartitionedWriter(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize);
+        return new PartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
       }
     }
 
@@ -338,16 +342,17 @@ class Writer implements DataSourceWriter {
        * Generates EncryptedOutputFile for UnpartitionedWriter.
        */
       public EncryptedOutputFile newOutputFile() {
-        OutputFile file = fileIo.newOutputFile(locations.newDataLocation(generateFilename()));
-        return encryptionManager.encrypt(file);
+        OutputFile file = io.value().newOutputFile(locations.newDataLocation(generateFilename()));
+        return encryptionManager.value().encrypt(file);
       }
 
       /**
        * Generates EncryptedOutputFile for PartitionedWriter.
        */
       public EncryptedOutputFile newOutputFile(PartitionKey key) {
-        OutputFile rawOutputFile = fileIo.newOutputFile(locations.newDataLocation(spec, key, generateFilename()));
-        return encryptionManager.encrypt(rawOutputFile);
+        String newDataLocation = locations.newDataLocation(spec, key, generateFilename());
+        OutputFile rawOutputFile = io.value().newOutputFile(newDataLocation);
+        return encryptionManager.value().encrypt(rawOutputFile);
       }
     }
   }


### PR DESCRIPTION
This PR fixes #553.

In some Spark jobs, we see a substantial scheduler delay, which happens in `TaskSetManager` when Spark serializes Iceberg `ReadTask`. The latter contains a reference to `FileIO` (which can contain a full Hadoop conf).

The current idea is to broadcast `EncryptionManager` and `FileIO` in `IcebergSource`. Then `Reader` and `ReadTask` can store references to the broadcasted values and fetch actual ones in `createPartitionReader` while creating `TaskDataReader`.

All broadcasted values are automatically registered for clean-up in `SparkContext$broadcast`.

**Note!** Using this approach with Kryo requires providing a custom registrator to instruct Spark to apply Java serialization for `SerializableConfiguration`. We should extend #549 for this.