### PR TITLE
Fix ConcateCloseableIterable issue with starting empty iterables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -130,6 +130,20 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
       private ConcatCloseableIterator(Iterable<CloseableIterable<E>> inputs) {
         this.iterables = inputs.iterator();
         this.currentIterable = iterables.next();
+        // Exhaust the starting empty iterables.
+        while (Iterables.isEmpty(currentIterable)) {
+          try {
+            currentIterable.close();
+          } catch (IOException e) {
+            throw new RuntimeIOException(e, "Failed to close iterable");
+          }
+
+          if (iterables.hasNext()) {
+            this.currentIterable = iterables.next();
+          } else {
+            break;
+          }
+        }
         this.currentIterator = currentIterable.iterator();
       }
 

--- a/api/src/test/java/org/apache/iceberg/AssertHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/AssertHelpers.java
@@ -68,17 +68,43 @@ public class AssertHelpers {
     }
   }
 
+  /**
+   * A convenience method to avoid a large number of @Test(expected=...) tests
+   * @param message A String message to describe this assertion
+   * @param expected An Exception class that the Runnable should throw
+   * @param callable A Callable that is expected to throw the exception
+   */
+  public static void assertThrows(String message,
+                                  Class<? extends Exception> expected,
+                                  Callable callable) {
+    assertThrows(message, expected, null, callable);
+  }
+
+  /**
+   * A convenience method to avoid a large number of @Test(expected=...) tests
+   * @param message A String message to describe this assertion
+   * @param expected An Exception class that the Runnable should throw
+   * @param runnable A Runnable that is expected to throw the runtime exception
+   */
+  public static void assertThrows(String message,
+                                  Class<? extends Exception> expected,
+                                  Runnable runnable) {
+    assertThrows(message, expected, null, runnable);
+  }
+
   private static void handleException(String message,
                                       Class<? extends Exception> expected,
                                       String containedInMessage,
                                       Exception actual) {
     try {
       Assert.assertEquals(message, expected, actual.getClass());
-      Assert.assertTrue(
-          "Expected exception message (" + containedInMessage + ") missing: " +
-              actual.getMessage(),
-          actual.getMessage().contains(containedInMessage)
-      );
+      if (containedInMessage != null) {
+        Assert.assertTrue(
+            "Expected exception message (" + containedInMessage + ") missing: " +
+                actual.getMessage(),
+            actual.getMessage().contains(containedInMessage)
+        );
+      }
     } catch (AssertionError e) {
       e.addSuppressed(actual);
       throw e;

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import java.util.NoSuchElementException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCloseableIterable {
+
+  @Test(expected = NoSuchElementException.class)
+  public void testConcateWithEmptyIterables() {
+    CloseableIterable<Integer> iter = CloseableIterable.combine(Lists.newArrayList(1, 2, 3), () -> { });
+    CloseableIterable<Integer> empty = CloseableIterable.empty();
+
+    CloseableIterable<Integer> concat1 = CloseableIterable.concat(Lists.newArrayList(iter, empty, empty));
+    Assert.assertEquals(Iterables.getLast(concat1).intValue(), 3);
+
+    CloseableIterable<Integer> concat2 = CloseableIterable.concat(Lists.newArrayList(empty, empty, iter));
+    Assert.assertEquals(Iterables.getLast(concat2).intValue(), 3);
+
+    CloseableIterable<Integer> concat3 = CloseableIterable.concat(Lists.newArrayList(empty, iter, empty));
+    Assert.assertEquals(Iterables.getLast(concat3).intValue(), 3);
+
+    CloseableIterable<Integer> concat4 = CloseableIterable.concat(Lists.newArrayList(empty, iter, empty, empty, iter));
+    Assert.assertEquals(Iterables.getLast(concat4).intValue(), 3);
+
+    // This will throw a NoSuchElementException
+    CloseableIterable<Integer> concat5 = CloseableIterable.concat(Lists.newArrayList(empty, empty, empty));
+    Iterables.getLast(concat5);
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -22,12 +22,13 @@ package org.apache.iceberg.io;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.util.NoSuchElementException;
+import org.apache.iceberg.AssertHelpers;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestCloseableIterable {
 
-  @Test(expected = NoSuchElementException.class)
+  @Test
   public void testConcateWithEmptyIterables() {
     CloseableIterable<Integer> iter = CloseableIterable.combine(Lists.newArrayList(1, 2, 3), () -> { });
     CloseableIterable<Integer> empty = CloseableIterable.empty();
@@ -46,6 +47,8 @@ public class TestCloseableIterable {
 
     // This will throw a NoSuchElementException
     CloseableIterable<Integer> concat5 = CloseableIterable.concat(Lists.newArrayList(empty, empty, empty));
-    Iterables.getLast(concat5);
+    AssertHelpers.assertThrows("should throw NoSuchElementException",
+        NoSuchElementException.class,
+        () -> Iterables.getLast(concat5));
   }
 }


### PR DESCRIPTION
Guava has some APIs which will call `next()` before `hasNext()`, this will have an issue when using `ConcatCloseableIterable` with starting empty iterables. 

For example, calling `Iterables.getLast()` on `CloseableIterable.concat(Lists.newArrayList(empty, empty, iter))` will throw a `NoSuchElementException`, but obviously this `ConcatCloseableIterable` do has element. So here fixing this issue by exhausting the starting empty iterables.

Here's the implementation of `Iterables.getLast()`:

```java
  public static <T> T getLast(Iterator<T> iterator) {
    while (true) {
      T current = iterator.next();
      if (!iterator.hasNext()) {
        return current;
      }
    }
  }
```