### PR TITLE
Fix javadoc build

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
@@ -39,7 +39,7 @@ public interface VectorizedReader<T> {
   /**
    *
    * @param pages row group information for all the columns
-   * @param metadata map of {@link ColumnPath} -> {@link ColumnChunkMetaData} for the row group
+   * @param metadata map of {@link ColumnPath} -&gt; {@link ColumnChunkMetaData} for the row group
    */
   void setRowGroupInfo(PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata);
 


### PR DESCRIPTION
Fix javadoc build failure due to bad use of `>`.
