### PR TITLE
Fix manifest scanning in RemoveSnapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -198,7 +198,7 @@ class RemoveSnapshots implements ExpireSnapshots {
           boolean fromValidSnapshots = validIds.contains(manifest.snapshotId());
           boolean isFromAncestor = ancestorIds.contains(manifest.snapshotId());
           if (!fromValidSnapshots && isFromAncestor && manifest.hasDeletedFiles()) {
-            manifestsToScan.add(manifest);
+            manifestsToScan.add(manifest.copy());
           }
         }
 
@@ -228,7 +228,7 @@ class RemoveSnapshots implements ExpireSnapshots {
                 // snapshot is an ancestor of the current table state. Otherwise, a snapshot that
                 // deleted files and was rolled back will delete files that could be in the current
                 // table state.
-                manifestsToScan.add(manifest);
+                manifestsToScan.add(manifest.copy());
               }
 
               if (!isFromAncestor && isFromExpiringSnapshot && manifest.hasAddedFiles()) {
@@ -239,7 +239,7 @@ class RemoveSnapshots implements ExpireSnapshots {
                 // written and this expiration is known and there is no missing history. If history
                 // were missing, then the snapshot could be an ancestor of the table state but the
                 // ancestor ID set would not contain it and this would be unsafe.
-                manifestsToRevert.add(manifest);
+                manifestsToRevert.add(manifest.copy());
               }
             }
           }

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -19,7 +19,13 @@
 
 package org.apache.iceberg;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.ManifestEntry.Status;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -332,5 +338,53 @@ public class TestRemoveSnapshots extends TableTestBase {
         IllegalArgumentException.class,
         "Number of snapshots to retain must be at least 1, cannot be: 0",
         () -> table.expireSnapshots().retainLast(0).commit());
+  }
+
+  @Test
+  public void dataFilesCleanup() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    table.newFastAppend()
+        .appendFile(FILE_B)
+        .commit();
+
+    table.newRewrite()
+        .rewriteFiles(ImmutableSet.of(FILE_B), ImmutableSet.of(FILE_D))
+        .commit();
+    long thirdSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.newRewrite()
+        .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_C))
+        .commit();
+    long fourthSnapshotId = table.currentSnapshot().snapshotId();
+
+    long t4 = System.currentTimeMillis();
+    while (t4 <= table.currentSnapshot().timestampMillis()) {
+      t4 = System.currentTimeMillis();
+    }
+
+    List<ManifestFile> manifests = table.currentSnapshot().manifests();
+
+    ManifestFile newManifest = writeManifest(
+        "manifest-file-1.avro",
+        manifestEntry(Status.EXISTING, thirdSnapshotId, FILE_C),
+        manifestEntry(Status.EXISTING, fourthSnapshotId, FILE_D));
+
+    RewriteManifests rewriteManifests = table.rewriteManifests();
+    manifests.forEach(rewriteManifests::deleteManifest);
+    rewriteManifests.addManifest(newManifest);
+    rewriteManifests.commit();
+
+    Set<String> deletedFiles = Sets.newHashSet();
+
+    table.expireSnapshots()
+        .expireOlderThan(t4)
+        .deleteWith(deletedFiles::add)
+        .commit();
+
+    Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));
   }
 }


### PR DESCRIPTION
This PR fixes manifest scanning logic in `RemoveSnapshots` and prevents orphan files. We are reusing containers while reading manifests for a snapshot but don't create copies when adding entries to the set of manifests to scan.