### PR TITLE
Update RemoveSnapshots to protect cherry-picked data files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
@@ -188,6 +189,16 @@ class RemoveSnapshots implements ExpireSnapshots {
     // physically deleting files that were logically deleted in a commit that was rolled back.
     Set<Long> ancestorIds = Sets.newHashSet(SnapshotUtil.ancestorIds(base.currentSnapshot(), base::snapshot));
 
+    Set<Long> pickedAncestorSnapshotIds = Sets.newHashSet();
+    for (long snapshotId : ancestorIds) {
+      String sourceSnapshotId = base.snapshot(snapshotId).summary().get(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP);
+      if (sourceSnapshotId != null) {
+        // protect any snapshot that was cherry-picked into the current table state
+        pickedAncestorSnapshotIds.add(Long.parseLong(sourceSnapshotId));
+      }
+    }
+
+    // find manifests to clean up that are still referenced by a valid snapshot, but written by an expired snapshot
     Set<String> validManifests = Sets.newHashSet();
     Set<ManifestFile> manifestsToScan = Sets.newHashSet();
     for (Snapshot snapshot : snapshots) {
@@ -195,9 +206,16 @@ class RemoveSnapshots implements ExpireSnapshots {
         for (ManifestFile manifest : manifests) {
           validManifests.add(manifest.path());
 
-          boolean fromValidSnapshots = validIds.contains(manifest.snapshotId());
-          boolean isFromAncestor = ancestorIds.contains(manifest.snapshotId());
-          if (!fromValidSnapshots && isFromAncestor && manifest.hasDeletedFiles()) {
+          long snapshotId = manifest.snapshotId();
+          // whether the manifest was created by a valid snapshot (true) or an expired snapshot (false)
+          boolean fromValidSnapshots = validIds.contains(snapshotId);
+          // whether the snapshot that created the manifest was an ancestor of the table state
+          boolean isFromAncestor = ancestorIds.contains(snapshotId);
+          // whether the changes in this snapshot have been picked into the current table state
+          boolean isPicked = pickedAncestorSnapshotIds.contains(snapshotId);
+          // if the snapshot that wrote this manifest is no longer valid (has expired), then delete its deleted files.
+          // note that this is only for expired snapshots that are in the current table state
+          if (!fromValidSnapshots && (isFromAncestor || isPicked) && manifest.hasDeletedFiles()) {
             manifestsToScan.add(manifest);
           }
         }
@@ -208,12 +226,40 @@ class RemoveSnapshots implements ExpireSnapshots {
       }
     }
 
+    // find manifests to clean up that were only referenced by snapshots that have expired
     Set<String> manifestListsToDelete = Sets.newHashSet();
     Set<String> manifestsToDelete = Sets.newHashSet();
     Set<ManifestFile> manifestsToRevert = Sets.newHashSet();
     for (Snapshot snapshot : base.snapshots()) {
       long snapshotId = snapshot.snapshotId();
       if (!validIds.contains(snapshotId)) {
+        // determine whether the changes in this snapshot are in the current table state
+        if (pickedAncestorSnapshotIds.contains(snapshotId)) {
+          // this snapshot was cherry-picked into the current table state, so skip cleaning it up. its changes will
+          // expire when the picked snapshot expires.
+          // A -- C (source=B)
+          //  `- B <-- this commit
+          continue;
+        }
+
+        long sourceSnapshotId = PropertyUtil.propertyAsLong(
+            snapshot.summary(), SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, -1);
+        if (ancestorIds.contains(sourceSnapshotId)) {
+          // this commit was cherry-picked from a commit that is in the current table state. do not clean up its
+          // changes because it would revert data file additions that are in the current table.
+          // A -- B
+          //  `- C (source=B) <-- this commit
+          continue;
+        }
+
+        if (pickedAncestorSnapshotIds.contains(sourceSnapshotId)) {
+          // this commit was cherry-picked from a commit that is in the current table state. do not clean up its
+          // changes because it would revert data file additions that are in the current table.
+          // A -- C -- E (source=B)
+          //  `- B `- D (source=B) <-- this commit
+          continue;
+        }
+
         // find any manifests that are no longer needed
         try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
           for (ManifestFile manifest : manifests) {


### PR DESCRIPTION
This updates `RemoveSnapshots` to detect cherry-picked commits and skip cleanup.

This doesn't handle complex cases where snapshots are explicitly expired using `ExpireSnapshots.expireSnapshotId`, or where the current snapshot is directly modified. We will want a more thorough follow-up for those cases, tracked by #744.

This does handle cases where a change is picked into the current table state and the original commit expires. Cleanup for picked changes is done when the commit in the current snapshot's ancestors expires.