### PR TITLE
Remove warnings from the build

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
+++ b/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
@@ -93,7 +93,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public List<String> struct(Types.StructType readStruct, Iterable<List<String>> fieldErrorLists) {
+  public ImmutableList<String> struct(Types.StructType readStruct, Iterable<List<String>> fieldErrorLists) {
     Preconditions.checkNotNull(readStruct, "Evaluation must start with a schema.");
 
     if (!currentType.isStructType()) {
@@ -130,11 +130,11 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
       }
     }
 
-    return errors;
+    return ImmutableList.copyOf(errors);
   }
 
   @Override
-  public List<String> field(Types.NestedField readField, Supplier<List<String>> fieldErrors) {
+  public ImmutableList<String> field(Types.NestedField readField, Supplier<List<String>> fieldErrors) {
     Types.StructType struct = currentType.asStructType();
     Types.NestedField field = struct.field(readField.fieldId());
     List<String> errors = Lists.newArrayList();
@@ -163,15 +163,14 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
         }
       }
 
-      return errors;
-
+      return ImmutableList.copyOf(errors);
     } finally {
       this.currentType = struct;
     }
   }
 
   @Override
-  public List<String> list(Types.ListType readList, Supplier<List<String>> elementErrors) {
+  public ImmutableList<String> list(Types.ListType readList, Supplier<List<String>> elementErrors) {
     if (!currentType.isListType()) {
       return ImmutableList.of(String.format(": %s cannot be read as a list", currentType));
     }
@@ -187,15 +186,14 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
 
       errors.addAll(elementErrors.get());
 
-      return errors;
-
+      return ImmutableList.copyOf(errors);
     } finally {
       this.currentType = list;
     }
   }
 
   @Override
-  public List<String> map(Types.MapType readMap, Supplier<List<String>> keyErrors, Supplier<List<String>> valueErrors) {
+  public ImmutableList<String> map(Types.MapType readMap, Supplier<List<String>> keyErrors, Supplier<List<String>> valueErrors) {
     if (!currentType.isMapType()) {
       return ImmutableList.of(String.format(": %s cannot be read as a map", currentType));
     }
@@ -214,15 +212,14 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
       this.currentType = map.valueType();
       errors.addAll(valueErrors.get());
 
-      return errors;
-
+      return ImmutableList.copyOf(errors);
     } finally {
       this.currentType = map;
     }
   }
 
   @Override
-  public List<String> primitive(Type.PrimitiveType readPrimitive) {
+  public ImmutableList<String> primitive(Type.PrimitiveType readPrimitive) {
     if (currentType.equals(readPrimitive)) {
       return NO_ERRORS;
     }

--- a/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
+++ b/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
@@ -93,7 +93,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public ImmutableList<String> struct(Types.StructType readStruct, Iterable<List<String>> fieldErrorLists) {
+  public List<String> struct(Types.StructType readStruct, Iterable<List<String>> fieldErrorLists) {
     Preconditions.checkNotNull(readStruct, "Evaluation must start with a schema.");
 
     if (!currentType.isStructType()) {
@@ -134,7 +134,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public ImmutableList<String> field(Types.NestedField readField, Supplier<List<String>> fieldErrors) {
+  public List<String> field(Types.NestedField readField, Supplier<List<String>> fieldErrors) {
     Types.StructType struct = currentType.asStructType();
     Types.NestedField field = struct.field(readField.fieldId());
     List<String> errors = Lists.newArrayList();
@@ -170,7 +170,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public ImmutableList<String> list(Types.ListType readList, Supplier<List<String>> elementErrors) {
+  public List<String> list(Types.ListType readList, Supplier<List<String>> elementErrors) {
     if (!currentType.isListType()) {
       return ImmutableList.of(String.format(": %s cannot be read as a list", currentType));
     }
@@ -193,7 +193,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public ImmutableList<String> map(
+  public List<String> map(
       Types.MapType readMap, Supplier<List<String>> keyErrors, Supplier<List<String>> valueErrors) {
     if (!currentType.isMapType()) {
       return ImmutableList.of(String.format(": %s cannot be read as a map", currentType));
@@ -220,7 +220,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public ImmutableList<String> primitive(Type.PrimitiveType readPrimitive) {
+  public List<String> primitive(Type.PrimitiveType readPrimitive) {
     if (currentType.equals(readPrimitive)) {
       return NO_ERRORS;
     }

--- a/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
+++ b/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
@@ -193,7 +193,8 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
   }
 
   @Override
-  public ImmutableList<String> map(Types.MapType readMap, Supplier<List<String>> keyErrors, Supplier<List<String>> valueErrors) {
+  public ImmutableList<String> map(
+      Types.MapType readMap, Supplier<List<String>> keyErrors, Supplier<List<String>> valueErrors) {
     if (!currentType.isMapType()) {
       return ImmutableList.of(String.format(": %s cannot be read as a map", currentType));
     }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -53,7 +53,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   private static final String REPLACED_MANIFESTS_COUNT = "manifests-replaced";
   private static final String PROCESSED_ENTRY_COUNT = "entries-processed";
 
-  private static final Set<ManifestEntry.Status> ALLOWED_ENTRY_STATUSES = ImmutableSet.of(
+  private static final ImmutableSet<ManifestEntry.Status> ALLOWED_ENTRY_STATUSES = ImmutableSet.of(
       ManifestEntry.Status.EXISTING);
 
   private final TableOperations ops;

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -53,7 +53,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   private static final String REPLACED_MANIFESTS_COUNT = "manifests-replaced";
   private static final String PROCESSED_ENTRY_COUNT = "entries-processed";
 
-  private static final ImmutableSet<ManifestEntry.Status> ALLOWED_ENTRY_STATUSES = ImmutableSet.of(
+  private static final Set<ManifestEntry.Status> ALLOWED_ENTRY_STATUSES = ImmutableSet.of(
       ManifestEntry.Status.EXISTING);
 
   private final TableOperations ops;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -136,29 +136,22 @@ class ParquetFilters {
             case NOT_EQ:
               return FilterApi.notEq(col, getParquetPrimitive(lit));
           }
-
+          break;
         case INTEGER:
+        case DATE:
           return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit));
         case LONG:
+        case TIME:
+        case TIMESTAMP:
           return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit));
         case FLOAT:
           return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit));
         case DOUBLE:
           return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit));
-        case DATE:
-          return pred(op, FilterApi.intColumn(path), getParquetPrimitive(lit));
-        case TIME:
-          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit));
-        case TIMESTAMP:
-          return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit));
         case STRING:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
         case UUID:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
         case FIXED:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
         case BINARY:
-          return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
         case DECIMAL:
           return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
       }


### PR DESCRIPTION
Such as:

- Returning both mutable and immutable collections
- Returning mutable collections
- Removing fallthrough in switch statement
- Ungrouped branches in switch statement