### PR TITLE
Update projection in addedFiles to support appending

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -163,7 +163,7 @@ class BaseSnapshot implements Snapshot {
         manifest -> Objects.equal(manifest.snapshotId(), snapshotId));
     try (CloseableIterable<ManifestEntry> entries = new ManifestGroup(io, changedManifests)
         .ignoreExisting()
-        .select(ManifestReader.CHANGE_WITH_STATS_COLUMNS)
+        .select(ManifestReader.ALL_COLUMNS)
         .entries()) {
       for (ManifestEntry entry : entries) {
         switch (entry.status()) {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -49,7 +49,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 public class ManifestReader extends CloseableGroup implements Filterable<FilteredManifest> {
   private static final Logger LOG = LoggerFactory.getLogger(ManifestReader.class);
 
-  private static final ImmutableList<String> ALL_COLUMNS = ImmutableList.of("*");
+  static final ImmutableList<String> ALL_COLUMNS = ImmutableList.of("*");
   static final ImmutableList<String> CHANGE_COLUMNS = ImmutableList.of(
       "file_path", "file_format", "partition", "record_count", "file_size_in_bytes");
   static final ImmutableList<String> CHANGE_WITH_STATS_COLUMNS = ImmutableList.<String>builder()

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -277,28 +276,5 @@ public class TestFastAppend extends TableTestBase {
     Assert.assertTrue("Should commit same new manifest", new File(newManifest.path()).exists());
     Assert.assertTrue("Should commit the same new manifest",
         metadata.currentSnapshot().manifests().contains(newManifest));
-  }
-
-  @Test
-  public void testAppendFilesFromTable() {
-    table.newFastAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
-        .commit();
-
-    // collect data files from deserialization
-    Iterator<DataFile> filesIterator = table.currentSnapshot().addedFiles().iterator();
-
-    table.newDelete().deleteFile(FILE_A).deleteFile(FILE_B).commit();
-
-    Snapshot oldSnapshot = table.currentSnapshot();
-
-    AppendFiles fastAppend = table.newFastAppend();
-    while (filesIterator.hasNext()) {
-      fastAppend.appendFile(filesIterator.next());
-    }
-
-    Snapshot newSnapshot = fastAppend.apply();
-    validateSnapshot(oldSnapshot, newSnapshot, FILE_A, FILE_B);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -276,5 +277,28 @@ public class TestFastAppend extends TableTestBase {
     Assert.assertTrue("Should commit same new manifest", new File(newManifest.path()).exists());
     Assert.assertTrue("Should commit the same new manifest",
         metadata.currentSnapshot().manifests().contains(newManifest));
+  }
+
+  @Test
+  public void testAppendFilesFromTable() {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    // collect data files from deserialization
+    Iterator<DataFile> filesIterator = table.currentSnapshot().addedFiles().iterator();
+
+    table.newDelete().deleteFile(FILE_A).deleteFile(FILE_B).commit();
+
+    Snapshot oldSnapshot = table.currentSnapshot();
+
+    AppendFiles fastAppend = table.newFastAppend();
+    while (filesIterator.hasNext()) {
+      fastAppend.appendFile(filesIterator.next());
+    }
+
+    Snapshot newSnapshot = fastAppend.apply();
+    validateSnapshot(oldSnapshot, newSnapshot, FILE_A, FILE_B);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshot.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshot.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Test;
+
+public class TestSnapshot extends TableTestBase {
+
+  @Test
+  public void testAppendFilesFromTable() {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    // collect data files from deserialization
+    Iterable<DataFile> filesToAdd = table.currentSnapshot().addedFiles();
+
+    table.newDelete().deleteFile(FILE_A).deleteFile(FILE_B).commit();
+
+    Snapshot oldSnapshot = table.currentSnapshot();
+
+    AppendFiles fastAppend = table.newFastAppend();
+    for (DataFile file : filesToAdd) {
+      fastAppend.appendFile(file);
+    }
+
+    Snapshot newSnapshot = fastAppend.apply();
+    validateSnapshot(oldSnapshot, newSnapshot, FILE_A, FILE_B);
+  }
+
+  @Test
+  public void testAppendFoundFiles() {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Iterable<DataFile> filesToAdd = FindFiles.in(table)
+        .inPartition(table.spec(), StaticDataTask.Row.of(0))
+        .inPartition(table.spec(), StaticDataTask.Row.of(1))
+        .collect();
+
+    table.newDelete().deleteFile(FILE_A).deleteFile(FILE_B).commit();
+
+    Snapshot oldSnapshot = table.currentSnapshot();
+
+    AppendFiles fastAppend = table.newFastAppend();
+    for (DataFile file : filesToAdd) {
+      fastAppend.appendFile(file);
+    }
+
+    Snapshot newSnapshot = fastAppend.apply();
+    validateSnapshot(oldSnapshot, newSnapshot, FILE_A, FILE_B);
+  }
+
+}


### PR DESCRIPTION
Sometimes we need to append data files from an existing table like below:
```java
    Iterator<DataFile> datafiles = sourceTable.currentSnapshot().addedFiles().iterator();
    AppendFiles appendFiles = targetTable.newAppend();
    while (datafiles.hasNext()) {
      appendFiles.appendFile(datafiles.next());
    }
```

 The `addedFiles` read from `Snapshot`  has a projection while the schema from Avro writer doesn't have such projection and thus leads to error.

This PR enforces the manifest reader to do full columns projection to fix the problem.




