### PR TITLE
fix: Failed to get status issue because of s3 eventual consistency

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -139,7 +139,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   @Override
   public long length() {
     try {
-      return writer.getPos() + writeStore.getBufferedSize();
+      return writer.getPos() + (writeStore.isColumnFlushNeeded() ? writeStore.getBufferedSize() : 0);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to get file length");
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -433,6 +433,7 @@ class Writer implements DataSourceWriter {
         currentAppender.close();
         // metrics are only valid after the appender is closed
         Metrics metrics = currentAppender.metrics();
+        long fileSizeInBytes = currentAppender.length();
         List<Long> splitOffsets = currentAppender.splitOffsets();
         this.currentAppender = null;
 
@@ -440,7 +441,9 @@ class Writer implements DataSourceWriter {
           fileIo.deleteFile(currentFile.encryptingOutputFile());
         } else {
           DataFile dataFile = DataFiles.builder(spec)
-              .withEncryptedOutputFile(currentFile)
+              .withEncryptionKeyMetadata(currentFile.keyMetadata())
+              .withPath(currentFile.encryptingOutputFile().location())
+              .withFileSizeInBytes(fileSizeInBytes)
               .withPartition(spec.fields().size() == 0 ? null : currentKey) // set null if unpartitioned
               .withMetrics(metrics)
               .withSplitOffsets(splitOffsets)


### PR DESCRIPTION
fix for: https://github.com/apache/incubator-iceberg/issues/881
s3a file will invoke HadoopInputFile.getStat when getting length of file.
this call might fail because of s3 eventual consistency.

instead use appender.length to get file size and call respective setter methods
while creating instance of data file.
