### PR TITLE
Fix static tables when there is no current snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -58,8 +58,13 @@ class StaticTableScan extends BaseTableScan {
   }
 
   @Override
+  public CloseableIterable<FileScanTask> planFiles() {
+    return CloseableIterable.withNoopClose(buildTask.apply(this));
+  }
+
+  @Override
   protected CloseableIterable<FileScanTask> planFiles(
       TableOperations ops, Snapshot snapshot, Expression rowFilter, boolean caseSensitive, boolean colStats) {
-    return CloseableIterable.withNoopClose(buildTask.apply(this));
+    throw new UnsupportedOperationException("Not supported for a static table");
   }
 }


### PR DESCRIPTION
`BaseTableScan.planFiles` will return no splits if there is no current table snapshot. This isn't correct behavior for metadata tables like `snapshots` because there could be staged snapshots if the table is newly created and has a staged but not published snapshot. The fix is to bypass the default `planFiles` in `StaticTableScan`, which will return a static task anyway.