### PR TITLE
BaseRewriteManifests should keep different manifest for different partitionSpec

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -57,7 +57,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
       ManifestEntry.Status.EXISTING);
 
   private final TableOperations ops;
-  private final PartitionSpec spec;
+  private final Map<Integer, PartitionSpec> specsById;
   private final long manifestTargetSizeBytes;
 
   private final Set<ManifestFile> deletedManifests = Sets.newHashSet();
@@ -79,7 +79,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   BaseRewriteManifests(TableOperations ops) {
     super(ops);
     this.ops = ops;
-    this.spec = ops.current().spec();
+    this.specsById = ops.current().specsById();
     this.manifestTargetSizeBytes =
       ops.current().propertyAsLong(MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
   }
@@ -139,7 +139,6 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   }
 
   private ManifestFile copyManifest(ManifestFile manifest) {
-    Map<Integer, PartitionSpec> specsById = ops.current().specsById();
     try (ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()), specsById)) {
       OutputFile newFile = manifestPath(manifestSuffix.getAndIncrement());
       return ManifestWriter.copyManifest(reader, newFile, snapshotId(), summaryBuilder, ALLOWED_ENTRY_STATUSES);
@@ -223,7 +222,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
                      ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current().specsById())) {
                 FilteredManifest filteredManifest = reader.select(Arrays.asList("*"));
                 filteredManifest.liveEntries().forEach(
-                    entry -> appendEntry(entry, clusterByFunc.apply(entry.file()))
+                    entry -> appendEntry(entry, clusterByFunc.apply(entry.file()), manifest.partitionSpecId())
                 );
 
               } catch (IOException x) {
@@ -270,12 +269,12 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     return activeFilesCount;
   }
 
