### PR TITLE
Add incompatible changes to UpdateSchema API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -136,7 +136,7 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * <p>
    * Because "." may be interpreted as a column path separator or may be used in field names, it is
    * not allowed in names passed to this method. To add to nested structures or to add fields with
-   * names that contain ".", use {@link #addColumn(String, String, Type)}.
+   * names that contain ".", use {@link #addRequiredColumn(String, String, Type)}.
    * <p>
    * If type is a nested type, its field IDs are reassigned when added to the existing schema.
    *
@@ -157,7 +157,7 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    * <p>
    * Because "." may be interpreted as a column path separator or may be used in field names, it is
    * not allowed in names passed to this method. To add to nested structures or to add fields with
-   * names that contain ".", use {@link #addColumn(String, String, Type)}.
+   * names that contain ".", use {@link #addRequiredColumn(String, String, Type)}.
    * <p>
    * If type is a nested type, its field IDs are reassigned when added to the existing schema.
    *

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -31,6 +31,22 @@ import org.apache.iceberg.types.Type;
 public interface UpdateSchema extends PendingUpdate<Schema> {
 
   /**
+   * Allow incompatible changes to the schema.
+   * <p>
+   * Incompatible changes can cause failures when attempting to read older data files. For example, adding a required
+   * column and attempting to read data files without that column will cause a failure. However, if there are no data
+   * files that are not compatible with the change, it can be allowed.
+   * <p>
+   * This option allows incompatible changes to be made to a schema. This should be used when the caller has validated
+   * that the change will not break. For example, if a column is added as optional but always populated and data older
+   * than the column addition has been deleted from the table, this can be used with {@link #requireColumn(String)} to
+   * mark the column required.
+   *
+   * @return this for method chaining
+   */
+  UpdateSchema allowIncompatibleChanges();
+
+  /**
    * Add a new top-level column.
    * <p>
    * Because "." may be interpreted as a column path separator or may be used in field names, it is
@@ -113,6 +129,100 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema addColumn(String parent, String name, Type type, String doc);
 
   /**
+   * Add a new required top-level column.
+   * <p>
+   * This is an incompatible change that can break reading older data. This method will result in an exception unless
+   * {@link #allowIncompatibleChanges()} has been called.
+   * <p>
+   * Because "." may be interpreted as a column path separator or may be used in field names, it is
+   * not allowed in names passed to this method. To add to nested structures or to add fields with
+   * names that contain ".", use {@link #addColumn(String, String, Type)}.
+   * <p>
+   * If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * @param name name for the new column
+   * @param type type for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name contains "."
+   */
+  default UpdateSchema addRequiredColumn(String name, Type type) {
+    return addRequiredColumn(name, type, null);
+  }
+
+  /**
+   * Add a new required top-level column.
+   * <p>
+   * This is an incompatible change that can break reading older data. This method will result in an exception unless
+   * {@link #allowIncompatibleChanges()} has been called.
+   * <p>
+   * Because "." may be interpreted as a column path separator or may be used in field names, it is
+   * not allowed in names passed to this method. To add to nested structures or to add fields with
+   * names that contain ".", use {@link #addColumn(String, String, Type)}.
+   * <p>
+   * If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * @param name name for the new column
+   * @param type type for the new column
+   * @param doc documentation string for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name contains "."
+   */
+  UpdateSchema addRequiredColumn(String name, Type type, String doc);
+
+  /**
+   * Add a new required top-level column.
+   * <p>
+   * This is an incompatible change that can break reading older data. This method will result in an exception unless
+   * {@link #allowIncompatibleChanges()} has been called.
+   * <p>
+   * The parent name is used to find the parent using {@link Schema#findField(String)}. If the
+   * parent name is null, the new column will be added to the root as a top-level column. If parent
+   * identifies a struct, a new column is added to that struct. If it identifies a list, the column
+   * is added to the list element struct, and if it identifies a map, the new column is added to
+   * the map's value struct.
+   * <p>
+   * The given name is used to name the new column and names containing "." are not handled
+   * differently.
+   * <p>
+   * If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * @param parent name of the parent struct to the column will be added to
+   * @param name name for the new column
+   * @param type type for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If parent doesn't identify a struct
+   */
+  default UpdateSchema addRequiredColumn(String parent, String name, Type type) {
+    return addRequiredColumn(parent, name, type, null);
+  }
+
+  /**
+   * Add a new required top-level column.
+   * <p>
+   * This is an incompatible change that can break reading older data. This method will result in an exception unless
+   * {@link #allowIncompatibleChanges()} has been called.
+   * <p>
+   * The parent name is used to find the parent using {@link Schema#findField(String)}. If the
+   * parent name is null, the new column will be added to the root as a top-level column. If parent
+   * identifies a struct, a new column is added to that struct. If it identifies a list, the column
+   * is added to the list element struct, and if it identifies a map, the new column is added to
+   * the map's value struct.
+   * <p>
+   * The given name is used to name the new column and names containing "." are not handled
+   * differently.
+   * <p>
+   * If type is a nested type, its field IDs are reassigned when added to the existing schema.
+   *
+   * @param parent name of the parent struct to the column will be added to
+   * @param name name for the new column
+   * @param type type for the new column
+   * @param doc documentation string for the new column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If parent doesn't identify a struct
+   */
+  UpdateSchema addRequiredColumn(String parent, String name, Type type, String doc);
+
+  /**
    * Rename a column in the schema.
    * <p>
    * The name is used to find the column to rename using {@link Schema#findField(String)}.
@@ -183,6 +293,25 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    *                                  with other additions, renames, or updates.
    */
   UpdateSchema updateColumnDoc(String name, String newDoc);
+
+  /**
+   * Update a column to optional.
+   *
+   * @param name name of the column to mark optional
+   * @return this for method chaining
+   */
+  UpdateSchema makeColumnOptional(String name);
+
+  /**
+   * Update a column to required.
+   * <p>
+   * This is an incompatible change that can break reading older data. This method will result in an exception unless
+   * {@link #allowIncompatibleChanges()} has been called.
+   *
+   * @param name name of the column to mark required
+   * @return this for method chaining
+   */
+  UpdateSchema requireColumn(String name);
 
   /**
    * Delete a column in the schema.

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -429,6 +429,14 @@ public class Types {
       return new NestedField(false, id, name, type, doc);
     }
 
+    public static NestedField of(int id, boolean isOptional, String name, Type type) {
+      return new NestedField(isOptional, id, name, type, null);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
+      return new NestedField(isOptional, id, name, type, doc);
+    }
+
     private final boolean isOptional;
     private final int id;
     private final String name;

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -37,9 +37,6 @@ import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.iceberg.types.Types.NestedField.optional;
-import static org.apache.iceberg.types.Types.NestedField.required;
-
 /**
  * Schema evolution API implementation.
  */
@@ -55,6 +52,7 @@ class SchemaUpdate implements UpdateSchema {
   private final Multimap<Integer, Types.NestedField> adds =
       Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
   private int lastColumnId;
+  private boolean allowIncompatibleChanges = false;
 
   SchemaUpdate(TableOperations ops) {
     this.ops = ops;
@@ -74,6 +72,12 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   @Override
+  public SchemaUpdate allowIncompatibleChanges() {
+    this.allowIncompatibleChanges = true;
+    return this;
+  }
+
+  @Override
   public UpdateSchema addColumn(String name, Type type, String doc) {
     Preconditions.checkArgument(!name.contains("."),
         "Cannot add column with ambiguous name: %s, use addColumn(parent, name, type)", name);
@@ -82,6 +86,27 @@ class SchemaUpdate implements UpdateSchema {
 
   @Override
   public UpdateSchema addColumn(String parent, String name, Type type, String doc) {
+    internalAddColumn(parent, name, true, type, doc);
+    return this;
+  }
+
+  @Override
+  public UpdateSchema addRequiredColumn(String name, Type type, String doc) {
+    Preconditions.checkArgument(!name.contains("."),
+        "Cannot add column with ambiguous name: %s, use addColumn(parent, name, type)", name);
+    addRequiredColumn(null, name, type, doc);
+    return this;
+  }
+
+  @Override
+  public UpdateSchema addRequiredColumn(String parent, String name, Type type, String doc) {
+    Preconditions.checkArgument(allowIncompatibleChanges,
+        "Incompatible change: cannot add required column: %s", name);
+    internalAddColumn(parent, name, false, type, doc);
+    return this;
+  }
+
+  private void internalAddColumn(String parent, String name, boolean isOptional, Type type, String doc) {
     int parentId = TABLE_ROOT_ID;
     if (parent != null) {
       Types.NestedField parentField = schema.findField(parent);
@@ -112,10 +137,8 @@ class SchemaUpdate implements UpdateSchema {
 
     // assign new IDs in order
     int newId = assignNewColumnId();
-    adds.put(parentId, optional(newId, name,
+    adds.put(parentId, Types.NestedField.of(newId, isOptional, name,
         TypeUtil.assignFreshIds(type, this::assignNewColumnId), doc));
-
-    return this;
   }
 
   @Override
@@ -144,12 +167,48 @@ class SchemaUpdate implements UpdateSchema {
     int fieldId = field.fieldId();
     Types.NestedField update = updates.get(fieldId);
     if (update != null) {
-      updates.put(fieldId, required(fieldId, newName, update.type(), update.doc()));
+      updates.put(fieldId, Types.NestedField.of(fieldId, update.isOptional(), newName, update.type(), update.doc()));
     } else {
-      updates.put(fieldId, required(fieldId, newName, field.type(), field.doc()));
+      updates.put(fieldId, Types.NestedField.of(fieldId, field.isOptional(), newName, field.type(), field.doc()));
     }
 
     return this;
+  }
+
+  @Override
+  public UpdateSchema requireColumn(String name) {
+    internalUpdateColumnRequirement(name, false);
+    return this;
+  }
+
+  @Override
+  public UpdateSchema makeColumnOptional(String name) {
+    internalUpdateColumnRequirement(name, true);
+    return this;
+  }
+
+  private void internalUpdateColumnRequirement(String name, boolean isOptional) {
+    Types.NestedField field = schema.findField(name);
+    Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
+
+    if ((!isOptional && field.isRequired()) || (isOptional && field.isOptional())) {
+      // if the change is a noop, avoid failing if it updating to required is not allowed
+      return;
+    }
+
+    Preconditions.checkArgument(isOptional || allowIncompatibleChanges,
+        "Cannot change column nullability: %s: optional -> required", name);
+    Preconditions.checkArgument(!deletes.contains(field.fieldId()),
+        "Cannot update a column that will be deleted: %s", field.name());
+
+    int fieldId = field.fieldId();
+    Types.NestedField update = updates.get(fieldId);
+
+    if (update != null) {
+      updates.put(fieldId, Types.NestedField.of(fieldId, isOptional, update.name(), update.type(), update.doc()));
+    } else {
+      updates.put(fieldId, Types.NestedField.of(fieldId, isOptional, field.name(), field.type(), field.doc()));
+    }
   }
 
   @Override
@@ -158,16 +217,21 @@ class SchemaUpdate implements UpdateSchema {
     Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
     Preconditions.checkArgument(!deletes.contains(field.fieldId()),
         "Cannot update a column that will be deleted: %s", field.name());
+
+    if (field.type().equals(newType)) {
+      return this;
+    }
+
     Preconditions.checkArgument(TypeUtil.isPromotionAllowed(field.type(), newType),
         "Cannot change column type: %s: %s -> %s", name, field.type(), newType);
 
     // merge with a rename, if present
     int fieldId = field.fieldId();
-    Types.NestedField rename = updates.get(fieldId);
-    if (rename != null) {
-      updates.put(fieldId, required(fieldId, rename.name(), newType, rename.doc()));
+    Types.NestedField update = updates.get(fieldId);
+    if (update != null) {
+      updates.put(fieldId, Types.NestedField.of(fieldId, update.isOptional(), update.name(), newType, update.doc()));
     } else {
-      updates.put(fieldId, required(fieldId, field.name(), newType, field.doc()));
+      updates.put(fieldId, Types.NestedField.of(fieldId, field.isOptional(), field.name(), newType, field.doc()));
     }
 
     return this;
@@ -180,13 +244,17 @@ class SchemaUpdate implements UpdateSchema {
     Preconditions.checkArgument(!deletes.contains(field.fieldId()),
         "Cannot update a column that will be deleted: %s", field.name());
 
+    if (Objects.equals(field.doc(), doc)) {
+      return this;
+    }
+
     // merge with a rename or update, if present
     int fieldId = field.fieldId();
     Types.NestedField update = updates.get(fieldId);
     if (update != null) {
-      updates.put(fieldId, required(fieldId, update.name(), update.type(), doc));
+      updates.put(fieldId, Types.NestedField.of(fieldId, update.isOptional(), update.name(), update.type(), doc));
     } else {
-      updates.put(fieldId, required(fieldId, field.name(), field.type(), doc));
+      updates.put(fieldId, Types.NestedField.of(fieldId, field.isOptional(), field.name(), field.type(), doc));
     }
 
     return this;
@@ -286,23 +354,22 @@ class SchemaUpdate implements UpdateSchema {
         Types.NestedField field = struct.fields().get(i);
         String name = field.name();
         String doc = field.doc();
+        boolean isOptional = field.isOptional();
         Types.NestedField update = updates.get(field.fieldId());
         if (update != null) {
           name = update.name();
           doc = update.doc();
+          isOptional = update.isOptional();
         }
 
-        if (!name.equals(field.name()) ||
-            field.type() != resultType ||
-            !Objects.equals(doc, field.doc())) {
-          hasChange = true;
-          if (field.isOptional()) {
-            newFields.add(optional(field.fieldId(), name, resultType, doc));
-          } else {
-            newFields.add(required(field.fieldId(), name, resultType, doc));
-          }
-        } else {
+        if (name.equals(field.name()) &&
+            isOptional == field.isOptional() &&
+            field.type() == resultType &&
+            Objects.equals(doc, field.doc())) {
           newFields.add(field);
+        } else {
+          hasChange = true;
+          newFields.add(Types.NestedField.of(field.fieldId(), isOptional, name, resultType, doc));
         }
       }
 
@@ -340,26 +407,30 @@ class SchemaUpdate implements UpdateSchema {
     }
 
     @Override
-    public Type list(Types.ListType list, Type result) {
+    public Type list(Types.ListType list, Type elementResult) {
       // use field to apply updates
-      Type elementResult = field(list.fields().get(0), result);
-      if (elementResult == null) {
+      Types.NestedField elementField = list.fields().get(0);
+      Type elementType = field(elementField, elementResult);
+      if (elementType == null) {
         throw new IllegalArgumentException("Cannot delete element type from list: " + list);
       }
 
-      if (list.elementType() == elementResult) {
+      Types.NestedField elementUpdate = updates.get(elementField.fieldId());
+      boolean isElementOptional = elementUpdate != null ? elementUpdate.isOptional() : list.isElementOptional();
+
+      if (isElementOptional == elementField.isOptional() && list.elementType() == elementType) {
         return list;
       }
 
-      if (list.isElementOptional()) {
-        return Types.ListType.ofOptional(list.elementId(), elementResult);
+      if (isElementOptional) {
+        return Types.ListType.ofOptional(list.elementId(), elementType);
       } else {
-        return Types.ListType.ofRequired(list.elementId(), elementResult);
+        return Types.ListType.ofRequired(list.elementId(), elementType);
       }
     }
 
     @Override
-    public Type map(Types.MapType map, Type kResult, Type vResult) {
+    public Type map(Types.MapType map, Type kResult, Type valueResult) {
       // if any updates are intended for the key, throw an exception
       int keyId = map.fields().get(0).fieldId();
       if (deletes.contains(keyId)) {
@@ -373,19 +444,23 @@ class SchemaUpdate implements UpdateSchema {
       }
 
       // use field to apply updates to the value
-      Type valueResult = field(map.fields().get(1), vResult);
-      if (valueResult == null) {
+      Types.NestedField valueField = map.fields().get(1);
+      Type valueType = field(valueField, valueResult);
+      if (valueType == null) {
         throw new IllegalArgumentException("Cannot delete value type from map: " + map);
       }
 
-      if (map.valueType() == valueResult) {
+      Types.NestedField valueUpdate = updates.get(valueField.fieldId());
+      boolean isValueOptional = valueUpdate != null ? valueUpdate.isOptional() : map.isValueOptional();
+
+      if (isValueOptional == map.isValueOptional() && map.valueType() == valueType) {
         return map;
       }
 
-      if (map.isValueOptional()) {
-        return Types.MapType.ofOptional(map.keyId(), map.valueId(), map.keyType(), valueResult);
+      if (isValueOptional) {
+        return Types.MapType.ofOptional(map.keyId(), map.valueId(), map.keyType(), valueType);
       } else {
-        return Types.MapType.ofRequired(map.keyId(), map.valueId(), map.keyType(), valueResult);
+        return Types.MapType.ofRequired(map.keyId(), map.valueId(), map.keyType(), valueType);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -192,7 +192,7 @@ class SchemaUpdate implements UpdateSchema {
     Preconditions.checkArgument(field != null, "Cannot update missing column: %s", name);
 
     if ((!isOptional && field.isRequired()) || (isOptional && field.isOptional())) {
-      // if the change is a noop, avoid failing if it updating to required is not allowed
+      // if the change is a noop, allow it even if allowIncompatibleChanges is false
       return;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -365,10 +365,61 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testAddRequiredColumn() {
+    Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
+    Schema expected = new Schema(
+        required(1, "id", Types.IntegerType.get()),
+        required(2, "data", Types.StringType.get()));
+
+    AssertHelpers.assertThrows("Should reject add required column if incompatible changes are not allowed",
+        IllegalArgumentException.class, "Incompatible change: cannot add required column: data",
+        () -> new SchemaUpdate(schema, 1).addRequiredColumn("data", Types.StringType.get()));
+
+    Schema result = new SchemaUpdate(schema, 1)
+        .allowIncompatibleChanges()
+        .addRequiredColumn("data", Types.StringType.get())
+        .apply();
+
+    Assert.assertEquals("Should add required column", expected.asStruct(), result.asStruct());
+  }
+
+  @Test
+  public void testMakeColumnOptional() {
+    Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
+    Schema expected = new Schema(optional(1, "id", Types.IntegerType.get()));
+
+    Schema result = new SchemaUpdate(schema, 1)
+        .makeColumnOptional("id")
+        .apply();
+
+    Assert.assertEquals("Should update column to be optional", expected.asStruct(), result.asStruct());
+  }
+
+  @Test
+  public void testRequireColumn() {
+    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
+    Schema expected = new Schema(required(1, "id", Types.IntegerType.get()));
+
+    AssertHelpers.assertThrows("Should reject change to required if incompatible changes are not allowed",
+        IllegalArgumentException.class, "Cannot change column nullability: id: optional -> required",
+        () -> new SchemaUpdate(schema, 1).requireColumn("id"));
+
+    // required to required is not an incompatible change
+    new SchemaUpdate(expected, 1).requireColumn("id").apply();
+
+    Schema result = new SchemaUpdate(schema, 1)
+        .allowIncompatibleChanges()
+        .requireColumn("id")
+        .apply();
+
+    Assert.assertEquals("Should update column to be required", expected.asStruct(), result.asStruct());
+  }
+
+  @Test
   public void testMixedChanges() {
     Schema expected = new Schema(
         required(1, "id", Types.LongType.get(), "unique id"),
-        optional(2, "json", Types.StringType.get()),
+        required(2, "json", Types.StringType.get()),
         optional(3, "options", Types.StructType.of(
             required(8, "feature1", Types.BooleanType.get()),
             optional(9, "newfeature", Types.BooleanType.get())
@@ -382,11 +433,12 @@ public class TestSchemaUpdate {
             ),
             Types.StructType.of(
                 required(12, "latitude", Types.DoubleType.get(), "latitude"),
-                optional(25, "alt", Types.FloatType.get())
+                optional(25, "alt", Types.FloatType.get()),
+                required(28, "description", Types.StringType.get(), "Location description")
             )), "map of address to coordinate"),
         optional(5, "points", Types.ListType.ofOptional(14,
             Types.StructType.of(
-                required(15, "X", Types.LongType.get()),
+                optional(15, "X", Types.LongType.get()),
                 required(16, "y.y", Types.LongType.get()),
                 optional(26, "z", Types.LongType.get()),
                 optional(27, "t.t", Types.LongType.get(), "name with '.'")
@@ -413,6 +465,10 @@ public class TestSchemaUpdate {
         .updateColumnDoc("locations.lat", "latitude")
         .deleteColumn("locations.long")
         .deleteColumn("properties")
+        .makeColumnOptional("points.x")
+        .allowIncompatibleChanges()
+        .requireColumn("data")
+        .addRequiredColumn("locations", "description", Types.StringType.get(), "Location description")
         .apply();
 
     Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());


### PR DESCRIPTION
Currently, the [`UpdateSchema` API](http://iceberg.apache.org/javadoc/master/index.html?org/apache/iceberg/UpdateSchema.html) doesn't allow changes that _could_ break compatibility with existing data files. But there are cases where these changes are safe. For example, creating a table with no data and making updates before any rows are written is always safe.

This extends the `UpdateSchema` API with incompatible methods: `addRequiredColumn` and `requireColumn`. By default, these methods will throw an `IllegalArgumentException` when called to make an incompatible change, unless `allowIncompatibleChanges` has been called. This ensures that the caller knows that changes are not compatible.

This also adds a compatible change, `makeColumnOptional`.