### PR TITLE
Enable a path for consuming applications to not reuse underlying arrow buffers.

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -35,18 +35,21 @@ public class VectorHolder {
 
   @Nullable
   private final Dictionary dictionary;
+  private final NullabilityHolder nullabilityHolder;
 
-  public static final VectorHolder NULL_VECTOR_HOLDER = new VectorHolder(null, null, false, null);
+  public static final VectorHolder NULL_VECTOR_HOLDER = new VectorHolder(null, null, false, null, null);
 
   public VectorHolder(
       ColumnDescriptor columnDescriptor,
       FieldVector vector,
       boolean isDictionaryEncoded,
-      Dictionary dictionary) {
+      Dictionary dictionary,
+      NullabilityHolder holder) {
     this.columnDescriptor = columnDescriptor;
     this.vector = vector;
     this.isDictionaryEncoded = isDictionaryEncoded;
     this.dictionary = dictionary;
+    this.nullabilityHolder = holder;
   }
 
   public ColumnDescriptor getDescriptor() {
@@ -63,5 +66,9 @@ public class VectorHolder {
 
   public Dictionary getDictionary() {
     return dictionary;
+  }
+
+  public NullabilityHolder getNullabilityHolder() {
+    return nullabilityHolder;
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetValuesReader.java
@@ -1008,7 +1008,6 @@ public final class VectorizedParquetValuesReader extends ValuesReader {
       switch (mode) {
         case RLE:
           for (int i = 0; i < num; i++) {
-            // TODO: samarth I am assuming/hopeful that the decimalBytes array has typeWidth length
             byte[] decimalBytes = dict.decodeToBinary(currentValue).getBytesUnsafe();
             byte[] vectorBytes = new byte[DecimalVector.TYPE_WIDTH];
             System.arraycopy(decimalBytes, 0, vectorBytes, DecimalVector.TYPE_WIDTH - typeWidth, typeWidth);
@@ -1018,7 +1017,6 @@ public final class VectorizedParquetValuesReader extends ValuesReader {
           break;
         case PACKED:
           for (int i = 0; i < num; i++) {
-            // TODO: samarth I am assuming/hopeful that the decimal bytes has typeWidth length
             byte[] decimalBytes = dict.decodeToBinary(packedValuesBuffer[packedValuesBufferIdx++]).getBytesUnsafe();
             byte[] vectorBytes = new byte[DecimalVector.TYPE_WIDTH];
             System.arraycopy(decimalBytes, 0, vectorBytes, DecimalVector.TYPE_WIDTH - typeWidth, typeWidth);
@@ -1198,13 +1196,11 @@ public final class VectorizedParquetValuesReader extends ValuesReader {
               byte[] byteArray = new byte[DecimalVector.TYPE_WIDTH];
               valuesReader.getBuffer(typeWidth).get(byteArray, 0, typeWidth);
               vector.getDataBuffer().setBytes(bufferIdx * DecimalVector.TYPE_WIDTH, byteArray);
-              bufferIdx++;
-              //BitVectorHelper.setValidityBitToOne(validityBuffer, validityBufferIdx);
+              BitVectorHelper.setValidityBitToOne(vector.getValidityBuffer(), bufferIdx);
             } else {
-              //BitVectorHelper.setValidityBitToOne(validityBuffer, validityBufferIdx);
-              nullabilityHolder.setNull(bufferIdx);
-              bufferIdx++;
+              setNull(nullabilityHolder, bufferIdx, vector.getValidityBuffer());
             }
+            bufferIdx++;
           }
           break;
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -286,7 +286,7 @@ public class Parquet {
     private Schema schema = null;
     private Expression filter = null;
     private ReadSupport<?> readSupport = null;
-    private Function<MessageType, VectorizedReader> batchedReaderFunc = null;
+    private Function<MessageType, VectorizedReader<?>> batchedReaderFunc = null;
     private Function<MessageType, ParquetValueReader<?>> readerFunc = null;
     private boolean isBatchedReadEnabled = false;
     private boolean filterRecords = true;
@@ -347,7 +347,7 @@ public class Parquet {
       return this;
     }
 
-    public ReadBuilder createBatchedReaderFunc(Function<MessageType, VectorizedReader> func) {
+    public ReadBuilder createBatchedReaderFunc(Function<MessageType, VectorizedReader<?>> func) {
       this.batchedReaderFunc = func;
       return this;
     }
@@ -404,7 +404,7 @@ public class Parquet {
         ParquetReadOptions options = optionsBuilder.build();
 
         if (isBatchedReadEnabled) {
-          return new VectorizedParquetReader<>(file, schema, options, batchedReaderFunc, filter, reuseContainers,
+          return new VectorizedParquetReader(file, schema, options, batchedReaderFunc, filter, reuseContainers,
               caseSensitive, maxRecordsPerBatch);
         } else {
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/vectorized/VectorizedReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/vectorized/VectorizedReader.java
@@ -25,12 +25,14 @@ import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 
 /**
- * Marker interface for vectorized Iceberg readers.
+ * Interface for vectorized Iceberg readers.
  */
-public interface VectorizedReader<E, T> {
-  T read(E input);
+public interface VectorizedReader<T> {
+  T read();
 
   void setRowGroupInfo(PageReadStore pages, DictionaryPageReadStore dictionaryPageReadStore,
                        Map<ColumnPath, Boolean> columnPathBooleanMap);
+
+  void reuseContainers(boolean reuse);
 }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
@@ -70,9 +70,9 @@ public class IcebergArrowColumnVector extends ColumnVector {
   private final boolean isVectorDictEncoded;
   private ArrowColumnVector[] childColumns;
 
-  public IcebergArrowColumnVector(VectorHolder holder, NullabilityHolder nulls) {
+  public IcebergArrowColumnVector(VectorHolder holder) {
     super(ArrowUtils.instance().fromArrowField(holder.getVector().getField()));
-    this.nullabilityHolder = nulls;
+    this.nullabilityHolder = holder.getNullabilityHolder();
     this.columnDescriptor = holder.getDescriptor();
     this.dictionary = holder.getDictionary();
     this.isVectorDictEncoded = holder.isDictionaryEncoded();

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -65,17 +65,17 @@ public class VectorizedSparkParquetReaders {
     LOG.info("=> [VectorizedSparkParquetReaders] recordsPerBatch = {}", recordsPerBatch);
     return (ColumnarBatchReaders)
         TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), fileSchema,
-            new VectorReaderBuilder(tableSchema, expectedSchema, fileSchema, recordsPerBatch));
+            new VectorizedReaderBuilder(tableSchema, expectedSchema, fileSchema, recordsPerBatch));
   }
 
-  private static class VectorReaderBuilder extends TypeWithSchemaVisitor<VectorizedReader> {
+  private static class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedReader> {
     private final MessageType parquetSchema;
     private final Schema projectedIcebergSchema;
     private final Schema tableIcebergSchema;
     private final BufferAllocator rootAllocator;
     private final int recordsPerBatch;
 
-    VectorReaderBuilder(
+    VectorizedReaderBuilder(
         Schema tableSchema,
         Schema projectedIcebergSchema,
         MessageType parquetSchema,
@@ -134,8 +134,7 @@ public class VectorizedSparkParquetReaders {
           types.add(null);
         }
       }
-
-      return new ColumnarBatchReaders(types, expected, reorderedFields, recordsPerBatch);
+      return new ColumnarBatchReaders(reorderedFields, recordsPerBatch);
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -145,8 +145,6 @@ class Reader implements DataSourceReader,
 
       this.numRecordsPerBatch = VectorizedArrowReader.DEFAULT_BATCH_SIZE;
     }
-    LOG.info("=> Set Config numRecordsPerBatch = {}", numRecordsPerBatch);
-
     if (snapshotId != null && asOfTimestamp != null) {
       throw new IllegalArgumentException(
           "Cannot scan using both snapshot-id and as-of-timestamp to select the table snapshot");


### PR DESCRIPTION
Also, clean up interfaces and remove unused code.