-  private void appendEntry(ManifestEntry entry, Object key) {
+  private void appendEntry(ManifestEntry entry, Object key, int partitionSpecId) {
     Preconditions.checkNotNull(entry, "Manifest entry cannot be null");
     Preconditions.checkNotNull(key, "Key cannot be null");
 
     WriterWrapper writer = getWriter(key);
-    writer.addEntry(entry);
+    writer.addEntry(entry, partitionSpecId);
     entryCount.incrementAndGet();
   }
 
@@ -312,29 +311,52 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   }
 
   class WriterWrapper {
-    private ManifestWriter writer;
+    private final Map<Integer, ManifestWriter> manifestWritersBySpecId = Collections.synchronizedMap(new HashMap<>());
 
-    synchronized void addEntry(ManifestEntry entry) {
-      if (writer == null) {
-        writer = newWriter();
-      } else if (writer.length() >= getManifestTargetSizeBytes()) {
-        close();
-        writer = newWriter();
+    synchronized void addEntry(ManifestEntry entry, int partitionSpecId) {
+      ManifestWriter manifestWriter = manifestWritersBySpecId.get(partitionSpecId);
+      if (manifestWriter == null) {
+        manifestWriter = newWriter(partitionSpecId);
+      } else if (manifestWriter.length() >= getManifestTargetSizeBytes()) {
+        close(partitionSpecId);
+        manifestWriter = newWriter(partitionSpecId);
       }
-      writer.existing(entry);
+      manifestWriter.existing(entry);
     }
 
-    private ManifestWriter newWriter() {
-      return new ManifestWriter(spec, manifestPath(manifestSuffix.getAndIncrement()), snapshotId());
+    private ManifestWriter newWriter(int partitionSpecId) {
+      // create ManifestWriter with the correct partitionSpec
+      ManifestWriter manifestWriter = new ManifestWriter(specsById.get(partitionSpecId),
+          manifestPath(manifestSuffix.getAndIncrement()),
+          snapshotId());
+      manifestWritersBySpecId.put(partitionSpecId, manifestWriter);
+      return manifestWriter;
+    }
+
+    synchronized void close(int partitionSpecId) {
+      if (manifestWritersBySpecId != null) {
+        try {
+          ManifestWriter manifestWriter = manifestWritersBySpecId.get(partitionSpecId);
+          manifestWriter.close();
+          newManifests.add(manifestWriter.toManifestFile());
+          // remove so that we will not get the closed one again.
+          manifestWritersBySpecId.remove(partitionSpecId);
+        } catch (IOException x) {
+          throw new RuntimeIOException(x);
+        }
+      }
     }
 
     synchronized void close() {
-      if (writer != null) {
-        try {
-          writer.close();
-          newManifests.add(writer.toManifestFile());
-        } catch (IOException x) {
-          throw new RuntimeIOException(x);
+      if (manifestWritersBySpecId != null && manifestWritersBySpecId.size() > 0) {
+        // close all the manifestWriters belongs to writterWrapper
+        for (ManifestWriter manifestWriter : manifestWritersBySpecId.values()) {
+          try {
+            manifestWriter.close();
+            newManifests.add(manifestWriter.toManifestFile());
+          } catch (IOException x) {
+            throw new RuntimeIOException(x);
+          }
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -325,10 +325,16 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     }
 
     private ManifestWriter newWriter(int partitionSpecId) {
+
+      if (manifestWritersBySpecId.containsKey(partitionSpecId)) {
+        // should not reach here, but checking to avoid resource leak.
+        throw new RuntimeException("ManifestWriter already exists for this partition-specId " + partitionSpecId);
+      }
+
       // create ManifestWriter with the correct partitionSpec
-      ManifestWriter manifestWriter = new ManifestWriter(specsById.get(partitionSpecId),
-          manifestPath(manifestSuffix.getAndIncrement()),
-          snapshotId());
+      PartitionSpec partitionSpec = specsById.get(partitionSpecId);
+      OutputFile outputFile = manifestPath(manifestSuffix.getAndIncrement());
+      ManifestWriter manifestWriter = new ManifestWriter(partitionSpec, outputFile, snapshotId());
       manifestWritersBySpecId.put(partitionSpecId, manifestWriter);
       return manifestWriter;
     }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -393,6 +393,149 @@ public class TestRewriteManifests extends TableTestBase {
   }
 
   @Test
+  public void testWithMultiplePartitionSpec() throws IOException {
+    Assert.assertNull("Table should be empty", table.currentSnapshot());
+
+    table.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    TableMetadata base = readMetadata();
+    Assert.assertEquals("Should create 1 manifest for initial write",
+        1, base.currentSnapshot().manifests().size());
+    ManifestFile initialManifest = base.currentSnapshot().manifests().get(0);
+
+    int initialPartitionSpecId = initialManifest.partitionSpecId();
+
+    // build the new spec using the table's schema, which uses fresh IDs
+    PartitionSpec newSpec = PartitionSpec.builderFor(base.schema())
+        .bucket("data", 16)
+        .bucket("id", 4)
+        .build();
+
+    // commit the new partition spec to the table manually
+    table.ops().commit(base, base.updatePartitionSpec(newSpec));
+
+    DataFile newFileC = DataFiles.builder(newSpec)
+        .copy(FILE_C)
+        .withPartitionPath("data_bucket=2/id_bucket=3")
+        .build();
+
+    table.newAppend()
+        .appendFile(newFileC)
+        .commit();
+
+    DataFile newFileD = DataFiles.builder(newSpec)
+        .copy(FILE_D)
+        .withPartitionPath("data_bucket=2/id_bucket=4")
+        .build();
+
+    table.newAppend()
+        .appendFile(newFileD)
+        .commit();
+
+    Assert.assertEquals("Should use 3 manifest files",
+        3, table.currentSnapshot().manifests().size());
+
+    RewriteManifests rewriteManifests = table.rewriteManifests();
+    // try to cluster in 1 manifest file, but because of 2 partition specs
+    // we should still have 2 manifest files.
+    rewriteManifests.clusterBy(dataFile -> "file").commit();
+    List<ManifestFile> manifestFiles = table.currentSnapshot().manifests();
+
+    Assert.assertEquals("Rewrite manifest should produce 2 manifest files",
+        2, manifestFiles.size());
+
+    Assert.assertEquals("2 manifest files should have different partitionSpecId",
+        true, manifestFiles.get(0).partitionSpecId() != manifestFiles.get(1).partitionSpecId());
+
+    matchNumberOfManifestFileWithSpecId(manifestFiles, initialPartitionSpecId, 1);
+
+    matchNumberOfManifestFileWithSpecId(manifestFiles, table.ops().current().spec().specId(), 1);
+
+    Assert.assertEquals("first manifest file should have 2 data files",
+        Integer.valueOf(2), manifestFiles.get(0).existingFilesCount());
+
+    Assert.assertEquals("second manifest file should have 2 data files",
+        Integer.valueOf(2), manifestFiles.get(1).existingFilesCount());
+
+  }
+
+  @Test
+  public void testManifestSizeWithMultiplePartitionSpec() throws IOException {
+    Assert.assertNull("Table should be empty", table.currentSnapshot());
+
+    table.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    TableMetadata base = readMetadata();
+    Assert.assertEquals("Should create 1 manifest for initial write",
+        1, base.currentSnapshot().manifests().size());
+    ManifestFile initialManifest = base.currentSnapshot().manifests().get(0);
+    int initialPartitionSpecId = initialManifest.partitionSpecId();
+
+    // build the new spec using the table's schema, which uses fresh IDs
+    PartitionSpec newSpec = PartitionSpec.builderFor(base.schema())
+        .bucket("data", 16)
+        .bucket("id", 4)
+        .build();
+
+    // commit the new partition spec to the table manually
+    table.ops().commit(base, base.updatePartitionSpec(newSpec));
+
+    DataFile newFileC = DataFiles.builder(newSpec)
+        .copy(FILE_C)
+        .withPartitionPath("data_bucket=2/id_bucket=3")
+        .build();
+
+    table.newAppend()
+        .appendFile(newFileC)
+        .commit();
+
+    DataFile newFileD = DataFiles.builder(newSpec)
+        .copy(FILE_D)
+        .withPartitionPath("data_bucket=2/id_bucket=4")
+        .build();
+
+    table.newAppend()
+        .appendFile(newFileD)
+        .commit();
+
+    Assert.assertEquals("Rewrite manifests should produce 3 manifest files",
+        3, table.currentSnapshot().manifests().size());
+
+    // cluster by constant will combine manifests into one but small target size will create one per entry
+    BaseRewriteManifests rewriteManifests = spy((BaseRewriteManifests) table.rewriteManifests());
+    when(rewriteManifests.getManifestTargetSizeBytes()).thenReturn(1L);
+
+    // rewriteManifests should produce 4 manifestFiles, because of targetByteSize=1
+    rewriteManifests.clusterBy(dataFile -> "file").commit();
+    List<ManifestFile> manifestFiles = table.currentSnapshot().manifests();
+
+    Assert.assertEquals("Should use 4 manifest files",
+        4, manifestFiles.size());
+
+    matchNumberOfManifestFileWithSpecId(manifestFiles, initialPartitionSpecId, 2);
+
+    matchNumberOfManifestFileWithSpecId(manifestFiles, table.ops().current().spec().specId(), 2);
+
+    Assert.assertEquals("first manifest file should have 1 data files",
+        Integer.valueOf(1), manifestFiles.get(0).existingFilesCount());
+
+    Assert.assertEquals("second manifest file should have 1 data files",
+        Integer.valueOf(1), manifestFiles.get(1).existingFilesCount());
+
+    Assert.assertEquals("third manifest file should have 1 data files",
+        Integer.valueOf(1), manifestFiles.get(2).existingFilesCount());
+
+    Assert.assertEquals("fourth manifest file should have 1 data files",
+        Integer.valueOf(1), manifestFiles.get(3).existingFilesCount());
+  }
+
+  @Test
   public void testManifestReplacementConcurrentAppend() throws IOException {
     Assert.assertNull("Table should be empty", table.currentSnapshot());
 
@@ -742,5 +885,15 @@ public class TestRewriteManifests extends TableTestBase {
     Assert.assertEquals(
         "Entry count should match",
         entryCount, Integer.parseInt(summary.get("entries-processed")));
+  }
+
+  private void matchNumberOfManifestFileWithSpecId(List<ManifestFile> manifestFiles, int toBeMatchedPartitionSpecId,
+                                                   int numberOfManifestWithPartitionSpecID) {
+    long matchedManifestsCounter = manifestFiles.stream()
+        .filter(m -> m.partitionSpecId() == toBeMatchedPartitionSpecId).count();
+
+    Assert.assertEquals("manifest list should have " + numberOfManifestWithPartitionSpecID +
+            " manifests matching this partitionSpecId " + toBeMatchedPartitionSpecId,
+        numberOfManifestWithPartitionSpecID, matchedManifestsCounter);
   }
 }


### PR DESCRIPTION
trying to fix [issue](https://github.com/apache/incubator-iceberg/issues/480)

approach: Currently each WrapperWriter object is maintained per `clusterFunction.apply()` output.
this change will keep a `Map<PartitionSpecID, ManifestWriter>` with each `WritterWrapper` Object, so that it can write different manifest file for different `partitionSpecId`

@aokolnychyi can you please review this, thanks.