### PR TITLE
[ISSUE #813] fixed the oom in spark-shell

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/VectorizedReading.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/VectorizedReading.java
@@ -255,6 +255,7 @@ public class VectorizedReading {
           .project(readSchema)
           .split(task.start(), task.length())
           .enableBatchedRead()
+          .reuseContainers()
           .createBatchedReaderFunc(fileSchema -> VectorizedSparkParquetReaders.buildReader(tableSchema, readSchema,
               fileSchema, numRecordsPerBatch))
           .filter(task.residual())


### PR DESCRIPTION
I think, we should set ` reuseContainers  = true` while read a batch data into Arrow buffers. that would avoid the Arrow OOM.