### PR TITLE
StructType#indexFields() breaks when schema contains column names which differ only by case

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -611,37 +611,35 @@ public class Types {
 
     private Map<String, NestedField> lazyFieldsByName() {
       if (fieldsByName == null) {
-        indexFields();
+        ImmutableMap.Builder<String, NestedField> byNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byNameBuilder.put(field.name(), field);
+        }
+        fieldsByName = byNameBuilder.build();
       }
       return fieldsByName;
     }
 
     private Map<String, NestedField> lazyFieldsByLowerCaseName() {
       if (fieldsByLowerCaseName == null) {
-        indexFields();
+        ImmutableMap.Builder<String, NestedField> byLowerCaseNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byLowerCaseNameBuilder.put(field.name().toLowerCase(Locale.ROOT), field);
+        }
+        fieldsByLowerCaseName = byLowerCaseNameBuilder.build();
       }
       return fieldsByLowerCaseName;
     }
 
     private Map<Integer, NestedField> lazyFieldsById() {
       if (fieldsById == null) {
-        indexFields();
+        ImmutableMap.Builder<Integer, NestedField> byIdBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byIdBuilder.put(field.fieldId(), field);
+        }
+        this.fieldsById = byIdBuilder.build();
       }
       return fieldsById;
-    }
-
-    private void indexFields() {
-      ImmutableMap.Builder<String, NestedField> byNameBuilder = ImmutableMap.builder();
-      ImmutableMap.Builder<String, NestedField> byLowerCaseNameBuilder = ImmutableMap.builder();
-      ImmutableMap.Builder<Integer, NestedField> byIdBuilder = ImmutableMap.builder();
-      for (NestedField field : fields) {
-        byNameBuilder.put(field.name(), field);
-        byLowerCaseNameBuilder.put(field.name().toLowerCase(Locale.ROOT), field);
-        byIdBuilder.put(field.fieldId(), field);
-      }
-      this.fieldsByName = byNameBuilder.build();
-      this.fieldsByLowerCaseName = byLowerCaseNameBuilder.build();
-      this.fieldsById = byIdBuilder.build();
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -21,12 +21,26 @@
 package org.apache.iceberg.types;
 
 import org.apache.iceberg.Schema;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 
 public class TestTypeUtil {
+  @Test
+  public void testReassignIdsDuplicateColumns() {
+    Schema schema = new Schema(
+        required(0, "a", Types.IntegerType.get()),
+        required(1, "A", Types.IntegerType.get())
+    );
+    Schema sourceSchema = new Schema(
+        required(1, "a", Types.IntegerType.get()),
+        required(2, "A", Types.IntegerType.get())
+    );
+    final Schema actualSchema = TypeUtil.reassignIds(schema, sourceSchema);
+    Assert.assertEquals(sourceSchema.asStruct(), actualSchema.asStruct());
+  }
 
   @Test(expected = IllegalArgumentException.class)
   public void testReassignIdsIllegalArgumentException() {


### PR DESCRIPTION
We have a few datasets having columns which differ by case only.  When updating existing Iceberg tables schema, we use `reassignIds` which breaks when building the `fieldsByLowerCaseName` map.  We see the following exception

```
at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:214)
        at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:208)
        at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:146)
        at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:109)
        at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:392)
        at org.apache.iceberg.types.Types$StructType.indexFields(Types.java:643)
        at org.apache.iceberg.types.Types$StructType.lazyFieldsByName(Types.java:614)
        at org.apache.iceberg.types.Types$StructType.field(Types.java:547)
        at org.apache.iceberg.types.ReassignIds.field(ReassignIds.java:89)
        at org.apache.iceberg.types.ReassignIds.field(ReassignIds.java:29)
```

I think this map is only used to support case-insensitive access. As long as we don't use that feature for these tables I think it should be ok to make this change.