### PR TITLE
Fix iceberg-api javadoc @link issue

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StructType;
 
 /**
  * Represents how to produce partition data for a table.
@@ -99,9 +100,9 @@ public class PartitionSpec implements Serializable {
   }
 
   /**
-   * @return a {@link Types.StructType} for partition data defined by this spec.
+   * @return a {@link StructType} for partition data defined by this spec.
    */
-  public Types.StructType partitionType() {
+  public StructType partitionType() {
     List<Types.NestedField> structFields = Lists.newArrayListWithExpectedSize(fields.length);
 
     for (int i = 0; i < fields.length; i += 1) {

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -34,7 +34,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
 
 /**
  * The schema of a data table.
@@ -43,27 +44,27 @@ public class Schema implements Serializable {
   private static final Joiner NEWLINE = Joiner.on('\n');
   private static final String ALL_COLUMNS = "*";
 
-  private final Types.StructType struct;
+  private final StructType struct;
   private transient BiMap<String, Integer> aliasToId = null;
-  private transient Map<Integer, Types.NestedField> idToField = null;
+  private transient Map<Integer, NestedField> idToField = null;
   private transient BiMap<String, Integer> nameToId = null;
   private transient BiMap<String, Integer> lowerCaseNameToId = null;
   private transient Map<Integer, Accessor<StructLike>> idToAccessor = null;
 
-  public Schema(List<Types.NestedField> columns, Map<String, Integer> aliases) {
-    this.struct = Types.StructType.of(columns);
+  public Schema(List<NestedField> columns, Map<String, Integer> aliases) {
+    this.struct = StructType.of(columns);
     this.aliasToId = aliases != null ? ImmutableBiMap.copyOf(aliases) : null;
   }
 
-  public Schema(List<Types.NestedField> columns) {
-    this.struct = Types.StructType.of(columns);
+  public Schema(List<NestedField> columns) {
+    this.struct = StructType.of(columns);
   }
 
-  public Schema(Types.NestedField... columns) {
+  public Schema(NestedField... columns) {
     this(Arrays.asList(columns));
   }
 
-  private Map<Integer, Types.NestedField> lazyIdToField() {
+  private Map<Integer, NestedField> lazyIdToField() {
     if (idToField == null) {
       this.idToField = TypeUtil.indexById(struct);
     }
@@ -104,18 +105,18 @@ public class Schema implements Serializable {
   }
 
   /**
-   * Returns the underlying {@link Types.StructType struct type} for this schema.
+   * Returns the underlying {@link StructType struct type} for this schema.
    *
    * @return the StructType version of this schema.
    */
-  public Types.StructType asStruct() {
+  public StructType asStruct() {
     return struct;
   }
 
   /**
-   * @return a List of the {@link Types.NestedField columns} in this Schema.
+   * @return a List of the {@link NestedField columns} in this Schema.
    */
-  public List<Types.NestedField> columns() {
+  public List<NestedField> columns() {
     return struct.fields();
   }
 
@@ -131,7 +132,7 @@ public class Schema implements Serializable {
    * @return a Type for the sub-field or null if it is not found
    */
   public Type findType(int id) {
-    Types.NestedField field = lazyIdToField().get(id);
+    NestedField field = lazyIdToField().get(id);
     if (field != null) {
       return field.type();
     }
@@ -139,24 +140,24 @@ public class Schema implements Serializable {
   }
 
   /**
-   * Returns the sub-field identified by the field id as a {@link Types.NestedField}.
+   * Returns the sub-field identified by the field id as a {@link NestedField}.
    *
    * @param id a field id
    * @return the sub-field or null if it is not found
    */
-  public Types.NestedField findField(int id) {
+  public NestedField findField(int id) {
     return lazyIdToField().get(id);
   }
 
   /**
-   * Returns a sub-field by name as a {@link Types.NestedField}.
+   * Returns a sub-field by name as a {@link NestedField}.
    * <p>
    * The result may be a top-level or a nested field.
    *
    * @param name a String name
    * @return a Type for the sub-field or null if it is not found
    */
-  public Types.NestedField findField(String name) {
+  public NestedField findField(String name) {
     Preconditions.checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
     Integer id = lazyNameToId().get(name);
     if (id != null) {
@@ -166,14 +167,14 @@ public class Schema implements Serializable {
   }
 
   /**
-   * Returns a sub-field by name as a {@link Types.NestedField}.
+   * Returns a sub-field by name as a {@link NestedField}.
    * <p>
    * The result may be a top-level or a nested field.
    *
    * @param name a String name
    * @return the sub-field or null if it is not found
    */
-  public Types.NestedField caseInsensitiveFindField(String name) {
+  public NestedField caseInsensitiveFindField(String name) {
     Preconditions.checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
     Integer id = lazyLowerCaseNameToId().get(name.toLowerCase(Locale.ROOT));
     if (id != null) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -24,10 +24,10 @@ import java.util.Comparator;
 import java.util.Set;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StructType;
 
 /**
- * Evaluates an {@link Expression} for data described by a {@link Types.StructType}.
+ * Evaluates an {@link Expression} for data described by a {@link StructType}.
  * <p>
  * Data rows must implement {@link StructLike} and are passed to {@link #eval(StructLike)}.
  * <p>
@@ -44,11 +44,11 @@ public class Evaluator implements Serializable {
     return visitors.get();
   }
 
-  public Evaluator(Types.StructType struct, Expression unbound) {
+  public Evaluator(StructType struct, Expression unbound) {
     this.expr = Binder.bind(struct, unbound, true);
   }
 
-  public Evaluator(Types.StructType struct, Expression unbound, boolean caseSensitive) {
+  public Evaluator(StructType struct, Expression unbound, boolean caseSensitive) {
     this.expr = Binder.bind(struct, unbound, caseSensitive);
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StructType;
 
 import static org.apache.iceberg.expressions.Expression.Operation.IS_NULL;
 import static org.apache.iceberg.expressions.Expression.Operation.NOT_NULL;
@@ -70,23 +71,23 @@ public class UnboundPredicate<T> extends Predicate<NamedReference> {
    *
    * Access modifier is package-private, to only allow use from existing tests.
    *
-   * @param struct The {@link Types.StructType struct type} to resolve references by name.
+   * @param struct The {@link StructType struct type} to resolve references by name.
    * @return an {@link Expression}
    * @throws ValidationException if literals do not match bound references, or if comparison on expression is invalid
    */
-  Expression bind(Types.StructType struct) {
+  Expression bind(StructType struct) {
     return bind(struct, true);
   }
 
   /**
    * Bind this UnboundPredicate.
    *
-   * @param struct The {@link Types.StructType struct type} to resolve references by name.
+   * @param struct The {@link StructType struct type} to resolve references by name.
    * @param caseSensitive A boolean flag to control whether the bind should enforce case sensitivity.
    * @return an {@link Expression}
    * @throws ValidationException if literals do not match bound references, or if comparison on expression is invalid
    */
-  public Expression bind(Types.StructType struct, boolean caseSensitive) {
+  public Expression bind(StructType struct, boolean caseSensitive) {
     Schema schema = new Schema(struct.fields());
     Types.NestedField field = caseSensitive ?
         schema.findField(ref().name()) :

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.types.Type;
  * Factory methods for transforms.
  * <p>
  * Most users should create transforms using a
- * {@link PartitionSpec.Builder#builderFor(Schema)} partition spec builder}.
+ * {@link PartitionSpec#builderFor(Schema)} partition spec builder}.
  *
  * @see PartitionSpec#builderFor(Schema) The partition spec builder.
  */


### PR DESCRIPTION
Fix iceberg-api javadoc `@link reference not found` warnings using the [workaround](https://www.oracle.com/technetwork/java/javase/documentation/index-137483.html#namenotreferenced).