### PR TITLE
Incremental scan followups

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -134,13 +134,24 @@ class ManifestGroup {
    * @return a {@link CloseableIterable} of {@link FileScanTask}
    */
   public CloseableIterable<FileScanTask> planFiles() {
+    LoadingCache<Integer, ResidualEvaluator> residualCache = Caffeine.newBuilder().build(specId -> {
+      PartitionSpec spec = specsById.get(specId);
+      return ResidualEvaluator.of(spec, dataFilter, caseSensitive);
+    });
+    boolean dropStats = FilteredManifest.dropStats(dataFilter, columns);
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {
-      PartitionSpec spec = specsById.get(manifest.partitionSpecId());
+      int partitionSpecId = manifest.partitionSpecId();
+      PartitionSpec spec = specsById.get(partitionSpecId);
       String schemaString = SchemaParser.toJson(spec.schema());
       String specString = PartitionSpecParser.toJson(spec);
-      ResidualEvaluator residuals = ResidualEvaluator.of(spec, dataFilter, caseSensitive);
-      return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-          e.copy().file(), schemaString, specString, residuals));
+      ResidualEvaluator residuals = residualCache.get(partitionSpecId);
+      if (dropStats) {
+        return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
+            e.file().copyWithoutStats(), schemaString, specString, residuals));
+      } else {
+        return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
+            e.file().copy(), schemaString, specString, residuals));
+      }
     });
 
     if (executorService != null) {


### PR DESCRIPTION
Fixes: #765: This addresses the following follow-ups from #315
1. Cache residual evaluator
2. Detect and drop stats if possible