### PR TITLE
[ISSUE #672] Add SupportsNamespaces for 'HadoopCatalog' and 'HiveCatalog'

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -75,11 +75,6 @@ public class AllDataFilesTable extends BaseMetadataTable {
     }
   }
 
-  @Override
-  public String location() {
-    return table.currentSnapshot().manifestListLocation();
-  }
-
   public static class AllDataFilesTableScan extends BaseTableScan {
     private final Schema fileSchema;
 

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -68,11 +68,6 @@ public class AllEntriesTable extends BaseMetadataTable {
     }
   }
 
-  @Override
-  public String location() {
-    return table.currentSnapshot().manifestListLocation();
-  }
-
   private static class Scan extends BaseTableScan {
 
     Scan(TableOperations ops, Table table, Schema schema) {

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -79,11 +79,6 @@ public class AllManifestsTable extends BaseMetadataTable {
   }
 
   @Override
-  public String location() {
-    return ops.current().file().location();
-  }
-
-  @Override
   public Schema schema() {
     return MANIFEST_FILE_SCHEMA;
   }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -38,6 +38,11 @@ abstract class BaseMetadataTable implements Table {
   }
 
   @Override
+  public String location() {
+    return table().location();
+  }
+
+  @Override
   public EncryptionManager encryption() {
     return table().encryption();
   }

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -67,11 +67,6 @@ public class DataFilesTable extends BaseMetadataTable {
     }
   }
 
-  @Override
-  public String location() {
-    return table.currentSnapshot().manifestListLocation();
-  }
-
   public static class FilesTableScan extends BaseTableScan {
     private final Schema fileSchema;
 

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -65,11 +65,6 @@ public class HistoryTable extends BaseMetadataTable {
   }
 
   @Override
-  public String location() {
-    return ops.current().file().location();
-  }
-
-  @Override
   public Schema schema() {
     return HISTORY_SCHEMA;
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -68,11 +68,6 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
   }
 
-  @Override
-  public String location() {
-    return table.currentSnapshot().manifestListLocation();
-  }
-
   private static class EntriesTableScan extends BaseTableScan {
 
     EntriesTableScan(TableOperations ops, Table table, Schema schema) {

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -69,11 +69,6 @@ public class ManifestsTable extends BaseMetadataTable {
   }
 
   @Override
-  public String location() {
-    return ops.current().file().location();
-  }
-
-  @Override
   public Schema schema() {
     return SNAPSHOT_SCHEMA;
   }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -59,11 +59,6 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   @Override
-  public String location() {
-    return ops.current().file().location();
-  }
-
-  @Override
   public Schema schema() {
     return schema;
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -62,11 +62,6 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   @Override
-  public String location() {
-    return ops.current().file().location();
-  }
-
-  @Override
   public Schema schema() {
     return SNAPSHOT_SCHEMA;
   }


### PR DESCRIPTION
Add the SupportsNamespaces for HadoopCatalog and HiveCatalog, this is a simple implementation.
This implementation not support the Namespace properties change, and on HadoopCatalog not support additional properties stored.

I will writing an complicated implementation in [PR #679]

@aokolnychyi @rdblue 