### PR TITLE
Fix the ORC file read method 'schema' to 'project'

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
@@ -103,7 +103,7 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
 
       case ORC:
         ORC.ReadBuilder orc = ORC.read(input)
-                .schema(projection)
+                .project(projection)
                 .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(projection, fileSchema))
                 .split(task.start(), task.length());
 

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericReadProjection.java
@@ -46,7 +46,7 @@ public class TestGenericReadProjection extends TestReadProjection {
     }
 
     Iterable<Record> records = ORC.read(Files.localInput(file))
-        .schema(readSchema)
+        .project(readSchema)
         .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(readSchema, fileSchema))
         .build();
 

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -148,8 +148,8 @@ public class ORC {
       return this;
     }
 
-    public ReadBuilder schema(org.apache.iceberg.Schema projectSchema) {
-      this.schema = projectSchema;
+    public ReadBuilder project(Schema newSchema) {
+      this.schema = newSchema;
       return this;
     }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -185,7 +185,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       FileScanTask task,
       Schema readSchema) {
     return ORC.read(location)
-        .schema(readSchema)
+        .project(readSchema)
         .split(task.start(), task.length())
         .createReaderFunc(SparkOrcReader::new)
         .caseSensitive(caseSensitive)

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -49,7 +49,7 @@ public class TestSparkOrcReader extends AvroDataTest {
     }
 
     try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(testFile))
-        .schema(schema)
+        .project(schema)
         .createReaderFunc(SparkOrcReader::new)
         .build()) {
       final Iterator<InternalRow> actualRows = reader.iterator();


### PR DESCRIPTION
Fix the ORC file read method `schema` to `project`, keep it same as the Parquet and Avro read method `project`