### PR TITLE
Infer mapping from expected schema if file schema does not have field-ids and name mapping is missing

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -80,6 +80,10 @@ public class AvroSchemaUtil {
     return AvroSchemaVisitor.visit(schema, new SchemaToType(schema));
   }
 
+  static boolean hasIds(Schema schema) {
+    return AvroCustomOrderSchemaVisitor.visit(schema, new HasIds());
+  }
+
   public static Map<Type, Schema> convertTypes(Types.StructType type, String name) {
     TypeToSchema converter = new TypeToSchema(ImmutableMap.of(type, name));
     TypeUtil.visit(type, converter);

--- a/core/src/main/java/org/apache/iceberg/avro/HasIds.java
+++ b/core/src/main/java/org/apache/iceberg/avro/HasIds.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.avro.Schema;
+
+/**
+ * Lazily evaluates the schema to see if any field ids are set.
+ * Returns true when a first field is found which has field id set
+ */
+class HasIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
+  @Override
+  public Boolean record(Schema record, List<String> names, Iterable<Boolean> fields) {
+    for (Boolean field : fields) {
+      if (field) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Boolean field(Schema.Field field, Supplier<Boolean> fieldResult) {
+    // see if field id is present, if not, try to find it in the sub tree
+    return AvroSchemaUtil.hasFieldId(field) || fieldResult.get();
+  }
+
+  @Override
+  public Boolean map(Schema map, Supplier<Boolean> value) {
+    return AvroSchemaUtil.hasProperty(map, AvroSchemaUtil.KEY_ID_PROP) ||
+        AvroSchemaUtil.hasProperty(map, AvroSchemaUtil.VALUE_ID_PROP) ||
+        value.get();
+  }
+
+  @Override
+  public Boolean array(Schema array, Supplier<Boolean> element) {
+    return AvroSchemaUtil.hasProperty(array, AvroSchemaUtil.ELEMENT_ID_PROP) || element.get();
+  }
+
+  @Override
+  public Boolean union(Schema union, Iterable<Boolean> options) {
+    for (Boolean option : options) {
+      if (option) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Boolean primitive(Schema primitive) {
+    return false;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/RemoveIds.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RemoveIds.java
@@ -66,4 +66,8 @@ class RemoveIds extends AvroSchemaVisitor<Schema> {
     }
     return copy;
   }
+
+  static org.apache.avro.Schema removeIds(org.apache.iceberg.Schema schema) {
+    return AvroSchemaVisitor.visit(AvroSchemaUtil.convert(schema.asStruct(), "table"), new RemoveIds());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestHasIds.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestHasIds.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHasIds {
+  @Test
+  public void test() {
+    Schema schema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(5, "location", Types.MapType.ofOptional(6, 7,
+            Types.StringType.get(),
+            Types.StructType.of(
+                Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                Types.NestedField.optional(2, "long", Types.FloatType.get())
+            ))));
+
+    org.apache.avro.Schema avroSchema = RemoveIds.removeIds(schema);
+    Assert.assertFalse(AvroSchemaUtil.hasIds(avroSchema));
+
+    avroSchema.getFields().get(0).addProp("field-id", 1);
+    Assert.assertTrue(AvroSchemaUtil.hasIds(avroSchema));
+
+    // Create a fresh copy
+    avroSchema = RemoveIds.removeIds(schema);
+    avroSchema
+        .getFields().get(1).schema()
+        .getTypes().get(1).getValueType()
+        .getTypes().get(1).getFields().get(1)
+        .addProp("field-id", 1);
+    Assert.assertTrue(AvroSchemaUtil.hasIds(avroSchema));
+  }
+}


### PR DESCRIPTION
Fixes #528

@rdblue .  I've written `AvroSchemaUtil.hasIds` similar to Parquet's, in that if at least 1 field-id is missing we consider the schema to have no ids. This is slightly different from your comment on #528. 