### PR TITLE
expire table metadata with ExpireSnapshots

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -71,6 +71,17 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
   ExpireSnapshots retainLast(int numSnapshots);
 
   /**
+   * Retains the most recent metadata json files.
+   *
+   * This may keep more than {@code numFiles} metadata files if snapshots are added concurrently. This
+   * may keep less than {@code numFiles} metadata files if the current table state does not have that many.
+   *
+   * @param numFiles the number of metadata files to retain
+   * @return this for method chaining
+   */
+  ExpireSnapshots expireMetadataRetainLast(int numFiles);
+
+  /**
    * Passes an alternative delete implementation that will be used for manifests and data files.
    * <p>
    * Manifest files that are no longer used by valid snapshots will be deleted. Data files that were

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -499,10 +499,11 @@ public class TableMetadata {
       }
     }
 
-    ImmutableList.Builder<PartitionSpec> builder = ImmutableList.<PartitionSpec>builder()
-        .addAll(specs);
+    ImmutableList.Builder<PartitionSpec> builder = ImmutableList.<PartitionSpec>builder();
     if (!specsById.containsKey(specId)) {
       builder.add(freshSpec);
+    } else {
+      builder.addAll(specs);
     }
 
     Map<String, String> newProperties = Maps.newHashMap();

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -113,7 +113,7 @@ public class TestTransaction extends TableTestBase {
     Assert.assertEquals("Table should have one manifest after commit",
         1, readMetadata().currentSnapshot().manifests().size());
     Assert.assertEquals("Table snapshot should be the delete snapshot",
-        deleteSnapshot, readMetadata().currentSnapshot());
+        deleteSnapshot.snapshotId(), readMetadata().currentSnapshot().snapshotId());
     validateManifestEntries(readMetadata().currentSnapshot().manifests().get(0),
         ids(deleteSnapshot.snapshotId(), appendSnapshot.snapshotId()),
         files(FILE_A, FILE_B), statuses(Status.DELETED, Status.EXISTING));
@@ -164,7 +164,7 @@ public class TestTransaction extends TableTestBase {
     Assert.assertEquals("Table should have one manifest after commit",
         1, readMetadata().currentSnapshot().manifests().size());
     Assert.assertEquals("Table snapshot should be the delete snapshot",
-        deleteSnapshot, readMetadata().currentSnapshot());
+        deleteSnapshot.snapshotId(), readMetadata().currentSnapshot().snapshotId());
     validateManifestEntries(readMetadata().currentSnapshot().manifests().get(0),
         ids(deleteSnapshot.snapshotId(), appendSnapshot.snapshotId()),
         files(FILE_A, FILE_B), statuses(Status.DELETED, Status.EXISTING));


### PR DESCRIPTION
This PR takes care of the issue #181 and is follow-up of #631.

1. Adds new method `expireMetadataRetainLast` to `ExpireSnapshots`.
2. If `expireMetadataRetainLast(n)` is called,  retains at least `n` latest metadata files and deletes rest.
