### PR TITLE
Add list tables support in Iceberg catalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -26,11 +26,21 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
 
 /**
  * A Catalog API for table create, drop, and load operations.
  */
 public interface Catalog {
+
+  /**
+   * Return all the identifiers under this namespace.
+   *
+   * @param namespace a namespace
+   * @return an array of identifiers for tables
+   * @throws  NotFoundException if the namespace is not found
+   */
+  TableIdentifier[] listTables(Namespace namespace);
 
   /**
    * Create a table.

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.catalog;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -37,10 +38,10 @@ public interface Catalog {
    * Return all the identifiers under this namespace.
    *
    * @param namespace a namespace
-   * @return an array of identifiers for tables
+   * @return a list of identifiers for tables
    * @throws  NotFoundException if the namespace is not found
    */
-  TableIdentifier[] listTables(Namespace namespace);
+  List<TableIdentifier> listTables(Namespace namespace);
 
   /**
    * Create a table.

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -19,11 +19,15 @@
 
 package org.apache.iceberg.hadoop;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreCatalog;
@@ -32,7 +36,9 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 
 /**
@@ -77,6 +83,43 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
   public HadoopCatalog(Configuration conf) {
     this.conf = conf;
     this.warehouseLocation = conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE;
+  }
+
+  @Override
+  public TableIdentifier[] listTables(Namespace namespace) {
+    Preconditions.checkArgument(namespace.levels().length >= 1,
+        "Missing database in table identifier: %s", namespace);
+
+    Joiner slash = Joiner.on("/");
+    Path nsPath = new Path(slash.join(warehouseLocation, slash.join(namespace.levels())));
+    FileSystem fs = Util.getFs(nsPath, conf);
+    Set<TableIdentifier> tblIdents = Sets.newHashSet();
+
+    try {
+      if (!fs.exists(nsPath) || !fs.isDirectory(nsPath)) {
+        throw new NotFoundException("Unknown namespace " + namespace);
+      }
+
+      for (FileStatus s : fs.listStatus(nsPath)) {
+        Path path = s.getPath();
+        if (!fs.isDirectory(path)) {
+          // Ignore the path which is not a directory.
+          continue;
+        }
+
+        Path metadataPath = new Path(path, "metadata");
+        if (fs.exists(metadataPath) && fs.isDirectory(metadataPath)) {
+          // Only the path which contains metadata is the path for table, otherwise it could be
+          // still a namespace.
+          TableIdentifier tblIdent = TableIdentifier.of(namespace, path.getName());
+          tblIdents.add(tblIdent);
+        }
+      }
+    } catch (IOException ioe) {
+      throw new RuntimeException("Failed to list tables under " + namespace, ioe);
+    }
+
+    return tblIdents.toArray(new TableIdentifier[0]);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.hadoop;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
@@ -86,7 +88,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
-  public TableIdentifier[] listTables(Namespace namespace) {
+  public List<TableIdentifier> listTables(Namespace namespace) {
     Preconditions.checkArgument(namespace.levels().length >= 1,
         "Missing database in table identifier: %s", namespace);
 
@@ -119,7 +121,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
       throw new RuntimeException("Failed to list tables under " + namespace, ioe);
     }
 
-    return tblIdents.toArray(new TableIdentifier[0]);
+    return Lists.newArrayList(tblIdents);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -19,12 +19,18 @@
 
 package org.apache.iceberg.hadoop;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -73,5 +79,36 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
           catalog.renameTable(testTable, TableIdentifier.of("db", "tbl2"));
         }
     );
+  }
+
+  @Test
+  public void testListTables() throws Exception {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "tbl1");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns1", "tbl3");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    TableIdentifier[] tbls1 = catalog.listTables(Namespace.of("db"));
+    Set<String> tblSet =
+        Sets.newHashSet(Arrays.stream(tbls1).map(t -> t.name()).toArray(String[]::new));
+    Assert.assertEquals(tblSet.size(), 2);
+    Assert.assertTrue(tblSet.contains("tbl1"));
+    Assert.assertTrue(tblSet.contains("tbl2"));
+
+    TableIdentifier[] tbls2 = catalog.listTables(Namespace.of("db", "ns1"));
+    Assert.assertEquals(tbls2.length, 1);
+    Assert.assertTrue(tbls2[0].name().equals("tbl3"));
+
+    AssertHelpers.assertThrows("should throw exception", NotFoundException.class,
+        "Unknown namespace", () -> {
+        catalog.listTables(Namespace.of("db", "ns1", "ns2"));
+      });
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.hadoop;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -95,16 +95,15 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
         catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
     );
 
-    TableIdentifier[] tbls1 = catalog.listTables(Namespace.of("db"));
-    Set<String> tblSet =
-        Sets.newHashSet(Arrays.stream(tbls1).map(t -> t.name()).toArray(String[]::new));
+    List<TableIdentifier> tbls1 = catalog.listTables(Namespace.of("db"));
+    Set<String> tblSet = Sets.newHashSet(tbls1.stream().map(t -> t.name()).iterator());
     Assert.assertEquals(tblSet.size(), 2);
     Assert.assertTrue(tblSet.contains("tbl1"));
     Assert.assertTrue(tblSet.contains("tbl2"));
 
-    TableIdentifier[] tbls2 = catalog.listTables(Namespace.of("db", "ns1"));
-    Assert.assertEquals(tbls2.length, 1);
-    Assert.assertTrue(tbls2[0].name().equals("tbl3"));
+    List<TableIdentifier> tbls2 = catalog.listTables(Namespace.of("db", "ns1"));
+    Assert.assertEquals(tbls2.size(), 1);
+    Assert.assertTrue(tbls2.get(0).name().equals("tbl3"));
 
     AssertHelpers.assertThrows("should throw exception", NotFoundException.class,
         "Unknown namespace", () -> {

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -25,6 +25,7 @@ import java.io.Closeable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -57,7 +58,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
-  public TableIdentifier[] listTables(Namespace namespace) {
+  public List<TableIdentifier> listTables(Namespace namespace) {
     Preconditions.checkArgument(namespace.levels().length == 1,
         "Missing database in namespace: %s", namespace);
     String database = namespace.level(0);
@@ -66,7 +67,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
       List<String> tables = clients.run(client -> client.getAllTables(database));
       return tables.stream()
           .map(t -> TableIdentifier.of(namespace, t))
-          .toArray(TableIdentifier[]::new);
+          .collect(Collectors.toList());
 
     } catch (UnknownDBException e) {
       throw new NotFoundException(e, "Unknown namespace " + namespace.toString());

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.hive;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -255,12 +254,12 @@ public class HiveTableTest extends HiveTableBaseTest {
 
   @Test
   public void testListTables() {
-    TableIdentifier[] tableIdents = catalog.listTables(TABLE_IDENTIFIER.namespace());
-    TableIdentifier[] expectedIdents = Arrays.stream(tableIdents)
+    List<TableIdentifier> tableIdents = catalog.listTables(TABLE_IDENTIFIER.namespace());
+    List<TableIdentifier> expectedIdents = tableIdents.stream()
         .filter(t -> t.namespace().level(0).equals(DB_NAME) && t.name().equals(TABLE_NAME))
-        .toArray(TableIdentifier[]::new);
+        .collect(Collectors.toList());
 
-    Assert.assertEquals(1, expectedIdents.length);
+    Assert.assertEquals(1, expectedIdents.size());
     Assert.assertTrue(catalog.tableExists(TABLE_IDENTIFIER));
   }
 }

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.hive;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -250,5 +251,16 @@ public class HiveTableTest extends HiveTableBaseTest {
     icebergTable.updateSchema()
         .addColumn("data", Types.LongType.get())
         .commit();
+  }
+
+  @Test
+  public void testListTables() {
+    TableIdentifier[] tableIdents = catalog.listTables(TABLE_IDENTIFIER.namespace());
+    TableIdentifier[] expectedIdents = Arrays.stream(tableIdents)
+        .filter(t -> t.namespace().level(0).equals(DB_NAME) && t.name().equals(TABLE_NAME))
+        .toArray(TableIdentifier[]::new);
+
+    Assert.assertEquals(1, expectedIdents.length);
+    Assert.assertTrue(catalog.tableExists(TABLE_IDENTIFIER));
   }
 }


### PR DESCRIPTION
This address issue #623 , to support Spark DSv2 catalog interface, Iceberg should add a list table API to list all the tables under specific namespace.