### PR TITLE
Fix race condition in SnapshotProducer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -77,7 +77,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private final String commitUUID = UUID.randomUUID().toString();
   private final AtomicInteger attempt = new AtomicInteger(0);
   private final List<String> manifestLists = Lists.newArrayList();
-  private Long snapshotId = null;
+  private volatile Long snapshotId = null;
   private TableMetadata base = null;
   private boolean stageOnly = false;
   private Consumer<String> deleteFunc = defaultDelete;
@@ -317,7 +317,11 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   protected long snapshotId() {
     if (snapshotId == null) {
-      this.snapshotId = ops.newSnapshotId();
+      synchronized (this) {
+        if (snapshotId == null) {
+          this.snapshotId = ops.newSnapshotId();
+        }
+      }
     }
     return snapshotId;
   }


### PR DESCRIPTION
This PR fixes a race condition in `SnapshotProducer` while generating a new snapshot id.

As it turns out,  we can use different snapshot ids in `MergingSnapshotProducer` while writing filtered manifests. That can lead to loosing certain manifests that contain only deleted files, which, in turn, will corrupt the table stats.

Take a look at the last line of this snippet in `MergingSnapshotProducer`:

```
// filter any existing manifests
List<ManifestFile> filtered;
if (current != null) {
 List<ManifestFile> manifests = current.manifests();
 filtered = Arrays.asList(filterManifests(metricsEvaluator, manifests));
} else {
 filtered = ImmutableList.of();
}

Iterable<ManifestFile> unmergedManifests = Iterables.filter(
    Iterables.concat(newManifestsWithMetadata, filtered),
    // only keep manifests that have live data files or that were written by this commit
    manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles() || manifest.snapshotId() == snapshotId());
```
 
We need to ensure manifests written in `filterManifests` all have the same snapshot id.

