### PR TITLE
Add incremental scan support for Spark

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
@@ -34,6 +35,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
@@ -197,5 +199,89 @@ public class TestDataSourceOptions {
         .load(tableLocation);
 
     Assert.assertEquals("Spark partitions should match", 2, resultDf.javaRDD().getNumPartitions());
+  }
+
+  @Test
+  public void testIncrementalScanOptions() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    Table table = tables.create(SCHEMA, spec, options, tableLocation);
+
+    List<SimpleRecord> expectedRecords = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c"),
+        new SimpleRecord(4, "d")
+    );
+    for (SimpleRecord record : expectedRecords) {
+      Dataset<Row> originalDf = spark.createDataFrame(Lists.newArrayList(record), SimpleRecord.class);
+      originalDf.select("id", "data").write()
+          .format("iceberg")
+          .mode("append")
+          .save(tableLocation);
+    }
+    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+
+    // start-snapshot-id and snapshot-id are both configured.
+    AssertHelpers.assertThrows(
+        "Check both start-snapshot-id and snapshot-id are configured",
+        IllegalArgumentException.class,
+        "Cannot specify start-snapshot-id and end-snapshot-id to do incremental scan",
+        () -> {
+          spark.read()
+              .format("iceberg")
+              .option("snapshot-id", snapshotIds.get(3).toString())
+              .option("start-snapshot-id", snapshotIds.get(3).toString())
+              .load(tableLocation);
+        });
+
+    // end-snapshot-id and as-of-timestamp are both configured.
+    AssertHelpers.assertThrows(
+        "Check both start-snapshot-id and snapshot-id are configured",
+        IllegalArgumentException.class,
+        "Cannot specify start-snapshot-id and end-snapshot-id to do incremental scan",
+        () -> {
+          spark.read()
+              .format("iceberg")
+              .option("as-of-timestamp", Long.toString(table.snapshot(snapshotIds.get(3)).timestampMillis()))
+              .option("end-snapshot-id", snapshotIds.get(2).toString())
+              .load(tableLocation);
+        });
+
+    // only end-snapshot-id is configured.
+    AssertHelpers.assertThrows(
+        "Check both start-snapshot-id and snapshot-id are configured",
+        IllegalArgumentException.class,
+        "Cannot only specify option end-snapshot-id to do incremental scan",
+        () -> {
+          spark.read()
+              .format("iceberg")
+              .option("end-snapshot-id", snapshotIds.get(2).toString())
+              .load(tableLocation);
+        });
+
+    // test (1st snapshot, current snapshot] incremental scan.
+    List<SimpleRecord> result = spark.read()
+        .format("iceberg")
+        .option("start-snapshot-id", snapshotIds.get(3).toString())
+        .load(tableLocation)
+        .orderBy("id")
+        .as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
+    Assert.assertEquals("Records should match", expectedRecords.subList(1, 4), result);
+
+    // test (2nd snapshot, 3rd snapshot] incremental scan.
+    List<SimpleRecord> result1 = spark.read()
+        .format("iceberg")
+        .option("start-snapshot-id", snapshotIds.get(2).toString())
+        .option("end-snapshot-id", snapshotIds.get(1).toString())
+        .load(tableLocation)
+        .orderBy("id")
+        .as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
+    Assert.assertEquals("Records should match", expectedRecords.subList(2, 3), result1);
   }
 }


### PR DESCRIPTION
This PR and incremental scan support for Spark reader. 

User could specify `start-snapshot-id` or `end-snapshot-id` to do incremental scan. If `end-snapshot-id` is not specified, then the incremental scan will be from `start-snapshot-id` to current snapshot.