### PR TITLE
Add mechanism to expire old metadata versions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -123,7 +123,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     // always unique because it includes a UUID.
     TableMetadataParser.overwrite(metadata, newMetadataLocation);
 
-    return newTableMetadataFilePath;
+    return newMetadataLocation.location();
   }
 
   protected void refreshFromMetadataLocation(String newLocation) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -239,6 +239,7 @@ public class TableMetadata {
       }
       previous = metadataEntry;
     }
+
     Preconditions.checkArgument(
         currentSnapshotId < 0 || snapshotsById.containsKey(currentSnapshotId),
         "Invalid table metadata: Cannot find current version");
@@ -535,8 +536,8 @@ public class TableMetadata {
       return previousMetadata;
     }
 
-    int maxSize = PropertyUtil.propertyAsInt(updatedProperties,
-            TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT_DEFAULT);
+    int maxSize = Math.max(1, PropertyUtil.propertyAsInt(updatedProperties,
+            TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT));
 
     List<MetadataLogEntry> newMetadataLog = null;
     if (previousMetadata.size() >= maxSize) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -292,6 +292,6 @@ public class TableMetadataParser {
     return new TableMetadata(ops, file, uuid, location,
         lastUpdatedMillis, lastAssignedColumnId, schema, defaultSpecId, specs, properties,
         currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()),
-        ImmutableList.copyOf(metadataEntries.iterator()), null);
+        ImmutableList.copyOf(metadataEntries.iterator()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.TableMetadata.SnapshotLogEntry;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.InputFile;
@@ -95,6 +96,8 @@ public class TableMetadataParser {
   static final String SNAPSHOT_ID = "snapshot-id";
   static final String TIMESTAMP_MS = "timestamp-ms";
   static final String SNAPSHOT_LOG = "snapshot-log";
+  static final String METADATA_FILE = "metadata-file";
+  static final String METADATA_LOG = "metadata-log";
 
   public static void overwrite(TableMetadata metadata, OutputFile outputFile) {
     internalWrite(metadata, outputFile, true);
@@ -191,6 +194,15 @@ public class TableMetadataParser {
     }
     generator.writeEndArray();
 
+    generator.writeArrayFieldStart(METADATA_LOG);
+    for (MetadataLogEntry logEntry : metadata.previousMetadata()) {
+      generator.writeStartObject();
+      generator.writeNumberField(TIMESTAMP_MS, logEntry.timestampMillis());
+      generator.writeStringField(METADATA_FILE, logEntry.file());
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
+
     generator.writeEndObject();
   }
 
@@ -266,8 +278,20 @@ public class TableMetadataParser {
       }
     }
 
+    SortedSet<MetadataLogEntry> metadataEntries =
+            Sets.newTreeSet(Comparator.comparingLong(MetadataLogEntry::timestampMillis));
+    if (node.has(METADATA_LOG)) {
+      Iterator<JsonNode> logIterator = node.get(METADATA_LOG).elements();
+      while (logIterator.hasNext()) {
+        JsonNode entryNode = logIterator.next();
+        metadataEntries.add(new MetadataLogEntry(
+                JsonUtil.getLong(TIMESTAMP_MS, entryNode), JsonUtil.getString(METADATA_FILE, entryNode)));
+      }
+    }
+
     return new TableMetadata(ops, file, uuid, location,
         lastUpdatedMillis, lastAssignedColumnId, schema, defaultSpecId, specs, properties,
-        currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()));
+        currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()),
+        ImmutableList.copyOf(metadataEntries.iterator()), null);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -195,7 +195,7 @@ public class TableMetadataParser {
     generator.writeEndArray();
 
     generator.writeArrayFieldStart(METADATA_LOG);
-    for (MetadataLogEntry logEntry : metadata.previousMetadata()) {
+    for (MetadataLogEntry logEntry : metadata.previousFiles()) {
       generator.writeStartObject();
       generator.writeNumberField(TIMESTAMP_MS, logEntry.timestampMillis());
       generator.writeStringField(METADATA_FILE, logEntry.file());

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -92,8 +92,8 @@ public class TableProperties {
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "none";
 
-  public static final String PREVIOUS_METADATA_LOG_MAX_COUNT = "write.metadata.previous-log-max-count";
-  public static final int PREVIOUS_METADATA_LOG_MAX_COUNT_DEFAULT = 100;
+  public static final String METADATA_PREVIOUS_VERSIONS_MAX = "write.metadata.previous-versions-max";
+  public static final int METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT = 100;
 
   // This enables to delete the oldest metadata file after commit.
   public static final String METADATA_DELETE_AFTER_COMMIT_ENABLED = "write.metadata.delete-after-commit.enabled";

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -92,6 +92,13 @@ public class TableProperties {
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "none";
 
+  public static final String PREVIOUS_METADATA_LOG_MAX_COUNT = "write.metadata.previous-log-max-count";
+  public static final int PREVIOUS_METADATA_LOG_MAX_COUNT_DEFAULT = 100;
+
+  // This enables to delete the oldest metadata file after commit.
+  public static final String METADATA_DELETE_AFTER_COMMIT_ENABLED = "write.metadata.delete-after-commit.enabled";
+  public static final boolean METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT = false;
+
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -153,7 +153,7 @@ public class HadoopTableOperations implements TableOperations {
     // update the best-effort version pointer
     writeVersionHint(nextVersion);
 
-    deleteRemovedMetadata(base, metadata);
+    deleteRemovedMetadataFiles(base, metadata);
 
     this.shouldRefresh = true;
   }
@@ -294,9 +294,10 @@ public class HadoopTableOperations implements TableOperations {
   /**
    * Deletes the oldest metadata files if {@link TableProperties#METADATA_DELETE_AFTER_COMMIT_ENABLED} is true.
    *
-   * @param metadata the table metadata with removed metadata log entry.
+   * @param base     table metadata on which previous versions were based
+   * @param metadata new table metadata with updated previous versions
    */
-  private void deleteRemovedMetadata(TableMetadata base, TableMetadata metadata) {
+  private void deleteRemovedMetadataFiles(TableMetadata base, TableMetadata metadata) {
     if (base == null) {
       return;
     }
@@ -305,15 +306,15 @@ public class HadoopTableOperations implements TableOperations {
         TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED,
         TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT);
 
-    Set<TableMetadata.MetadataLogEntry> removedPreviousMetadata = Sets.newHashSet(base.previousMetadata());
-    removedPreviousMetadata.removeAll(metadata.previousMetadata());
+    Set<TableMetadata.MetadataLogEntry> removedPreviousMetadataFiles = Sets.newHashSet(base.previousFiles());
+    removedPreviousMetadataFiles.removeAll(metadata.previousFiles());
 
-    if (deleteAfterCommit && removedPreviousMetadata != null) {
-      Tasks.foreach(removedPreviousMetadata)
+    if (deleteAfterCommit) {
+      Tasks.foreach(removedPreviousMetadataFiles)
           .noRetry().suppressFailureWhenFinished()
-          .onFailure((previousMetadata, exc) ->
-              LOG.warn("Delete failed for previous metadata file: {}", previousMetadata, exc))
-          .run(previousMetadata -> io().deleteFile(previousMetadata.file()));
+          .onFailure((previousMetadataFile, exc) ->
+              LOG.warn("Delete failed for previous metadata file: {}", previousMetadataFile, exc))
+          .run(previousMetadataFile -> io().deleteFile(previousMetadataFile.file()));
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -232,7 +232,7 @@ public class TestTableMetadata {
         previousSnapshot.manifests(),
         metadata.snapshot(previousSnapshotId).manifests());
     Assert.assertEquals("Snapshot logs should match",
-            expected.previousMetadata(), metadata.previousMetadata());
+            expected.previousFiles(), metadata.previousFiles());
   }
 
   public static String toJsonWithoutSpecList(TableMetadata metadata) {
@@ -314,7 +314,7 @@ public class TestTableMetadata {
     TableMetadata metadataFromJson = TableMetadataParser.fromJson(ops, null,
         JsonUtil.mapper().readValue(asJson, JsonNode.class));
 
-    Assert.assertEquals("Metadata logs should match", previousMetadataLog, metadataFromJson.previousMetadata());
+    Assert.assertEquals("Metadata logs should match", previousMetadataLog, metadataFromJson.previousFiles());
   }
 
   @Test
@@ -357,10 +357,10 @@ public class TestTableMetadata {
 
     TableMetadata metadata = base.replaceProperties(
         ImmutableMap.of(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "5"));
-    Set<MetadataLogEntry> removedPreviousMetadata = Sets.newHashSet(base.previousMetadata());
-    removedPreviousMetadata.removeAll(metadata.previousMetadata());
+    Set<MetadataLogEntry> removedPreviousMetadata = Sets.newHashSet(base.previousFiles());
+    removedPreviousMetadata.removeAll(metadata.previousFiles());
 
-    Assert.assertEquals("Metadata logs should match", previousMetadataLog, metadata.previousMetadata());
+    Assert.assertEquals("Metadata logs should match", previousMetadataLog, metadata.previousFiles());
     Assert.assertEquals("Removed Metadata logs should be empty", 0, removedPreviousMetadata.size());
   }
 
@@ -413,11 +413,11 @@ public class TestTableMetadata {
 
     SortedSet<MetadataLogEntry> removedPreviousMetadata =
         Sets.newTreeSet(Comparator.comparingLong(MetadataLogEntry::timestampMillis));
-    removedPreviousMetadata.addAll(base.previousMetadata());
-    removedPreviousMetadata.removeAll(metadata.previousMetadata());
+    removedPreviousMetadata.addAll(base.previousFiles());
+    removedPreviousMetadata.removeAll(metadata.previousFiles());
 
     Assert.assertEquals("Metadata logs should match", previousMetadataLog.subList(1, 6),
-        metadata.previousMetadata());
+        metadata.previousFiles());
     Assert.assertEquals("Removed Metadata logs should contain 1", previousMetadataLog.subList(0, 1),
         ImmutableList.copyOf(removedPreviousMetadata));
   }
@@ -471,11 +471,11 @@ public class TestTableMetadata {
 
     SortedSet<MetadataLogEntry> removedPreviousMetadata =
         Sets.newTreeSet(Comparator.comparingLong(MetadataLogEntry::timestampMillis));
-    removedPreviousMetadata.addAll(base.previousMetadata());
-    removedPreviousMetadata.removeAll(metadata.previousMetadata());
+    removedPreviousMetadata.addAll(base.previousFiles());
+    removedPreviousMetadata.removeAll(metadata.previousFiles());
 
     Assert.assertEquals("Metadata logs should match", previousMetadataLog.subList(4, 6),
-        metadata.previousMetadata());
+        metadata.previousFiles());
     Assert.assertEquals("Removed Metadata logs should contain 4", previousMetadataLog.subList(0, 4),
         ImmutableList.copyOf(removedPreviousMetadata));
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -356,7 +356,7 @@ public class TestTableMetadata {
     previousMetadataLog.add(latestPreviousMetadata);
 
     TableMetadata metadata = base.replaceProperties(
-        ImmutableMap.of(TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, "5"));
+        ImmutableMap.of(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "5"));
     Set<MetadataLogEntry> removedPreviousMetadata = Sets.newHashSet(base.previousMetadata());
     removedPreviousMetadata.removeAll(metadata.previousMetadata());
 
@@ -409,7 +409,7 @@ public class TestTableMetadata {
     previousMetadataLog.add(latestPreviousMetadata);
 
     TableMetadata metadata = base.replaceProperties(
-        ImmutableMap.of(TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, "5"));
+        ImmutableMap.of(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "5"));
 
     SortedSet<MetadataLogEntry> removedPreviousMetadata =
         Sets.newTreeSet(Comparator.comparingLong(MetadataLogEntry::timestampMillis));
@@ -467,7 +467,7 @@ public class TestTableMetadata {
     previousMetadataLog.add(latestPreviousMetadata);
 
     TableMetadata metadata = base.replaceProperties(
-        ImmutableMap.of(TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, "2"));
+        ImmutableMap.of(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "2"));
 
     SortedSet<MetadataLogEntry> removedPreviousMetadata =
         Sets.newTreeSet(Comparator.comparingLong(MetadataLogEntry::timestampMillis));

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.TableMetadata.SnapshotLogEntry;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.types.Types;
@@ -51,7 +52,7 @@ import static org.apache.iceberg.TableMetadataParser.PROPERTIES;
 import static org.apache.iceberg.TableMetadataParser.SCHEMA;
 import static org.apache.iceberg.TableMetadataParser.SNAPSHOTS;
 
-public class TestTableMetadataJson {
+public class TestTableMetadata {
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -84,7 +85,7 @@ public class TestTableMetadataJson {
     TableMetadata expected = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
         ImmutableMap.of("property", "value"), currentSnapshotId,
-        Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog);
+        Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog, ImmutableList.of(), null);
 
     String asJson = TableMetadataParser.toJson(expected);
     TableMetadata metadata = TableMetadataParser.fromJson(ops, null,
@@ -145,7 +146,7 @@ public class TestTableMetadataJson {
     TableMetadata expected = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
         ImmutableMap.of("property", "value"), currentSnapshotId,
-        Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog);
+        Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog, ImmutableList.of(), null);
 
     // add the entries after creating TableMetadata to avoid the sorted check
     reversedSnapshotLog.add(
@@ -188,7 +189,7 @@ public class TestTableMetadataJson {
     TableMetadata expected = new TableMetadata(ops, null, null, "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 6, ImmutableList.of(spec),
         ImmutableMap.of("property", "value"), currentSnapshotId,
-        Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of());
+        Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of(), ImmutableList.of(), null);
 
     String asJson = toJsonWithoutSpecList(expected);
     TableMetadata metadata = TableMetadataParser
@@ -272,4 +273,194 @@ public class TestTableMetadataJson {
     }
     return writer.toString();
   }
+
+  @Test
+  public void testJsonWithPreviousMetadataLog() throws Exception {
+    Schema schema = new Schema(
+            Types.NestedField.required(1, "x", Types.LongType.get()),
+            Types.NestedField.required(2, "y", Types.LongType.get()),
+            Types.NestedField.required(3, "z", Types.LongType.get())
+    );
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(5).build();
+
+    long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
+    Snapshot previousSnapshot = new BaseSnapshot(
+            ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
+    long currentSnapshotId = System.currentTimeMillis();
+    Snapshot currentSnapshot = new BaseSnapshot(
+            ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
+
+    List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
+    long currentTimestamp = System.currentTimeMillis();
+    List<MetadataLogEntry> previousMetadataLog = Lists.newArrayList();
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp,
+            "file:/tmp/000001-" + UUID.randomUUID().toString() + ".metadata.json"));
+
+    TableMetadata base = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
+            System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
+            ImmutableMap.of("property", "value"), currentSnapshotId,
+            Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
+            ImmutableList.copyOf(previousMetadataLog), null);
+
+    String asJson = TableMetadataParser.toJson(base);
+    TableMetadata metadataFromJson = TableMetadataParser.fromJson(ops, null,
+            JsonUtil.mapper().readValue(asJson, JsonNode.class));
+
+    Assert.assertEquals("Metadata logs should match",
+            previousMetadataLog, metadataFromJson.previousMetadata());
+  }
+
+  @Test
+  public void testAddPreviousMetadataRemoveNone() throws Exception {
+    Schema schema = new Schema(
+            Types.NestedField.required(1, "x", Types.LongType.get()),
+            Types.NestedField.required(2, "y", Types.LongType.get()),
+            Types.NestedField.required(3, "z", Types.LongType.get())
+    );
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(5).build();
+
+    long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
+    Snapshot previousSnapshot = new BaseSnapshot(
+            ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
+    long currentSnapshotId = System.currentTimeMillis();
+    Snapshot currentSnapshot = new BaseSnapshot(
+            ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
+
+    List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
+    long currentTimestamp = System.currentTimeMillis();
+    List<MetadataLogEntry> previousMetadataLog = Lists.newArrayList();
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 100,
+            "file:/tmp/000001-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 90,
+            "file:/tmp/000002-" + UUID.randomUUID().toString() + ".metadata.json"));
+
+    TableMetadata base = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
+            System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
+            ImmutableMap.of(TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, "5"), currentSnapshotId,
+            Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
+            ImmutableList.copyOf(previousMetadataLog), null);
+
+    MetadataLogEntry latestPreviousMetadata = new MetadataLogEntry(currentTimestamp - 80,
+            "file:/tmp/000003-" + UUID.randomUUID().toString() + ".metadata.json");
+    previousMetadataLog.add(latestPreviousMetadata);
+
+    TableMetadata updated = base.addPreviousMetadata(
+            latestPreviousMetadata.file(), latestPreviousMetadata.timestampMillis());
+
+    Assert.assertEquals("Metadata logs should match",
+            previousMetadataLog, updated.previousMetadata());
+    Assert.assertEquals("Removed Metadata logs should be empty",
+            0, updated.removedPreviousMetadata().size());
+  }
+
+  @Test
+  public void testAddPreviousMetadataRemoveOne() throws Exception {
+    Schema schema = new Schema(
+            Types.NestedField.required(1, "x", Types.LongType.get()),
+            Types.NestedField.required(2, "y", Types.LongType.get()),
+            Types.NestedField.required(3, "z", Types.LongType.get())
+    );
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(5).build();
+
+    long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
+    Snapshot previousSnapshot = new BaseSnapshot(
+            ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
+    long currentSnapshotId = System.currentTimeMillis();
+    Snapshot currentSnapshot = new BaseSnapshot(
+            ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
+
+    List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
+    long currentTimestamp = System.currentTimeMillis();
+    List<MetadataLogEntry> previousMetadataLog = Lists.newArrayList();
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 100,
+            "file:/tmp/000001-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 90,
+            "file:/tmp/000002-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 80,
+            "file:/tmp/000003-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 70,
+            "file:/tmp/000004-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 60,
+            "file:/tmp/000005-" + UUID.randomUUID().toString() + ".metadata.json"));
+
+    TableMetadata base = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
+            System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
+            ImmutableMap.of(TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, "5"), currentSnapshotId,
+            Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
+            ImmutableList.copyOf(previousMetadataLog), null);
+
+    MetadataLogEntry latestPreviousMetadata = new MetadataLogEntry(currentTimestamp - 50,
+            "file:/tmp/000006-" + UUID.randomUUID().toString() + ".metadata.json");
+    previousMetadataLog.add(latestPreviousMetadata);
+
+    TableMetadata updated = base.addPreviousMetadata(
+            latestPreviousMetadata.file(), latestPreviousMetadata.timestampMillis());
+
+    Assert.assertEquals("Metadata logs should match",
+            previousMetadataLog.subList(1, 6), updated.previousMetadata());
+    Assert.assertEquals("Removed Metadata logs should contain 1",
+            previousMetadataLog.subList(0, 1), updated.removedPreviousMetadata());
+  }
+
+  @Test
+  public void testAddPreviousMetadataRemoveMultiple() throws Exception {
+    Schema schema = new Schema(
+            Types.NestedField.required(1, "x", Types.LongType.get()),
+            Types.NestedField.required(2, "y", Types.LongType.get()),
+            Types.NestedField.required(3, "z", Types.LongType.get())
+    );
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(5).build();
+
+    long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
+    Snapshot previousSnapshot = new BaseSnapshot(
+            ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
+    long currentSnapshotId = System.currentTimeMillis();
+    Snapshot currentSnapshot = new BaseSnapshot(
+            ops, currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
+            new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
+
+    List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
+    long currentTimestamp = System.currentTimeMillis();
+    List<MetadataLogEntry> previousMetadataLog = Lists.newArrayList();
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 100,
+            "file:/tmp/000001-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 90,
+            "file:/tmp/000002-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 80,
+            "file:/tmp/000003-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 70,
+            "file:/tmp/000004-" + UUID.randomUUID().toString() + ".metadata.json"));
+    previousMetadataLog.add(new MetadataLogEntry(currentTimestamp - 60,
+            "file:/tmp/000005-" + UUID.randomUUID().toString() + ".metadata.json"));
+
+    TableMetadata base = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
+            System.currentTimeMillis(), 3, schema, 2, ImmutableList.of(spec),
+            ImmutableMap.of(TableProperties.PREVIOUS_METADATA_LOG_MAX_COUNT, "2"), currentSnapshotId,
+            Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
+            ImmutableList.copyOf(previousMetadataLog), null);
+
+    MetadataLogEntry latestPreviousMetadata = new MetadataLogEntry(currentTimestamp - 50,
+            "file:/tmp/000006-" + UUID.randomUUID().toString() + ".metadata.json");
+    previousMetadataLog.add(latestPreviousMetadata);
+
+    TableMetadata updated = base.addPreviousMetadata(
+            latestPreviousMetadata.file(), latestPreviousMetadata.timestampMillis());
+
+    Assert.assertEquals("Metadata logs should match",
+            previousMetadataLog.subList(4, 6), updated.previousMetadata());
+    Assert.assertEquals("Removed Metadata logs should be null",
+            previousMetadataLog.subList(0, 4), updated.removedPreviousMetadata());
+  }
+
 }


### PR DESCRIPTION
This PR takes care of the issue [#181](https://github.com/apache/incubator-iceberg/issues/181).

Will raise another PR to expire metadata versions as part of `ExpireSnapshots`