### PR TITLE
Enable parallel execution for Gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@
 
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
+org.gradle.parallel=true


### PR DESCRIPTION
Would like to enable parallel execution for gradle build.
I could see a worthwhile boost to build times on my local machine:
(1) build and run tests:  66s --> 44s (save 33%)
(2) build and skip tests: 390s --> 290s (save 25%)

An alternative is to add "--parallel" when invoking gradlew.

Run with the change in gradle.properties for more than a week. Seems get no drawbacks but need some advices here.
@rdblue , works for you?