### PR TITLE
Allow caller to construct HadoopInputFile and HadoopOutputFile using an existing instance of FileSystem object.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -55,30 +55,21 @@ public class HadoopInputFile implements InputFile {
   }
 
   public static HadoopInputFile fromPath(Path path, Configuration conf) {
-    try {
-      FileSystem fs = path.getFileSystem(conf);
-      return new HadoopInputFile(fs, path, conf);
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to get file system for path: %s", path);
-    }
+    return fromPath(Util.getFs(path, conf), path, conf);
   }
 
   public static HadoopInputFile fromPath(Path path, long length, Configuration conf) {
-    try {
-      FileSystem fs = path.getFileSystem(conf);
-      return new HadoopInputFile(fs, path, length, conf);
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to get file system for path: %s", path);
-    }
+    FileSystem fs = Util.getFs(path, conf);
+    return new HadoopInputFile(fs, path, length, conf);
+  }
+
+  static HadoopInputFile fromPath(FileSystem fs, Path path, Configuration conf) {
+    return new HadoopInputFile(fs, path, conf);
   }
 
   public static HadoopInputFile fromStatus(FileStatus stat, Configuration conf) {
-    try {
-      FileSystem fs = stat.getPath().getFileSystem(conf);
-      return new HadoopInputFile(fs, stat, conf);
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to get file system for path: %s", stat.getPath());
-    }
+    FileSystem fs = Util.getFs(stat.getPath(), conf);
+    return new HadoopInputFile(fs, stat, conf);
   }
 
   private HadoopInputFile(FileSystem fs, Path path, Configuration conf) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopOutputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopOutputFile.java
@@ -44,8 +44,21 @@ public class HadoopOutputFile implements OutputFile {
     return fromPath(path, conf);
   }
 
+  public static OutputFile fromLocation(CharSequence location, FileSystem fs) {
+    Path path = new Path(location.toString());
+    return fromPath(path, fs);
+  }
+
   public static OutputFile fromPath(Path path, Configuration conf) {
     FileSystem fs = Util.getFs(path, conf);
+    return fromPath(path, fs, conf);
+  }
+
+  public static OutputFile fromPath(Path path, FileSystem fs) {
+    return fromPath(path, fs, fs.getConf());
+  }
+
+  public static OutputFile fromPath(Path path, FileSystem fs, Configuration conf) {
     return new HadoopOutputFile(fs, path, conf);
   }
 
@@ -90,7 +103,7 @@ public class HadoopOutputFile implements OutputFile {
 
   @Override
   public InputFile toInputFile() {
-    return HadoopInputFile.fromPath(fs, path, conf);
+    return HadoopInputFile.fromPath(path, fs, conf);
   }
 
   @Override


### PR DESCRIPTION
While obtaining a file system based on provided configuration covers the majority of use cases, it does not cover the ability to use an instance of FilterFileSystem with modified behavior or cases when caching of FileSystem object is disabled.