### PR TITLE
Support read-after-write eventual consistency problems on object stores

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -77,6 +77,8 @@ public class TableProperties {
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 
+  public static final String EVENTUAL_READ_AFTER_RIGHT = "write.read-after-right.eventual";
+
   public static final String OBJECT_STORE_PATH = "write.object-storage.path";
 
   // This only applies to files written after this property is set. Files previously written aren't

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -163,6 +163,11 @@ public class Tasks {
       return this;
     }
 
+    public Builder<I> onlyRetryOn(Collection<Class<? extends Exception>> exceptions) {
+      this.onlyRetryExceptions = Lists.newArrayList(exceptions);
+      return this;
+    }
+
     public Builder<I> onlyRetryOn(Class<? extends Exception> exception) {
       this.onlyRetryExceptions = Collections.singletonList(exception);
       return this;


### PR DESCRIPTION
On s3 read-after-write consistency is eventual in case of GET-PUT-GET scenario
which causes failures like Caused by: org.apache.iceberg.exceptions.NotFoundException: Failed to open input stream for file: s3a://feature-env-bucket-fe-cdp-sf-stress/datobase/dynamic-schema-storage/brand=9524/dynamic-schema-id=49975/metadata/snap-8360570545819086573-1-f18fb942-6dec-4e51-89be-1408a953352d.avro even though the file was written and updated in hive, as described in
https://codeburst.io/quick-explanation-of-the-s3-consistency-model-6c9f325e3f82
We suggest a retry on commits to be optionally extended to FileNotFound exceptions
