### PR TITLE
update hadoop table to support non-namespace case

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
@@ -106,6 +106,10 @@ public class TableIdentifier {
 
   @Override
   public String toString() {
-    return namespace.toString() + "." + name;
+    if (hasNamespace()) {
+      return namespace.toString() + "." + name;
+    } else {
+      return name;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -143,7 +143,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
 
   @Override
   protected boolean isValidIdentifier(TableIdentifier identifier) {
-    return identifier.namespace().levels().length >= 1;
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Hadoop tables don't have to bind to namespaces, they only need locations.