### PR TITLE
Allow iceberg build with Java 8 or above version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ plugins {
   id 'com.palantir.consistent-versions' version '1.9.2'
 }
 
-if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-  throw new GradleException("This build must be run with Java 8")
+if (!JavaVersion.current().java8Compatible) {
+  throw new GradleException("This build must be run with Java 8 or above version")
 }
 
 allprojects {


### PR DESCRIPTION
Now iceberg only allow to build with Java 8, this PR allow iceberg to build with Java 8 or above version.