### PR TITLE
Fix thread safety in HadoopTableOperations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -110,7 +110,7 @@ public class HadoopTableOperations implements TableOperations {
   }
 
   @Override
-  public void commit(TableMetadata base, TableMetadata metadata) {
+  public synchronized void commit(TableMetadata base, TableMetadata metadata) {
     if (base != current()) {
       throw new CommitFailedException("Cannot commit changes based on stale table metadata");
     }


### PR DESCRIPTION
Right now, using `Table` instances with `HadoopTableOperations` is not thread-safe.

For example, we have a use case when we load a table and reuse the same object in multiple threads. See `testConcurrentFastAppends` in `TestHiveTableConcurrency` for an example. While this works with tables tracked in HMS, the same test would fail with Hadoop tables and HDFS and might lead to losing snapshots. This seems to happen when one thread enters `commit` and passes the `base != current()` check and then another thread commits and refreshes the current metadata. That way, `version` is updated while the first thread commits, which, in turn, breaks the atomic rename operation as `nextVersion` will point to a non-existent file.

In Hive tables, we lock tables in `commit` and then verify the current metadata location. The proposed fix is to make `commit` in `HadoopTableOperations` synchronized so that only one thread will attempt to commit. As an alternative, we can use a lock with some timeout but that will complicate the overall logic and will require more changes.

The fix was tested with HDFS locally. I did not include that test in the PR because we don't have the required guarantees for renames in local file systems.