### PR TITLE
Hadoop tables: If the version matches, do not reload metadata.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -92,16 +92,20 @@ public class HadoopTableOperations implements TableOperations {
         nextMetadataFile = getMetadataFile(ver + 1);
       }
 
-      this.version = ver;
+      // only load if the current version is out of date
+      if (version == null || version != ver) {
+        this.version = ver;
 
-      TableMetadata newMetadata = TableMetadataParser.read(io(), io().newInputFile(metadataFile.toString()));
-      String newUUID = newMetadata.uuid();
-      if (currentMetadata != null) {
-        Preconditions.checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),
-            "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
+        TableMetadata newMetadata = TableMetadataParser.read(io(), io().newInputFile(metadataFile.toString()));
+        String newUUID = newMetadata.uuid();
+        if (currentMetadata != null) {
+          Preconditions.checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),
+              "Table UUID does not match: current=%s != refreshed=%s", currentMetadata.uuid(), newUUID);
+        }
+
+        this.currentMetadata = newMetadata;
       }
 
-      this.currentMetadata = newMetadata;
       this.shouldRefresh = false;
       return currentMetadata;
     } catch (IOException e) {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -357,7 +357,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     // inject the mockFS into the TableOperations
     doReturn(mockFs).when(spyOps).getFileSystem(any(), any());
     try {
-      spyOps.commit(spyOps.current(), meta1);
+      spyOps.commit(tops.current(), meta1);
       fail("Commit should fail due to mock file system");
     } catch (CommitFailedException expected) {
     }


### PR DESCRIPTION
#695 had a test failure because a Hadoop table had out of date metadata, even though there were no commits. The problem is that metadata is loaded into a new `TableMetadata` object each time refresh is called, even if it was already loaded and is still current. This adds a check when the current version is determined to avoid unnecessary reloads.