### PR TITLE
Make sure to use right table name when constructing a metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -153,7 +153,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         throw new NoSuchTableException("Table does not exist: " + baseTableIdentifier);
       }
 
-      Table baseTable = new BaseTable(ops, fullTableName(name(), identifier));
+      Table baseTable = new BaseTable(ops, fullTableName(name(), baseTableIdentifier));
 
       switch (type) {
         case ENTRIES:


### PR DESCRIPTION
This fixes metadata table name from `db.t.entries.entries` to `db.t.entries`