### PR TITLE
Fix flaky ScanSummary test

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestScanSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanSummary.java
@@ -45,7 +45,7 @@ public class TestScanSummary extends TableTestBase {
         .commit();
 
     long t1 = System.currentTimeMillis();
-    while (t1 == t0) {
+    while (t1 <= table.currentSnapshot().timestampMillis()) {
       t1 = System.currentTimeMillis();
     }
 
@@ -56,7 +56,7 @@ public class TestScanSummary extends TableTestBase {
     long secondSnapshotId = table.currentSnapshot().snapshotId();
 
     long t2 = System.currentTimeMillis();
-    while (t2 == t1) {
+    while (t2 <= table.currentSnapshot().timestampMillis()) {
       t2 = System.currentTimeMillis();
     }
 


### PR DESCRIPTION
This fixes the flaky tests for ScanSummary. The previous fix assumed that the timestamp from just before a commit matched the timestamp of the commit. Ensuring that the next timestamp was after a time just before the commit doesn't always work. This fix ensures that the next timestamp is always after the last commit's timestamp.

Closes #576.