### PR TITLE
Update indexing to handle nested lists

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -20,53 +20,97 @@
 package org.apache.iceberg.types;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import java.util.List;
+import java.util.Deque;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.ValidationException;
 
-public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
+public class IndexByName extends TypeUtil.CustomOrderSchemaVisitor<Map<String, Integer>> {
   private static final Joiner DOT = Joiner.on(".");
 
+  private final Deque<String> fieldNames = Lists.newLinkedList();
   private final Map<String, Integer> nameToId = Maps.newHashMap();
 
   @Override
-  public Map<String, Integer> schema(Schema schema, Map<String, Integer> structResult) {
+  public Map<String, Integer> schema(Schema schema, Supplier<Map<String, Integer>> structResult) {
+    return structResult.get();
+  }
+
+  @Override
+  public Map<String, Integer> struct(Types.StructType struct, Iterable<Map<String, Integer>> fieldResults) {
+    for (Map<String, Integer> ignored : fieldResults) {
+    }
     return nameToId;
   }
 
   @Override
-  public Map<String, Integer> struct(Types.StructType struct, List<Map<String, Integer>> fieldResults) {
-    return nameToId;
-  }
-
-  @Override
-  public Map<String, Integer> field(Types.NestedField field, Map<String, Integer> fieldResult) {
+  public Map<String, Integer> field(Types.NestedField field, Supplier<Map<String, Integer>> fieldResult) {
+    withName(field.name(), fieldResult::get);
     addField(field.name(), field.fieldId());
     return null;
   }
 
   @Override
-  public Map<String, Integer> list(Types.ListType list, Map<String, Integer> elementResult) {
+  public Map<String, Integer> list(Types.ListType list, Supplier<Map<String, Integer>> elementResult) {
+    // add element
     for (Types.NestedField field : list.fields()) {
       addField(field.name(), field.fieldId());
     }
+
+    if (list.elementType().isStructType()) {
+      // return to avoid errorprone failure
+      return elementResult.get();
+    }
+
+    withName("element", elementResult::get);
+
     return null;
   }
 
   @Override
-  public Map<String, Integer> map(Types.MapType map, Map<String, Integer> keyResult, Map<String, Integer> valueResult) {
+  public Map<String, Integer> map(Types.MapType map, Supplier<Map<String, Integer>> keyResult, Supplier<Map<String, Integer>> valueResult) {
+    withName("key", keyResult::get);
+
+    // add key and value
     for (Types.NestedField field : map.fields()) {
       addField(field.name(), field.fieldId());
     }
+
+    if (map.valueType().isStructType()) {
+      // return to avoid errorprone failure
+      return valueResult.get();
+    }
+
+    withName("value", valueResult::get);
+
     return null;
+  }
+
+  private <T> T withName(String name, Callable<T> callable) {
+    fieldNames.push(name);
+    try {
+      return callable.call();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      fieldNames.pop();
+    }
   }
 
   private void addField(String name, int fieldId) {
     String fullName = name;
-    if (!fieldNames().isEmpty()) {
-      fullName = DOT.join(DOT.join(fieldNames().descendingIterator()), name);
+    if (!fieldNames.isEmpty()) {
+      fullName = DOT.join(DOT.join(fieldNames.descendingIterator()), name);
     }
-    nameToId.put(fullName, fieldId);
+
+    Integer existingFieldId = nameToId.put(fullName, fieldId);
+    if (existingFieldId != null && !"element".equals(name) && !"value".equals(name)) {
+      throw new ValidationException(
+          "Invalid schema: multiple fields for name %s: %s and %s", fullName, existingFieldId, fieldId);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -42,10 +42,8 @@ public class IndexByName extends TypeUtil.CustomOrderSchemaVisitor<Map<String, I
 
   @Override
   public Map<String, Integer> struct(Types.StructType struct, Iterable<Map<String, Integer>> fieldResults) {
-    // iterate through the fields to update the index for each one
-    for (Map<String, Integer> result : fieldResults) {
-      result.size();
-    }
+    // iterate through the fields to update the index for each one, use size to avoid errorprone failure
+    Lists.newArrayList(fieldResults).size();
     return nameToId;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.types;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Deque;
@@ -44,7 +43,9 @@ public class IndexByName extends TypeUtil.CustomOrderSchemaVisitor<Map<String, I
   @Override
   public Map<String, Integer> struct(Types.StructType struct, Iterable<Map<String, Integer>> fieldResults) {
     // iterate through the fields to update the index for each one
-    Iterables.size(fieldResults);
+    for (Map<String, Integer> result : fieldResults) {
+      result.size();
+    }
     return nameToId;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.types;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.Deque;
@@ -42,8 +43,8 @@ public class IndexByName extends TypeUtil.CustomOrderSchemaVisitor<Map<String, I
 
   @Override
   public Map<String, Integer> struct(Types.StructType struct, Iterable<Map<String, Integer>> fieldResults) {
-    for (Map<String, Integer> ignored : fieldResults) {
-    }
+    // iterate through the fields to update the index for each one
+    Iterables.size(fieldResults);
     return nameToId;
   }
 
@@ -72,7 +73,9 @@ public class IndexByName extends TypeUtil.CustomOrderSchemaVisitor<Map<String, I
   }
 
   @Override
-  public Map<String, Integer> map(Types.MapType map, Supplier<Map<String, Integer>> keyResult, Supplier<Map<String, Integer>> valueResult) {
+  public Map<String, Integer> map(Types.MapType map,
+                                  Supplier<Map<String, Integer>> keyResult,
+                                  Supplier<Map<String, Integer>> valueResult) {
     withName("key", keyResult::get);
 
     // add key and value

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -190,7 +190,6 @@ public class TypeUtil {
   }
 
   public static class SchemaVisitor<T> {
-    private final Deque<String> fieldNames = Lists.newLinkedList();
     private final Deque<Integer> fieldIds = Lists.newLinkedList();
 
     public T schema(Schema schema, T structResult) {
@@ -217,10 +216,6 @@ public class TypeUtil {
       return null;
     }
 
-    protected Deque<String> fieldNames() {
-      return fieldNames;
-    }
-
     protected Deque<Integer> fieldIds() {
       return fieldIds;
     }
@@ -237,13 +232,11 @@ public class TypeUtil {
         List<T> results = Lists.newArrayListWithExpectedSize(struct.fields().size());
         for (Types.NestedField field : struct.fields()) {
           visitor.fieldIds.push(field.fieldId());
-          visitor.fieldNames.push(field.name());
           T result;
           try {
             result = visit(field.type(), visitor);
           } finally {
             visitor.fieldIds.pop();
-            visitor.fieldNames.pop();
           }
           results.add(visitor.field(field, result));
         }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -559,10 +559,10 @@ public class TestSchemaUpdate {
 
   @Test
   public void testAlterMapKey() {
-    AssertHelpers.assertThrows("Should reject add sub-field to map key",
+    AssertHelpers.assertThrows("Should reject alter sub-field of map key",
         IllegalArgumentException.class, "Cannot alter map keys", () -> {
           new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
-              .updateColumn("locations.zip", Types.LongType.get()).apply();
+              .updateColumn("locations.key.zip", Types.LongType.get()).apply();
         }
     );
   }


### PR DESCRIPTION
This updates how `Schema` fields are indexed by name.

Previously, the visit method maintained a list of parent field names in each visitor, and the `IndexByName` visitor used these fields to create qualified field names. But the visitor did not add "element", "key", and "value" parent names, which resulted in duplicate names when indexing, for example, a list of lists.

The purpose of omitting "element", "key", and "value" from parent field names was to avoid forcing users to handle unnamed structures. For example, leaving out "element" from names for `points: struct<x double, y double>` results in fields "points.x" and "points.y" (and the nested struct as "points.element") instead of "points.element.x" and "points.element.y".

This updates how element and value names are skipped, by only skipping the names if a map value or list element is a nested struct. That way, a list of lists will correctly add an "element" level when processing the outer list's element. This also updates indexing so that "key" is always used so that key and value fields will not conflict.

This also moves the parent field names into `IndexByName` because they are only used in that class, and changes it to be a `CustomOrderSchemaVisitor`.