### PR TITLE
Add back old constructor to BinPacking

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/BinPacking.java
+++ b/core/src/main/java/org/apache/iceberg/util/BinPacking.java
@@ -63,6 +63,11 @@ public class BinPacking {
     private final boolean largestBinFirst;
 
     public PackingIterable(Iterable<T> iterable, long targetWeight, int lookback,
+                           Function<T, Long> weightFunc) {
+      this(iterable, targetWeight, lookback, weightFunc, false);
+    }
+
+    public PackingIterable(Iterable<T> iterable, long targetWeight, int lookback,
                            Function<T, Long> weightFunc, boolean largestBinFirst) {
       Preconditions.checkArgument(lookback > 0,
           "Bin look-back size must be greater than 0: %s", lookback);


### PR DESCRIPTION
We had applications that depended on this constructor. No need to remove it.