### PR TITLE
Gitignore for eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ spark/tmp/
 .project
 .settings
 bin/
-

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,8 @@ coverage.xml
 spark/tmp/
 
 # vscode/eclipse files
+.classpath
 .project
+.settings
+bin/
+


### PR DESCRIPTION
This is a really minor change but I needed to do modify `.gitignore` after importing Iceberg as a Gradle project into Eclipse in order to prevent the files/folders listed from showing up as git differences.