### PR TITLE
Fix NPE when calling locationProvider() in HadoopTableOperations with no current metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -607,7 +607,11 @@ class BaseTransaction implements Transaction {
 
     @Override
     public LocationProvider locationProvider() {
-      return transactionOps.locationProvider();
+      if (currentSnapshot() != null) {
+        return transactionOps.locationProvider();
+      } else {
+        return LocationProviders.locationsFor(location(), properties());
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -607,11 +607,7 @@ class BaseTransaction implements Transaction {
 
     @Override
     public LocationProvider locationProvider() {
-      if (currentSnapshot() != null) {
-        return transactionOps.locationProvider();
-      } else {
-        return LocationProviders.locationsFor(location(), properties());
-      }
+      return transactionOps.locationProvider();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -178,6 +179,51 @@ public class HadoopTableOperations implements TableOperations {
   @Override
   public String metadataFileLocation(String fileName) {
     return metadataPath(fileName).toString();
+  }
+
+  @Override
+  public TableOperations temp(TableMetadata uncommittedMetadata) {
+    return new TableOperations() {
+      @Override
+      public TableMetadata current() {
+        return uncommittedMetadata;
+      }
+
+      @Override
+      public TableMetadata refresh() {
+        throw new UnsupportedOperationException("Cannot call refresh on temporary table operations");
+      }
+
+      @Override
+      public void commit(TableMetadata base, TableMetadata metadata) {
+        throw new UnsupportedOperationException("Cannot call commit on temporary table operations");
+      }
+
+      @Override
+      public String metadataFileLocation(String fileName) {
+        return HadoopTableOperations.this.metadataFileLocation(fileName);
+      }
+
+      @Override
+      public LocationProvider locationProvider() {
+        return LocationProviders.locationsFor(uncommittedMetadata.location(), uncommittedMetadata.properties());
+      }
+
+      @Override
+      public FileIO io() {
+        return HadoopTableOperations.this.io();
+      }
+
+      @Override
+      public EncryptionManager encryption() {
+        return HadoopTableOperations.this.encryption();
+      }
+
+      @Override
+      public long newSnapshotId() {
+        return HadoopTableOperations.this.newSnapshotId();
+      }
+    };
   }
 
   private Path getMetadataFile(int metadataVersion) throws IOException {


### PR DESCRIPTION
Trying to use this PR to address a NPE like:
```
java.lang.NullPointerException
	at org.apache.iceberg.hadoop.HadoopTableOperations.locationProvider(HadoopTableOperations.java:171)
	at org.apache.iceberg.BaseTransaction$TransactionTableOperations.locationProvider(BaseTransaction.java:464)
	at org.apache.iceberg.BaseTransaction$TransactionTable.locationProvider(BaseTransaction.java:605)
```
It happens when we are working on spark-3 branch, but it seems also applied to master branch.
We are using HadoopCatalog and calling Catalog#newCreateTableTransaction(). HadoopTableOperations#locationProvider() is called when the table is being created and there is no commit yet. So HadoopTableOperations.current() returns null as there is no current metadata.
The NPE is triggered [here](https://github.com/apache/incubator-iceberg/blob/e279a35e532db514be62f41c6e1609f959e89490/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java#L175), as:
```
@Override
public LocationProvider locationProvider() {
  return LocationProviders.locationsFor(current().location(), current().properties());
}
```