### PR TITLE
Update GenericDataFile to return ByteBuffer for keyMetadata in get

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -379,7 +379,7 @@ class GenericDataFile
       case 12:
         return upperBounds;
       case 13:
-        return keyMetadata;
+        return keyMetadata();
       case 14:
         return splitOffsets;
       default:


### PR DESCRIPTION
This PR updates `GenericDataFile` to return `ByteBuffer` for `keyMetadata` in `get` as discussed [here](https://github.com/apache/incubator-iceberg/pull/675#discussion_r363243746).