### PR TITLE
Improve getWriter in BaseRewriteManifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -301,17 +301,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   }
 
   private WriterWrapper getWriter(Object key) {
-    WriterWrapper writer = writers.get(key);
-    if (writer == null) {
-      synchronized (writers) {
-        writer = writers.get(key); // check again after getting lock
-        if (writer == null) {
-          writer = new WriterWrapper();
-          writers.put(key, writer);
-        }
-      }
-    }
-    return writer;
+    return writers.computeIfAbsent(key, k -> new WriterWrapper());
   }
 
   @Override


### PR DESCRIPTION
Here, use concurrent map's atomic computeIfAbsent method instead of double checked locking to improve the code complexity and performance.

Related issue: https://github.com/apache/incubator-iceberg/issues/726.
