### PR TITLE
[WIP] [ISSUE #672] Add namespace metadata 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
@@ -20,7 +20,12 @@
 package org.apache.iceberg.catalog;
 
 import com.google.common.base.Joiner;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 
 /**
  * A namespace in a {@link Catalog}.
@@ -59,6 +64,72 @@ public class Namespace {
     return levels.length == 0;
   }
 
+  private String uuid;
+
+  public void setUuid(String uuid) {
+    this.uuid = uuid;
+  }
+
+  public String getUuid() {
+    return this.uuid;
+  }
+
+  private String location;
+
+  public void setLocation(String location) {
+    this.location = location;
+  }
+
+  public String getLocation() {
+    return this.location;
+  }
+
+  private long timestampMillis;
+
+  public void setTimestampMillis(Long timestampMillis) {
+    this.timestampMillis = timestampMillis;
+  }
+
+  public Long getTimestampMillis() {
+    return this.timestampMillis;
+  }
+
+  private Map<String, String> properties = new HashMap<>();
+
+  public void setProperties(String key, String value) {
+    this.properties.put(key, value);
+  }
+
+  public Map<String, String> getProperties() {
+    return this.properties;
+  }
+
+  public String getProperties(String key) {
+    return this.properties.get(key);
+  }
+
+  public boolean hasProperties(String key) {
+    return this.properties.containsKey(key);
+  }
+
+  private  List<String> tables = new ArrayList<>();
+
+  public void addTables(String tableName) {
+    this.tables.add(tableName);
+  }
+
+  public void deletTables(String tableName) {
+    this.tables.remove(tableName);
+  }
+
+  public void setTables(List<String> tableList) {
+    this.tables.addAll(tableList);
+  }
+
+  public List<String> getTables() {
+    return this.tables;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {
@@ -82,4 +153,5 @@ public class Namespace {
   public String toString() {
     return DOT.join(levels);
   }
+
 }

--- a/core/src/main/java/org/apache/iceberg/NamespaceMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/NamespaceMetadata.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.io.InputFile;
+
+public class NamespaceMetadata {
+  static final int NAMESPACE_FORMAT_VERSION = 1;
+
+  public static NamespaceMetadata newNamespaceMetadata(String location, Namespace namespace) {
+
+    return new NamespaceMetadata(null, UUID.randomUUID().toString(), location,
+        System.currentTimeMillis(), ImmutableList.of(namespace));
+  }
+
+
+  private final InputFile file;
+  // stored metadata
+  private final String uuid;
+  private final String location;
+  private final long lastUpdatedMillis;
+  private List<Namespace> namespaces;
+
+  NamespaceMetadata(InputFile file,
+                     String uuid,
+                     String location,
+                     long lastUpdatedMillis,
+                     List<Namespace> namespaces) {
+
+    this.file = file;
+    this.uuid = uuid;
+    this.location = location;
+    this.lastUpdatedMillis = lastUpdatedMillis;
+    this.namespaces = namespaces;
+  }
+
+  public InputFile file() {
+    return file;
+  }
+
+  public String uuid() {
+    return uuid;
+  }
+
+  public long lastUpdatedMillis() {
+    return lastUpdatedMillis;
+  }
+
+  public String location() {
+    return location;
+  }
+
+  public List<Namespace> namespaces() {
+    return namespaces;
+  }
+
+  public void addNamespace(List<Namespace> baseSpace) {
+    baseSpace.addAll(this.namespaces);
+    this.namespaces =  baseSpace;
+  }
+
+  public void replaceNamespace(List<Namespace> baseSpace) {
+    String name = this.namespaces().get(0).toString();
+    for (int i = baseSpace.size() - 1; i >= 0; i--) {
+      Namespace item = baseSpace.get(i);
+      if (item.toString().equals(name)) {
+        baseSpace.remove(item);
+      }
+    }
+    baseSpace.addAll(this.namespaces);
+    this.namespaces = baseSpace;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/NamespaceMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/NamespaceMetadataParser.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.util.JsonUtil;
+
+
+public class NamespaceMetadataParser {
+  public enum Codec {
+    NONE(""),
+    GZIP(".gz");
+
+    private final String extension;
+
+    Codec(String extension) {
+      this.extension = extension;
+    }
+
+    public static NamespaceMetadataParser.Codec fromName(String codecName) {
+      Preconditions.checkArgument(codecName != null, "Codec name is null");
+      return NamespaceMetadataParser.Codec.valueOf(codecName.toUpperCase(Locale.ENGLISH));
+    }
+
+    public static NamespaceMetadataParser.Codec fromFileName(String fileName) {
+      Preconditions.checkArgument(fileName.contains(".namespace_metadata.json"),
+          "%s is not a valid metadata file", fileName);
+      // we have to be backward-compatible with .metadata.json.gz files
+      if (fileName.endsWith(".namespace_metadata.json.gz")) {
+        return NamespaceMetadataParser.Codec.GZIP;
+      }
+      String fileNameWithoutSuffix = fileName.substring(0, fileName.lastIndexOf(".namespace_metadata.json"));
+      if (fileNameWithoutSuffix.endsWith(NamespaceMetadataParser.Codec.GZIP.extension)) {
+        return NamespaceMetadataParser.Codec.GZIP;
+      } else {
+        return NamespaceMetadataParser.Codec.NONE;
+      }
+    }
+  }
+
+  private NamespaceMetadataParser(){}
+
+  // visible for testing
+  private static final String FORMAT_VERSION = "format-version";
+  private static final String UUID = "uuid";
+  private static final String LOCATION = "location";
+  private static final String LAST_UPDATED_MILLIS = "last-updated-ms";
+  private static final String NAMESPACES = "namespaces";
+
+
+  public static void overwrite(NamespaceMetadata metadata, OutputFile outputFile) {
+    internalWrite(metadata, outputFile, true);
+  }
+
+  public static void write(NamespaceMetadata metadata, OutputFile outputFile) {
+    internalWrite(metadata, outputFile, false);
+  }
+
+  private  static void internalWrite(
+      NamespaceMetadata metadata, OutputFile outputFile, boolean overwrite) {
+    boolean isGzip = NamespaceMetadataParser.Codec.fromFileName(
+        outputFile.location()) == NamespaceMetadataParser.Codec.GZIP;
+    OutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
+    try (OutputStreamWriter writer = new OutputStreamWriter(isGzip ? new GZIPOutputStream(stream) : stream)) {
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      generator.useDefaultPrettyPrinter();
+      toJson(metadata, generator);
+      generator.flush();
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile);
+    }
+  }
+
+  public static String getFileExtension(Codec codec) {
+    return codec.extension + ".namespace_metadata.json";
+  }
+
+  public static String getOldFileExtension(Codec codec) {
+    // we have to be backward-compatible with .metadata.json.gz files
+    return ".namespace_metadata.json" + codec.extension;
+  }
+
+
+  public static String toJson(NamespaceMetadata metadata) {
+    StringWriter writer = new StringWriter();
+    try {
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      toJson(metadata, generator);
+      generator.flush();
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to write json for: %s", metadata);
+    }
+    return writer.toString();
+  }
+
+  private static void toJson(NamespaceMetadata metadata, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+
+    generator.writeNumberField(FORMAT_VERSION, NamespaceMetadata.NAMESPACE_FORMAT_VERSION);
+    generator.writeStringField(UUID, metadata.uuid());
+    generator.writeStringField(LOCATION, metadata.location());
+    generator.writeNumberField(LAST_UPDATED_MILLIS, metadata.lastUpdatedMillis());
+    generator.writeArrayFieldStart(NAMESPACES);
+    for (Namespace namespace : metadata.namespaces()) {
+      namespace.setTimestampMillis(metadata.lastUpdatedMillis());
+      NamespaceParser.toJson(namespace, generator);
+    }
+    generator.writeEndArray();
+    generator.writeEndObject();
+
+  }
+
+  public static NamespaceMetadata read(FileIO io, InputFile file) {
+    Codec codec = Codec.fromFileName(file.location());
+    try (InputStream is = codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {
+      return fromJson(io, file, JsonUtil.mapper().readValue(is, JsonNode.class));
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to read file: %s", file);
+    }
+  }
+
+  private static NamespaceMetadata fromJson(FileIO io, InputFile file, JsonNode node) {
+    Preconditions.checkArgument(node.isObject(),
+        "Cannot parse metadata from a non-object: %s", node);
+
+    int formatVersion = JsonUtil.getInt(FORMAT_VERSION, node);
+    Preconditions.checkArgument(formatVersion == NamespaceMetadata.NAMESPACE_FORMAT_VERSION,
+        "Cannot read unsupported version %s", formatVersion);
+
+    String uuid = JsonUtil.getStringOrNull(UUID, node);
+    String location = JsonUtil.getString(LOCATION, node);
+    long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
+
+
+    JsonNode namespaceArray = node.get(NAMESPACES);
+    Preconditions.checkArgument(namespaceArray.isArray(),
+        "Cannot parse snapshots from non-array: %s", namespaceArray);
+
+    List<Namespace> namespaces = Lists.newArrayListWithExpectedSize(namespaceArray.size());
+    Iterator<JsonNode> iterator = namespaceArray.elements();
+    while (iterator.hasNext()) {
+      namespaces.add(NamespaceParser.fromJson(io, iterator.next()));
+    }
+    return new NamespaceMetadata(file, uuid, location, lastUpdatedMillis, namespaces);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/NamespaceParser.java
+++ b/core/src/main/java/org/apache/iceberg/NamespaceParser.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.util.JsonUtil;
+
+
+class NamespaceParser {
+  private NamespaceParser() {}
+
+  private static final String NAMESPACE = "namespace";
+  private static final String LAST_UPDATED_MILLIS = "last-updated-ms";
+  private static final String TABLES = "tables";
+  private static final String PROPERTIES = "properties";
+
+  static void toJson(Namespace namespace, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeStringField(NAMESPACE, namespace.toString());
+    generator.writeNumberField(LAST_UPDATED_MILLIS, namespace.getTimestampMillis());
+    generator.writeArrayFieldStart(TABLES);
+    for (String table : namespace.getTables()) {
+      generator.writeString(table);
+    }
+    generator.writeEndArray();
+
+    generator.writeObjectFieldStart(PROPERTIES);
+    if (namespace.getProperties() != null) {
+      namespace.getProperties().forEach((key, value) -> {
+        try {
+          generator.writeStringField(key, value);
+        } catch (IOException e) {
+          throw new RuntimeIOException(e, "Failed to write json for: %s", e.getMessage());
+        }
+      });
+    }
+    generator.writeEndObject();
+    generator.writeEndObject();
+  }
+
+  static Namespace fromJson(FileIO io, JsonNode node) {
+    Preconditions.checkArgument(node.isObject(),
+        "Cannot parse table version from a non-object: %s", node);
+    String namespace = JsonUtil.getString(NAMESPACE, node);
+    List<String> tableList = JsonUtil.getStringList(TABLES, node);
+    long lastUpdatetime = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
+    Map<String, String> properties = JsonUtil.getStringMap(PROPERTIES, node);
+
+    Namespace space = Namespace.of(namespace);
+    tableList.forEach(space::addTables);
+    space.setTimestampMillis(lastUpdatetime);
+    properties.forEach(space::setProperties);
+    return space;
+  }
+
+}

--- a/core/src/test/java/org/apache/iceberg/NamespaceMetadataParserCodecTest.java
+++ b/core/src/test/java/org/apache/iceberg/NamespaceMetadataParserCodecTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class NamespaceMetadataParserCodecTest {
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void testCompressionCodec() {
+    Assert.assertEquals(NamespaceMetadataParser.Codec.GZIP,
+        NamespaceMetadataParser.Codec.fromName("gzip"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.GZIP,
+        NamespaceMetadataParser.Codec.fromName("gZiP"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.GZIP,
+        NamespaceMetadataParser.Codec.fromFileName("v3.gz.namespace_metadata.json"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.GZIP,
+        NamespaceMetadataParser.Codec.fromFileName("v3-f326-4b66-a541-7b1c.gz.namespace_metadata.json"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.GZIP,
+        NamespaceMetadataParser.Codec.fromFileName("v3-f326-4b66-a541-7b1c.namespace_metadata.json.gz"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.NONE,
+        NamespaceMetadataParser.Codec.fromName("none"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.NONE,
+        NamespaceMetadataParser.Codec.fromName("nOnE"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.NONE,
+        NamespaceMetadataParser.Codec.fromFileName("v3.namespace_metadata.json"));
+    Assert.assertEquals(NamespaceMetadataParser.Codec.NONE,
+        NamespaceMetadataParser.Codec.fromFileName("v3-f326-4b66-a541-7b1c.namespace_metadata.json"));
+  }
+
+  @Test
+  public void testInvalidCodecName() {
+    exceptionRule.expect(IllegalArgumentException.class);
+    exceptionRule.expectMessage("No enum constant");
+    NamespaceMetadataParser.Codec.fromName("invalid");
+  }
+
+  @Test
+  public void testInvalidFileName() {
+    exceptionRule.expect(IllegalArgumentException.class);
+    exceptionRule.expectMessage("path/to/file.parquet is not a valid metadata file");
+    NamespaceMetadataParser.Codec.fromFileName("path/to/file.parquet");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/NamespaceMetadataParserTest.java
+++ b/core/src/test/java/org/apache/iceberg/NamespaceMetadataParserTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipException;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.io.OutputFile;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith(Parameterized.class)
+public class NamespaceMetadataParserTest {
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { "none" },
+        new Object[] { "gzip" }
+    };
+  }
+
+  private final String codecName;
+
+  public NamespaceMetadataParserTest(String codecName) {
+    this.codecName = codecName;
+  }
+
+  @Test
+  public void testCompressionProperty() throws IOException {
+    NamespaceMetadataParser.Codec codec = NamespaceMetadataParser.Codec.fromName(codecName);
+    String fileExtension = NamespaceMetadataParser.getFileExtension(codec);
+    String fileName = "v3" + fileExtension;
+    OutputFile outputFile = Files.localOutput(fileName);
+
+    String location = "file://tmp/db/";
+    Namespace namespace = Namespace.of("n1", "n2", "n3");
+    namespace.setProperties(TableProperties.METADATA_COMPRESSION, codecName);
+    namespace.setProperties("owner", "apache");
+    namespace.addTables("table1");
+    namespace.addTables("table2");
+    NamespaceMetadata metadata = NamespaceMetadata.newNamespaceMetadata(location, namespace);
+    NamespaceMetadataParser.write(metadata, outputFile);
+    Assert.assertEquals(codec == NamespaceMetadataParser.Codec.GZIP, isCompressed(fileName));
+    NamespaceMetadata actualMetadata = NamespaceMetadataParser.read(null, Files.localInput(new File(fileName)));
+    verifyMetadata(metadata, actualMetadata);
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    NamespaceMetadataParser.Codec codec = NamespaceMetadataParser.Codec.fromName(codecName);
+    Path metadataFilePath = Paths.get("v3" + NamespaceMetadataParser.getFileExtension(codec));
+    java.nio.file.Files.deleteIfExists(metadataFilePath);
+  }
+
+  private void verifyMetadata(NamespaceMetadata expected, NamespaceMetadata actual) {
+    Assert.assertEquals(expected.location(), actual.location());
+    Assert.assertEquals(expected.uuid(), actual.uuid());
+  }
+
+  private boolean isCompressed(String path) throws IOException {
+    try (InputStream ignored = new GZIPInputStream(new FileInputStream(new File(path)))) {
+      return true;
+    } catch (ZipException e) {
+      if (e.getMessage().equals("Not in GZIP format")) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Create a namespace metadata file  and save it into** _${WAREHOUSE_BASE}/namespace_metadata_  
**Then :** 
1. The commands of `list namespace` or `list table` read the namespace metadata file. Reading from the file could have better performance than listing directories on file system, especially  on Object Store, like S3。
2. Move the functions of namespace manager out of catalog. Hive catalog could also take advantage of the namespace manager to support multi-part namespace, to meet the requirement of multi-part namespace in Spark.
3. It could help to manage the Iceberg tables and namespaces without the help from a center meta store service like Hive MetaStore.
 
**TODO: To guarantee the atomicity of create/drop table,  which includes the operations on both 'metadata.json' and 'namespace_metadata.json'**

The followings demonstrate the content of 'namespace_metadata.json'
```
{
  "format-version" : 1,
  "uuid" : "628e40f3-93dc-4b4f-bd00-dee78d7073d1",
  "location" : "/data/tmp/namespace_metadata",
  "last-updated-ms" : 1575278464343,
  "namespaces" : [
                   {
                      "namespace" : "default",
                       "last-updated-ms" : 1575278464343,
                       "tables" : ["tbl1", "tbl2" ],
                       "properties" : { 
                          "owner" : "apache" 
                        }
                   }, 
                   {
                         "namespace" : "db.n2.n3",
                          "last-updated-ms" : 1575278464343,
                          "tables" : [ ],
                          "properties" : { }
                   } 
    ]
}
```

@rdblue 
