### PR TITLE
Fix UUID check for existing tables without a UUID

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -148,8 +148,8 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
               TableMetadataParser.read(io(), metadataLocation)));
 
       String newUUID = newMetadata.get().uuid();
-      if (currentMetadata != null) {
-        Preconditions.checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),
+      if (currentMetadata != null && currentMetadata.uuid() != null && newUUID != null) {
+        Preconditions.checkState(newUUID.equals(currentMetadata.uuid()),
             "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
       }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -96,14 +96,7 @@ public class HadoopTableOperations implements TableOperations {
       if (version == null || version != ver) {
         this.version = ver;
 
-        TableMetadata newMetadata = TableMetadataParser.read(io(), metadataFile.toString());
-        String newUUID = newMetadata.uuid();
-        if (currentMetadata != null && currentMetadata.uuid() != null && newUUID != null) {
-          Preconditions.checkState(newUUID.equals(currentMetadata.uuid()),
-              "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
-        }
-
-        this.currentMetadata = newMetadata;
+        this.currentMetadata = checkUUID(currentMetadata, TableMetadataParser.read(io(), metadataFile.toString()));
       }
 
       this.shouldRefresh = false;
@@ -320,5 +313,14 @@ public class HadoopTableOperations implements TableOperations {
               LOG.warn("Delete failed for previous metadata file: {}", previousMetadataFile, exc))
           .run(previousMetadataFile -> io().deleteFile(previousMetadataFile.file()));
     }
+  }
+
+  private static TableMetadata checkUUID(TableMetadata currentMetadata, TableMetadata newMetadata) {
+    String newUUID = newMetadata.uuid();
+    if (currentMetadata != null && currentMetadata.uuid() != null && newUUID != null) {
+      Preconditions.checkState(newUUID.equals(currentMetadata.uuid()),
+          "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
+    }
+    return newMetadata;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -98,8 +98,8 @@ public class HadoopTableOperations implements TableOperations {
 
         TableMetadata newMetadata = TableMetadataParser.read(io(), metadataFile.toString());
         String newUUID = newMetadata.uuid();
-        if (currentMetadata != null) {
-          Preconditions.checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),
+        if (currentMetadata != null && currentMetadata.uuid() != null && newUUID != null) {
+          Preconditions.checkState(newUUID.equals(currentMetadata.uuid()),
               "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
         }
 

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -91,7 +91,10 @@ public class JsonUtil {
       return null;
     }
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isTextual(),
+    if (pNode != null && pNode.isNull()) {
+      return null;
+    }
+    Preconditions.checkArgument(pNode != null && pNode.isTextual(),
         "Cannot parse %s from non-string value: %s", property, pNode);
     return pNode.asText();
   }


### PR DESCRIPTION
This fixes two cases when assigning UUIDs to tables without them:
1. If the table is loaded, then assigned a UUID by a concurrent writer
2. If the table is written with a null UUID because no UUID was assigned