### PR TITLE
Allow ordered projections when writing

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
@@ -43,8 +44,9 @@ public class StreamingWriter extends Writer implements StreamWriter {
   private final String queryId;
   private final OutputMode mode;
 
-  StreamingWriter(Table table, DataSourceOptions options, String queryId, OutputMode mode, String applicationId) {
-    super(table, options, false, applicationId);
+  StreamingWriter(Table table, DataSourceOptions options, String queryId, OutputMode mode, String applicationId,
+      Schema dsSchema) {
+    super(table, options, false, applicationId, dsSchema);
     this.queryId = queryId;
     this.mode = mode;
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
@@ -338,4 +338,75 @@ public class TestParquetWrite {
     Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
     Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
+
+  @Test
+  public void testWriteProjection() throws IOException {
+    File parent = temp.newFolder("parquet");
+    File location = new File(parent, "test");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+
+    List<SimpleRecord> expected = Lists.newArrayList(
+        new SimpleRecord(1, null),
+        new SimpleRecord(2, null),
+        new SimpleRecord(3, null)
+    );
+
+    Dataset<Row> df = spark.createDataFrame(expected, SimpleRecord.class);
+
+    df.select("id").write() // select only id column
+        .format("iceberg")
+        .mode("append")
+        .save(location.toString());
+
+    table.refresh();
+
+    Dataset<Row> result = spark.read()
+        .format("iceberg")
+        .load(location.toString());
+
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+    Assert.assertEquals("Result rows should match", expected, actual);
+  }
+
+  @Test
+  public void testWriteProjectionWithMiddle() throws IOException {
+    File parent = temp.newFolder("parquet");
+    File location = new File(parent, "test");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Schema schema = new Schema(
+        optional(1, "c1", Types.IntegerType.get()),
+        optional(2, "c2", Types.StringType.get()),
+        optional(3, "c3", Types.StringType.get())
+    );
+    Table table = tables.create(schema, spec, location.toString());
+
+    List<ThreeColumnRecord> expected = Lists.newArrayList(
+        new ThreeColumnRecord(1, null, "hello"),
+        new ThreeColumnRecord(2, null, "world"),
+        new ThreeColumnRecord(3, null, null)
+    );
+
+    Dataset<Row> df = spark.createDataFrame(expected, ThreeColumnRecord.class);
+
+    df.select("c1", "c3").write()
+        .format("iceberg")
+        .mode("append")
+        .save(location.toString());
+
+    table.refresh();
+
+    Dataset<Row> result = spark.read()
+        .format("iceberg")
+        .load(location.toString());
+
+    List<ThreeColumnRecord> actual = result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+    Assert.assertEquals("Result rows should match", expected, actual);
+  }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/ThreeColumnRecord.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/ThreeColumnRecord.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Objects;
+
+public class ThreeColumnRecord {
+  private Integer c1;
+  private String c2;
+  private String c3;
+
+  public ThreeColumnRecord() {
+  }
+
+  public ThreeColumnRecord(Integer c1, String c2, String c3) {
+    this.c1 = c1;
+    this.c2 = c2;
+    this.c3 = c3;
+  }
+
+  public Integer getC1() {
+    return c1;
+  }
+
+  public void setC1(Integer c1) {
+    this.c1 = c1;
+  }
+
+  public String getC2() {
+    return c2;
+  }
+
+  public void setC2(String c2) {
+    this.c2 = c2;
+  }
+
+  public String getC3() {
+    return c3;
+  }
+
+  public void setC3(String c3) {
+    this.c3 = c3;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ThreeColumnRecord that = (ThreeColumnRecord) o;
+    return Objects.equals(c1, that.c1) &&
+        Objects.equals(c2, that.c2) &&
+        Objects.equals(c3, that.c3);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(c1, c2, c3);
+  }
+
+  @Override
+  public String toString() {
+    return "ThreeColumnRecord{" +
+        "c1=" + c1 +
+        ", c2='" + c2 + '\'' +
+        ", c3='" + c3 + '\'' +
+        '}';
+  }
+}


### PR DESCRIPTION
Having table schema `{ id : Int, data: String }`

We want to be able to:

```
spark.read
  .format("iceberg")
  .load(...)
  .select("id")
  .write
  .format("iceberg")
  .mode("append")
  .save(...)
```


We were getting:
```
java.lang.AssertionError: index (1) should < 1
	at org.apache.spark.sql.catalyst.expressions.UnsafeRow.assertIndexIsValid(UnsafeRow.java:131)
	at org.apache.spark.sql.catalyst.expressions.UnsafeRow.isNullAt(UnsafeRow.java:352)
	at org.apache.spark.sql.catalyst.expressions.UnsafeRow.get(UnsafeRow.java:308)
	at org.apache.iceberg.spark.data.SparkParquetWriters$InternalRowWriter.get(SparkParquetWriters.java:471)
	at org.apache.iceberg.spark.data.SparkParquetWriters$InternalRowWriter.get(SparkParquetWriters.java:453)
	at org.apache.iceberg.parquet.ParquetValueWriters$StructWriter.write(ParquetValueWriters.java:444)
	at org.apache.iceberg.parquet.ParquetWriter.add(ParquetWriter.java:110)
	at org.apache.iceberg.spark.source.Writer$BaseWriter.writeInternal(Writer.java:388)
	at org.apache.iceberg.spark.source.Writer$UnpartitionedWriter.write(Writer.java:472)
	at org.apache.iceberg.spark.source.Writer$UnpartitionedWriter.write(Writer.java:455)
	at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$$anonfun$run$3.apply(WriteToDataSourceV2Exec.scala:118)
	at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$$anonfun$run$3.apply(WriteToDataSourceV2Exec.scala:116)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1394)
	at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:146)
	at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec$$anonfun$doExecute$2.apply(WriteToDataSourceV2Exec.scala:67)
	at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec$$anonfun$doExecute$2.apply(WriteToDataSourceV2Exec.scala:66)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:123)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The stack points to Iceberg expecting `UnsafeRow` to match `table.schema`.

With this PR, we bubble down the write schema so writes of ordered projections are allowed.