### PR TITLE
Use session state to load full Hadoop conf

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -37,6 +37,10 @@
         <property name="format" value="^\n\n$"/>
         <property name="message" value="Two consecutive blank lines are not permitted."/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="sparkContext\(\)\.hadoopConfiguration\(\)"/>
+        <property name="message" value="Are you sure that you want to use sparkContext().hadoopConfiguration()? In most cases, you should use sessionState().newHadoopConf() instead, so that the hadoop configurations specified in Spark session configuration will come into effect."/>
+    </module>
     <module name="SuppressionFilter"> <!-- baseline-gradle: README.md -->
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -146,8 +146,8 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
     if (io.getValue() instanceof HadoopFileIO) {
       String scheme = "no_exist";
       try {
-        FileSystem fs = new Path(table.location()).getFileSystem(
-            SparkSession.active().sparkContext().hadoopConfiguration());
+        Configuration conf = SparkSession.active().sessionState().newHadoopConf();
+        FileSystem fs = new Path(table.location()).getFileSystem(conf);
         scheme = fs.getScheme().toLowerCase(Locale.ENGLISH);
       } catch (IOException ioe) {
         LOG.warn("Failed to get Hadoop Filesystem", ioe);
@@ -364,7 +364,7 @@ class Reader implements DataSourceReader, SupportsPushDownFilters, SupportsPushD
         return new String[0];
       }
 
-      Configuration conf = SparkSession.active().sparkContext().hadoopConfiguration();
+      Configuration conf = SparkSession.active().sessionState().newHadoopConf();
       Set<String> locations = Sets.newHashSet();
       for (FileScanTask f : task.files()) {
         Path path = new Path(f.file().path().toString());


### PR DESCRIPTION
This PR uses `SessionState` to load Hadoop confs so that so the Hadoop properties specified in Spark session configuration will come into effect.