### PR TITLE
Use SessionState to load Hadoop conf

### DIFF
--- a/examples/Convert table to Iceberg.ipynb
+++ b/examples/Convert table to Iceberg.ipynb
@@ -143,7 +143,7 @@
     "{ // use a block to avoid values (conf, etc.) getting caught in closures\n",
     "\n",
     "    // remove the temp table if it already exists\n",
-    "    val conf = spark.sparkContext.hadoopConfiguration\n",
+    "    val conf = spark.sessionState.newHadoopConf()\n",
     "    val fs = new Path(path).getFileSystem(conf)\n",
     "    fs.delete(new Path(path), true /* recursive */ )\n",
     "\n",
@@ -338,7 +338,7 @@
     }
    ],
    "source": [
-    "val tables = new HadoopTables(spark.sparkContext.hadoopConfiguration)\n",
+    "val tables = new HadoopTables(spark.sessionState.newHadoopConf())\n",
     "val table = tables.load(path)\n",
     "\n",
     "table.currentSnapshot"

--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -28,7 +28,7 @@ The Hive catalog connects to a Hive MetaStore to keep track of Iceberg tables. T
 ```scala
 import org.apache.iceberg.hive.HiveCatalog
 
-val catalog = new HiveCatalog(spark.sparkContext.hadoopConfiguration)
+val catalog = new HiveCatalog(spark.sessionState.newHadoopConf())
 ```
 
 The `Catalog` interface defines methods for working with tables, like `createTable`, `loadTable`, `renameTable`, and `dropTable`.

--- a/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+++ b/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
@@ -97,7 +97,7 @@ public abstract class IcebergSourceBenchmark {
         .config("spark.ui.enabled", false)
         .master("local")
         .getOrCreate();
-    Configuration sparkHadoopConf = spark.sparkContext().hadoopConfiguration();
+    Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
     hadoopConf.forEach(entry -> sparkHadoopConf.set(entry.getKey(), entry.getValue()));
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -125,7 +125,7 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
 
   private Configuration lazyBaseConf() {
     if (lazyConf == null) {
-      this.lazyConf = lazySparkSession().sparkContext().hadoopConfiguration();
+      this.lazyConf = lazySparkSession().sessionState().newHadoopConf();
     }
     return lazyConf;
   }

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -509,7 +509,7 @@ object SparkTableUtil {
     val format = sourceTable.storage.serde.orElse(sourceTable.provider)
     require(format.nonEmpty, "Could not determine table format")
 
-    val conf = spark.sparkContext.hadoopConfiguration
+    val conf = spark.sessionState.newHadoopConf()
     val metricsConfig = MetricsConfig.fromProperties(targetTable.properties)
 
     val files = listPartition(Map.empty, sourceTable.location.toString, format.get, conf, metricsConfig)
@@ -528,7 +528,7 @@ object SparkTableUtil {
 
     import spark.implicits._
 
-    val conf = spark.sparkContext.hadoopConfiguration
+    val conf = spark.sessionState.newHadoopConf()
     val serializableConf = new SerializableConfiguration(conf)
     val partitions = getPartitions(spark, sourceTableIdent)
     val parallelism = Math.min(partitions.size, spark.sessionState.conf.parallelPartitionDiscoveryParallelism)

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -240,7 +240,7 @@ public class TestDataFrameWrites extends AvroDataTest {
         .write().parquet(sourcePath);
 
     // this is our iceberg dataset to which we will append data
-    new HadoopTables(spark.sparkContext().hadoopConfiguration())
+    new HadoopTables(spark.sessionState().newHadoopConf())
         .create(
             icebergSchema,
             PartitionSpec.builderFor(icebergSchema).identity("requiredField").build(),
@@ -290,7 +290,7 @@ public class TestDataFrameWrites extends AvroDataTest {
         .getOrCreate();
 
     // this is our iceberg dataset to which we will append data
-    new HadoopTables(newSparkSession.sparkContext().hadoopConfiguration())
+    new HadoopTables(newSparkSession.sessionState().newHadoopConf())
         .create(
             icebergSchema,
             PartitionSpec.builderFor(icebergSchema).identity("requiredField").build(),

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -133,7 +133,7 @@ public class TestDataSourceOptions {
   @Test
   public void testHadoopOptions() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
-    Configuration sparkHadoopConf = spark.sparkContext().hadoopConfiguration();
+    Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
     String originalDefaultFS = sparkHadoopConf.get("fs.default.name");
 
     try {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -117,7 +117,7 @@ public class TestPartitionValues {
     File dataFolder = new File(location, "data");
     Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
 
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table table = tables.create(SIMPLE_SCHEMA, SPEC, location.toString());
     table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
 
@@ -160,7 +160,7 @@ public class TestPartitionValues {
         "b", "i", "l", "f", "d", "date", "ts", "s", "bytes", "dec_9_0", "dec_11_2", "dec_38_10"
     };
 
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
 
     // create a table around the source data
     String sourceLocation = temp.newFolder("source_table").toString();

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -144,7 +144,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
             .saveAsTable("test_partitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
             .parseTableIdentifier("test_partitioned_table");
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table table = tables.create(SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),
@@ -162,7 +162,7 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
             .saveAsTable("test_unpartitioned_table");
     TableIdentifier source = spark.sessionState().sqlParser()
             .parseTableIdentifier("test_unpartitioned_table");
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table table = tables.create(SparkSchemaUtil.schemaForTable(spark, qualifiedTableName),
             SparkSchemaUtil.specForTable(spark, qualifiedTableName),
             ImmutableMap.of(),


### PR DESCRIPTION
We should avoid using `spark.sparkContext.hadoopConfiguration` as it ignores Hadoop props set in the SQL conf.

This PR resolves #636.