### PR TITLE
Fix manifests table for empty ManifestFiles

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -105,6 +105,10 @@ public class ManifestsTable extends BaseMetadataTable {
   }
 
   private List<StaticDataTask.Row> partitionSummariesToRows(List<ManifestFile.PartitionFieldSummary> summaries) {
+    if (summaries == null) {
+      return null;
+    }
+
     List<StaticDataTask.Row> rows = Lists.newArrayList();
 
     for (int i = 0; i < spec.fields().size(); i += 1) {


### PR DESCRIPTION
Tables written before manifest lists were added to the format contain some snapshots where manifests only have a file path. This fixes a NullPointerException in the manifests metadata table for those cases.