### PR TITLE
Fix case sensitivity setting in Spark

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -71,9 +71,9 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
   public DataSourceReader createReader(StructType readSchema, DataSourceOptions options) {
     Configuration conf = new Configuration(lazyBaseConf());
     Table table = getTableAndResolveHadoopConfiguration(options, conf);
-    String caseSensitive = lazySparkSession().conf().get("spark.sql.caseSensitive", "true");
+    String caseSensitive = lazySparkSession().conf().get("spark.sql.caseSensitive");
 
-    Reader reader = new Reader(table, Boolean.valueOf(caseSensitive), options);
+    Reader reader = new Reader(table, Boolean.parseBoolean(caseSensitive), options);
     if (readSchema != null) {
       // convert() will fail if readSchema contains fields not in table.schema()
       SparkSchemaUtil.convert(table.schema(), readSchema);


### PR DESCRIPTION
This fixes the call to detect Spark's case sensitivity. Using `get(property, default)` variant will override the default value of a Spark config with the supplied default. If "spark.sql.caseSensitive" is not set in the conf, then Spark will use its default for case sensitivity (false) but Iceberg would override that default (true).

This also fixes a warning about unnecessary boxing.