### PR TITLE
Add quick build option to disable checkstyle and error-prone

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -32,8 +32,10 @@ subprojects {
   // Thus we concede to applying all of the Baseline plugins individually on all the projects we are
   // ready to enforce linting on.
   apply plugin: 'org.inferred.processors'
-  apply plugin: 'com.palantir.baseline-checkstyle'
-  apply plugin: 'com.palantir.baseline-error-prone'
+  if (!project.hasProperty('quick')) {
+    apply plugin: 'com.palantir.baseline-checkstyle'
+    apply plugin: 'com.palantir.baseline-error-prone'
+  }
   apply plugin: 'com.palantir.baseline-scalastyle'
   apply plugin: 'com.palantir.baseline-class-uniqueness'
   apply plugin: 'com.palantir.baseline-reproducibility'
@@ -58,21 +60,23 @@ subprojects {
     }
   }
 
-  tasks.withType(JavaCompile).configureEach {
-    options.errorprone.errorproneArgs += [
-        // error-prone is slow, don't run on tests
-        '-XepExcludedPaths:.*/test/.*',
-        // specific to Palantir
-        '-Xep:PreferSafeLoggingPreconditions:OFF',
-        '-Xep:PreferSafeLoggableExceptions:OFF',
-        '-Xep:Slf4jLogsafeArgs:OFF',
-        // subclasses are not equal
-        '-Xep:EqualsGetClass:OFF',
-        // patterns that are allowed
-        '-Xep:SwitchStatementDefaultCase:OFF',
-        '-Xep:MissingCasesInEnumSwitch:OFF',
-        '-Xep:TypeParameterShadowing:OFF',
-        '-Xep:TypeParameterUnusedInFormals:OFF',
-      ]
+  pluginManager.withPlugin('com.palantir.baseline-error-prone') {
+    tasks.withType(JavaCompile).configureEach {
+      options.errorprone.errorproneArgs += [
+          // error-prone is slow, don't run on tests
+          '-XepExcludedPaths:.*/test/.*',
+          // specific to Palantir
+          '-Xep:PreferSafeLoggingPreconditions:OFF',
+          '-Xep:PreferSafeLoggableExceptions:OFF',
+          '-Xep:Slf4jLogsafeArgs:OFF',
+          // subclasses are not equal
+          '-Xep:EqualsGetClass:OFF',
+          // patterns that are allowed
+          '-Xep:SwitchStatementDefaultCase:OFF',
+          '-Xep:MissingCasesInEnumSwitch:OFF',
+          '-Xep:TypeParameterShadowing:OFF',
+          '-Xep:TypeParameterUnusedInFormals:OFF',
+        ]
+    }
   }
 }

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -32,7 +32,9 @@ configure(jmhProjects) {
   }
 
   jmhCompileGeneratedClasses {
-    options.errorprone.enabled = false
+    pluginManager.withPlugin('com.palantir.baseline-error-prone') {
+      options.errorprone.enabled = false
+    }
   }
 }
 


### PR DESCRIPTION
Checkstyle and error-prone run by baseline take a significant amount of time and are run even if there are no changes in an incremental build. This makes iterating on code more time consuming because static analysis is run on all modules.

This PR adds a "quick" property to disable checkstyle and error-prone. This can be set in an IDE so that running individual test cases is quick for mostly incremental builds. By default, this is disabled so that CI still runs the checks.