### PR TITLE
[ISSUE  #672] Add SupportsNamespaces for 'HadoopCatalog' and 'HiveCatalog'

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -305,16 +305,57 @@ public interface Catalog {
    */
   Table loadTable(TableIdentifier identifier);
 
+
+  /**
+   * Create a namespace in the catalog.
+   *
+   * @param namespace {@link Namespace}.
+   */
   boolean createNamespace(Namespace namespace);
 
+  /**
+   * List top-level namespaces from the catalog.
+   * <p>
+   * If an object such as a table, view, or function exists, its parent namespaces must also exist
+   * and must be returned by this discovery method. For example, if table a.b.t exists, this method
+   * must return ["a"] in the result array.
+   *
+   * @return an List of namespace {@link Namespace} names
+   */
   List<Namespace> listNamespaces();
 
+  /**
+   * List  namespaces from the namespace.
+   * <p>
+   * For example, if table a.b.t exists, use 'SELECT NAMESPACE IN a' this method
+   * must return Namepace.of("b") {@link Namespace}.
+   *
+   * @return an List of namespace {@link Namespace} names
+   */
   List<Namespace> listNamespaces(Namespace namespace);
 
+  /**
+   * Load metadata properties for a namespace.
+   *
+   * @param namespace a Namespace.of(name) {@link Namespace}
+   * @return a string map of properties for the given namespace
+   */
   Map<String, String>  loadNamespaceMetadata(Namespace namespace);
 
+  /**
+   * Load metadata properties for a namespace.
+   *
+   * @param namespace a Namespace.of(name) {@link Namespace}
+   * @return true while drop success.
+   */
   boolean dropNamespace(Namespace namespace) throws IOException;
 
-  boolean alterNamespace(Namespace current, Namespace namespace);
+  /**
+   * Load metadata properties for a namespace.
+   *
+   * @param namespace a Namespace.of(name) {@link Namespace}
+   * @return true while alter success.
+   */
+  boolean alterNamespace(Namespace namespace);
 
 }

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.catalog;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
@@ -303,4 +304,17 @@ public interface Catalog {
    * @throws NoSuchTableException if the table does not exist
    */
   Table loadTable(TableIdentifier identifier);
+
+  boolean createNamespace(Namespace namespace);
+
+  List<Namespace> listNamespaces();
+
+  List<Namespace> listNamespaces(Namespace namespace);
+
+  Map<String, String>  loadNamespaceMetadata(Namespace namespace);
+
+  boolean dropNamespace(Namespace namespace) throws IOException;
+
+  boolean alterNamespace(Namespace current, Namespace namespace);
+
 }

--- a/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.catalog;
 
 import com.google.common.base.Joiner;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A namespace in a {@link Catalog}.
@@ -45,6 +47,20 @@ public class Namespace {
 
   private Namespace(String[] levels) {
     this.levels = levels;
+  }
+
+  private  Map<String, String> parameters = new HashMap<>();
+
+  public void setParameters(String key, String value) {
+    parameters.put(key, value);
+  }
+
+  public Map<String, String> getParameters() {
+    return parameters;
+  }
+
+  public String getParameters(String key) {
+    return parameters.get(key);
   }
 
   public String[] levels() {

--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -48,6 +48,7 @@ public interface FileIO extends Serializable {
   /**
    * Convenience method to {@link #deleteFile(String) delete} an {@link InputFile}.
    */
+
   default void deleteFile(InputFile file) {
     deleteFile(file.location());
   }
@@ -58,4 +59,11 @@ public interface FileIO extends Serializable {
   default void deleteFile(OutputFile file) {
     deleteFile(file.location());
   }
+
+  /**
+   * make a path on file system
+   * @return
+   */
+  boolean mkdir(String path);
+
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -26,9 +26,11 @@ import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -142,6 +144,31 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       throw new NoSuchTableException("Invalid table identifier: %s", identifier);
     }
   }
+
+  public boolean createNamespace(Namespace namespace) {
+    return false;
+  }
+
+  public List<Namespace> listNamespaces() {
+    return null;
+  }
+
+  public List<Namespace> listNamespaces(Namespace namespace) {
+    return null;
+  }
+
+  public Map<String, String>  loadNamespaceMetadata(Namespace namespace) {
+    return null;
+  }
+
+  public boolean dropNamespace(Namespace namespace) {
+    return false;
+  }
+
+  public boolean alterNamespace(Namespace current, Namespace namespace) {
+    return false;
+  }
+
 
   private Table loadMetadataTable(TableIdentifier identifier) {
     String name = identifier.name();

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -165,7 +165,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     return false;
   }
 
-  public boolean alterNamespace(Namespace current, Namespace namespace) {
+  public boolean alterNamespace(Namespace namespace) {
     return false;
   }
 

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -57,6 +57,36 @@ public class CachingCatalog implements Catalog {
   }
 
   @Override
+  public boolean createNamespace(Namespace namespace) {
+    return false;
+  }
+
+  @Override
+  public List<Namespace> listNamespaces() {
+    return null;
+  }
+
+  @Override
+  public List<Namespace> listNamespaces(Namespace namespace) {
+    return null;
+  }
+
+  @Override
+  public Map<String, String>  loadNamespaceMetadata(Namespace namespace) {
+    return null;
+  }
+
+  @Override
+  public boolean dropNamespace(Namespace namespace) {
+    return false;
+  }
+
+  @Override
+  public boolean alterNamespace(Namespace current, Namespace namespace) {
+    return false;
+  }
+
+  @Override
   public Table createTable(TableIdentifier ident, Schema schema, PartitionSpec spec, String location,
                            Map<String, String> properties) {
     AtomicBoolean created = new AtomicBoolean(false);

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -82,7 +82,7 @@ public class CachingCatalog implements Catalog {
   }
 
   @Override
-  public boolean alterNamespace(Namespace current, Namespace namespace) {
+  public boolean alterNamespace(Namespace namespace) {
     return false;
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -205,7 +205,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
 
   @Override
   public boolean createNamespace(Namespace namespace) {
-    Preconditions.checkArgument(namespace.isEmpty(), "Your Namespace must be not empty!");
+    Preconditions.checkArgument(!namespace.isEmpty(), "Your Namespace must be not empty!");
     Joiner slash = Joiner.on("/");
     Path nsPath = new Path(slash.join(warehouseLocation, slash.join(namespace.levels())));
     return io().mkdir(nsPath.toString());
@@ -326,8 +326,8 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
-  public boolean alterNamespace(Namespace current, Namespace namespace) {
-    throw new UnsupportedOperationException("Cannot alter Namespaces for Hadoop tables");
+  public boolean alterNamespace(Namespace namespace) {
+    throw new UnsupportedOperationException("Cannot alter Namespaces for Hadoop namespace");
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -21,8 +21,10 @@ package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -56,4 +58,18 @@ public class HadoopFileIO implements FileIO {
       throw new RuntimeIOException(e, "Failed to delete file: %s", path);
     }
   }
+
+  @Override
+  public boolean mkdir(String path) {
+    Path toCreate = new Path(path);
+    FileSystem fs = Util.getFs(toCreate, hadoopConf.get());
+    try {
+      return fs.mkdirs(toCreate);
+    } catch (FileAlreadyExistsException e) {
+      throw new AlreadyExistsException(e, "Path already exists: %s", path);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to create file: %s", path);
+    }
+  }
+
 }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -222,5 +222,13 @@ public class TestTables {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }
+
+    @Override
+    public boolean mkdir(String path) {
+      if (!new File(path).mkdir()) {
+        throw new RuntimeIOException("Failed to mkdir: " + path);
+      }
+      return true;
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.hadoop;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
@@ -110,4 +111,93 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
         catalog.listTables(Namespace.of("db", "ns1", "ns2"));
       });
   }
+
+  @Test
+  public void testListNamespace() throws Exception {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns3", "tbl4");
+    TableIdentifier tbl4 = TableIdentifier.of("db", "metadata");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    List<Namespace> nsp1 = catalog.listNamespaces(Namespace.of("db"));
+
+    Set<String> tblSet = Sets.newHashSet(nsp1.stream().map(t -> t.toString()).iterator());
+    Assert.assertEquals(tblSet.size(), 3);
+    Assert.assertTrue(tblSet.contains("db.ns1"));
+    Assert.assertTrue(tblSet.contains("db.ns2"));
+    Assert.assertTrue(tblSet.contains("db.ns3"));
+
+    List<Namespace> nsp2 = catalog.listNamespaces(Namespace.of("db", "ns1"));
+    Assert.assertEquals(nsp2.size(), 1);
+    Assert.assertTrue(nsp2.get(0).toString().equals("db.ns1.ns2"));
+
+    List<Namespace> nsp3 = catalog.listNamespaces();
+    Set<String> tblSet2 = Sets.newHashSet(nsp3.stream().map(t -> t.toString()).iterator());
+    Assert.assertEquals(tblSet2.size(), 1);
+    Assert.assertTrue(tblSet2.contains("db"));
+    AssertHelpers.assertThrows("should throw exception", NotFoundException.class,
+        "Unknown namespace", () -> {
+          catalog.listNamespaces(Namespace.of("db", "db2", "ns2"));
+        });
+  }
+
+  @Test
+  public void testLoadNamespaceMeta() throws IOException {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns3", "tbl4");
+    TableIdentifier tbl4 = TableIdentifier.of("db", "metadata");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    catalog.loadNamespaceMetadata(Namespace.of("db"));
+
+    AssertHelpers.assertThrows("should throw exception", NotFoundException.class,
+        "Unknown namespace", () -> {
+          catalog.loadNamespaceMetadata(Namespace.of("db", "db2", "ns2"));
+        });
+  }
+
+  @Test
+  public void testDropNamespace() throws IOException {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "tbl1");
+    TableIdentifier tbl2 = TableIdentifier.of("db1", "ns1", "tbl1");
+
+    Lists.newArrayList(tbl1, tbl2).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "This Namespace have tables, cannot drop it", () -> {
+          catalog.dropNamespace(Namespace.of("db"));
+        });
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "This Namespace have sub Namespace, cannot drop it", () -> {
+          catalog.dropNamespace(Namespace.of("db1"));
+        });
+    catalog.dropTable(tbl1);
+    catalog.dropNamespace(Namespace.of("db"));
+    String metaLocation = warehousePath + "/" + "db";
+    FileSystem fs = Util.getFs(new Path(metaLocation), conf);
+    Assert.assertFalse(fs.isDirectory(new Path(metaLocation)));
+  }
+
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -113,6 +113,29 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
   }
 
   @Test
+  public void testCreateNamespace() throws Exception {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+
+    Lists.newArrayList(tbl1, tbl2).forEach(t ->
+        catalog.createNamespace(t.namespace())
+    );
+
+    String metaLocation1 = warehousePath + "/" + "db/ns1/ns2";
+    FileSystem fs1 = Util.getFs(new Path(metaLocation1), conf);
+    Assert.assertTrue(fs1.isDirectory(new Path(metaLocation1)));
+
+    String metaLocation2 = warehousePath + "/" + "db/ns2/ns3";
+    FileSystem fs2 = Util.getFs(new Path(metaLocation2), conf);
+    Assert.assertTrue(fs2.isDirectory(new Path(metaLocation2)));
+
+  }
+
+  @Test
   public void testListNamespace() throws Exception {
     Configuration conf = new Configuration();
     String warehousePath = temp.newFolder().getAbsolutePath();

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hive;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.thrift.TException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHiveCatalog extends HiveMetastoreTest {
+  @Test
+  public void testCreateNamespace() throws TException {
+    Namespace namespace = Namespace.of("dbname");
+    namespace.setParameters("owner", "apache");
+    namespace.setParameters("group", "iceberg");
+
+    catalog.createNamespace(namespace);
+
+    Database database = metastoreClient.getDatabase(namespace.toString());
+    Map<String, String> dbMeta = catalog.getMetafrpmhiveDb(database);
+    Assert.assertTrue(dbMeta.get("owner").equals("apache"));
+    Assert.assertTrue(dbMeta.get("group").equals("iceberg"));
+    Assert.assertEquals("there no same location for db and namespace",
+        dbMeta.get("location"), catalog.nameSpaceToHiveDb(namespace).getLocationUri());
+  }
+
+  @Test
+  public void testListNamespace() throws TException {
+    Namespace namespace1 = Namespace.of("dbname1");
+    namespace1.setParameters("owner", "apache1");
+    namespace1.setParameters("group", "iceberg1");
+    catalog.createNamespace(namespace1);
+
+    Namespace namespace2 = Namespace.of("dbname2");
+    namespace2.setParameters("owner", "apache2");
+    namespace2.setParameters("group", "iceberg2");
+    catalog.createNamespace(namespace2);
+
+    List<Namespace> namespaces = catalog.listNamespaces();
+
+    Assert.assertTrue("hive db not hive the namespace 'dbname1'", namespaces.contains(namespace1));
+    Assert.assertTrue("hive db not hive the namespace 'dbname2'", namespaces.contains(namespace2));
+    for (Namespace namespace : namespaces) {
+      if (namespace.toString().equals(namespace1)) {
+        Assert.assertEquals("the metadata is not echo",
+            namespace.getParameters("owner"), namespace1.getParameters("owner"));
+      }
+    }
+  }
+
+  @Test
+  public void testLoadNamespaceMeta() throws TException {
+    Namespace namespace = Namespace.of("dbname_load");
+    namespace.setParameters("owner", "apache");
+    namespace.setParameters("group", "iceberg");
+    catalog.createNamespace(namespace);
+
+    Map<String, String> nameMata = catalog.loadNamespaceMetadata(namespace);
+    Assert.assertTrue(nameMata.get("owner").equals("apache"));
+    Assert.assertTrue(nameMata.get("group").equals("iceberg"));
+    Assert.assertEquals("there no same location for db and namespace",
+        nameMata.get("location"), catalog.nameSpaceToHiveDb(namespace).getLocationUri());
+  }
+
+  @Test
+  public void testDropNamespace() throws TException {
+
+    Namespace namespace = Namespace.of("dbname_drop");
+    namespace.setParameters("owner", "apache");
+    namespace.setParameters("group", "iceberg");
+    catalog.createNamespace(namespace);
+
+    Map<String, String> nameMata = catalog.loadNamespaceMetadata(namespace);
+    Assert.assertTrue(nameMata.get("owner").equals("apache"));
+    Assert.assertTrue(nameMata.get("group").equals("iceberg"));
+
+    Assert.assertTrue("drop namespace " + namespace.toString() + "error", catalog.dropNamespace(namespace));
+
+    AssertHelpers.assertThrows("Unknown namespace " + namespace.toString(),
+        org.apache.iceberg.exceptions.NotFoundException.class,
+        "Unknown namespace " + namespace.toString(), () -> {
+          catalog.loadNamespaceMetadata(namespace);
+        });
+  }
+
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -201,5 +201,13 @@ class TestTables {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }
+
+    @Override
+    public boolean mkdir(String path) {
+      if (!new File(path).mkdir()) {
+        throw new RuntimeIOException("Failed to mkdir: " + path);
+      }
+      return true;
+    }
   }
 }


### PR DESCRIPTION
Add the SupportsNamespaces for `HadoopCatalog` and `HiveCatalog`, this is a simple implementation.
This implementation not support the Namespace properties change, and on HadoopCatalog not support additional  properties stored.

I will writing an complicated  implementation in [PR #679]
