### PR TITLE
Make the size of Hive client pool configurable

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -50,7 +50,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   private boolean closed;
 
   public HiveCatalog(Configuration conf) {
-    this.clients = new HiveClientPool(2, conf);
+    this.clients = new HiveClientPool(conf);
     this.conf = conf;
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -112,6 +112,7 @@ public class TestHiveMetastore {
     newHiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, "thrift://localhost:" + port);
     newHiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:" + hiveLocalDir.getAbsolutePath());
     newHiveConf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname, "false");
+    newHiveConf.set("iceberg.hive.client-pool-size", "2");
     return newHiveConf;
   }
 


### PR DESCRIPTION
Right now, the size of the client pool in `HiveCatalog` is hardcoded to 2. This PR makes it configurable by calling another constructor of `HiveClientPool` in `HiveCatalog`.