### PR TITLE
Minor fix for TableIdentifier

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
@@ -106,6 +106,10 @@ public class TableIdentifier {
 
   @Override
   public String toString() {
-    return namespace.toString() + "." + name;
+    if (hasNamespace()) {
+      return namespace.toString() + "." + name;
+    } else {
+      return name;
+    }
   }
 }


### PR DESCRIPTION
If we create a table without specified namespace like this:
```java
    Table table = catalog.createTable(TableIdentifier.of("table"), SCHEMA, spec);
```
The `table.name()` is: `hive..table` or `hadoop..table`.