### PR TITLE
Fix the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
 
   - language: python
     python: 3.6
-    install: pip install tox-travis
+    install: pip install tox-travis "virtualenv<20.0.0"
     before_script:
       - cd python
     script: tox


### PR DESCRIPTION
There is a new release of virtualenv that broke the support with Tox: https://pypi.org/project/virtualenv/#history

Using the previous version is the best solution for now.