### PR TITLE
Fix NullPointerException when message isn't included with exception

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -177,7 +177,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       throw new AlreadyExistsException("Table already exists: %s.%s", database, tableName);
 
     } catch (TException | UnknownHostException e) {
-      if (e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
+      if (e.getMessage() != null && e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
         throw new RuntimeException("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't " +
             "exist, this probably happened when using embedded metastore or doesn't create a " +
             "transactional meta table. To fix this, use an alternative metastore", e);


### PR DESCRIPTION
### _Why is this change needed?_
Some thrift exceptions are thrown without a message. When no message is passed, Iceberg will fail with a `NullPointerException` when trying to check if the string is in the exception message. 

### _How does this fix the problem?_
Does a `null` check in the first clause of the `if` statement avoiding checking to see if the string is contained within the message if the message is `null`. It should not effect the functionality of the check.

### _Any other important information?_
I discovered this error when testing Iceberg for the first time with an improper Hive configuration file. The Thrift exception thrown was because the localhost port it tried to connect to rejected the connection attempt. 