### PR TITLE
Static import the method of Preconditions.checkArgument

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -40,6 +40,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Represents how to produce partition data for a table.
  * <p>
@@ -321,23 +323,23 @@ public class PartitionSpec implements Serializable {
       if (identitySourceColumnId != null) {
         // for identity transform case we allow  conflicts between partition and schema field name as
         //   long as they are sourced from the same schema field
-        Preconditions.checkArgument(schemaField == null || schemaField.fieldId() == identitySourceColumnId,
+        checkArgument(schemaField == null || schemaField.fieldId() == identitySourceColumnId,
             "Cannot create identity partition sourced from different field in schema: %s", name);
       } else {
         // for all other transforms we don't allow conflicts between partition name and schema field name
-        Preconditions.checkArgument(schemaField == null,
+        checkArgument(schemaField == null,
             "Cannot create partition from name that exists in schema: %s", name);
       }
-      Preconditions.checkArgument(name != null && !name.isEmpty(),
+      checkArgument(name != null && !name.isEmpty(),
           "Cannot use empty or null partition name: %s", name);
-      Preconditions.checkArgument(!partitionNames.contains(name),
+      checkArgument(!partitionNames.contains(name),
           "Cannot use partition name more than once: %s", name);
       partitionNames.add(name);
     }
 
     private void checkForRedundantPartitions(PartitionField field) {
       PartitionField timeField = timeFields.get(field.sourceId());
-      Preconditions.checkArgument(timeField == null,
+      checkArgument(timeField == null,
           "Cannot add redundant partition: %s conflicts with %s", timeField, field);
       timeFields.put(field.sourceId(), field);
     }
@@ -349,7 +351,7 @@ public class PartitionSpec implements Serializable {
 
     private Types.NestedField findSourceColumn(String sourceName) {
       Types.NestedField sourceColumn = schema.findField(sourceName);
-      Preconditions.checkArgument(sourceColumn != null, "Cannot find source column: %s", sourceName);
+      checkArgument(sourceColumn != null, "Cannot find source column: %s", sourceName);
       return sourceColumn;
     }
 

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.Sets;
@@ -36,6 +35,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * The schema of a data table.
@@ -125,7 +126,7 @@ public class Schema implements Serializable {
   }
 
   public Type findType(String name) {
-    Preconditions.checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
+    checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
     return findType(lazyNameToId().get(name));
   }
 
@@ -162,7 +163,7 @@ public class Schema implements Serializable {
    * @return a Type for the sub-field or null if it is not found
    */
   public NestedField findField(String name) {
-    Preconditions.checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
+    checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
     Integer id = lazyNameToId().get(name);
     if (id != null) {
       return lazyIdToField().get(id);
@@ -179,7 +180,7 @@ public class Schema implements Serializable {
    * @return the sub-field or null if it is not found
    */
   public NestedField caseInsensitiveFindField(String name) {
-    Preconditions.checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
+    checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
     Integer id = lazyLowerCaseNameToId().get(name.toLowerCase(Locale.ROOT));
     if (id != null) {
       return lazyIdToField().get(id);

--- a/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
@@ -19,11 +19,12 @@
 
 package org.apache.iceberg.catalog;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Identifies a table in iceberg catalog.
@@ -36,7 +37,7 @@ public class TableIdentifier {
   private final String name;
 
   public static TableIdentifier of(String... names) {
-    Preconditions.checkArgument(names.length > 0, "Cannot create table identifier without a table name");
+    checkArgument(names.length > 0, "Cannot create table identifier without a table name");
     return new TableIdentifier(Namespace.of(Arrays.copyOf(names, names.length - 1)), names[names.length - 1]);
   }
 
@@ -50,7 +51,7 @@ public class TableIdentifier {
   }
 
   private TableIdentifier(Namespace namespace, String name) {
-    Preconditions.checkArgument(name != null && !name.isEmpty(), "Invalid table name %s", name);
+    checkArgument(name != null && !name.isEmpty(), "Invalid table name %s", name);
     this.namespace = namespace;
     this.name = name;
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -19,15 +19,16 @@
 
 package org.apache.iceberg.expressions;
 
-import com.google.common.base.Preconditions;
 import java.util.Comparator;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
   private final Literal<T> literal;
 
   BoundLiteralPredicate(Operation op, BoundTerm<T> term, Literal<T> lit) {
     super(op, term);
-    Preconditions.checkArgument(op != Operation.IN && op != Operation.NOT_IN,
+    checkArgument(op != Operation.IN && op != Operation.NOT_IN,
         "Bound literal predicate does not support operation: %s", op);
     this.literal = lit;
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundSetPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundSetPredicate.java
@@ -20,8 +20,9 @@
 package org.apache.iceberg.expressions;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class BoundSetPredicate<T> extends BoundPredicate<T> {
   private static final Joiner COMMA = Joiner.on(", ");
@@ -29,7 +30,7 @@ public class BoundSetPredicate<T> extends BoundPredicate<T> {
 
   BoundSetPredicate(Operation op, BoundTerm<T> term, Set<T> lits) {
     super(op, term);
-    Preconditions.checkArgument(op == Operation.IN || op == Operation.NOT_IN,
+    checkArgument(op == Operation.IN || op == Operation.NOT_IN,
         "%s predicate does not support a literal set", op);
     this.literalSet = lits;
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -27,6 +27,8 @@ import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Factory methods for creating {@link Expression expressions}.
  */
@@ -220,7 +222,7 @@ public class Expressions {
   }
 
   public static <T> UnboundPredicate<T> predicate(Operation op, String name, Literal<T> lit) {
-    Preconditions.checkArgument(op != Operation.IS_NULL && op != Operation.NOT_NULL,
+    checkArgument(op != Operation.IS_NULL && op != Operation.NOT_NULL,
         "Cannot create %s predicate inclusive a value", op);
     return new UnboundPredicate<T>(op, ref(name), lit);
   }
@@ -230,7 +232,7 @@ public class Expressions {
   }
 
   public static <T> UnboundPredicate<T> predicate(Operation op, String name) {
-    Preconditions.checkArgument(op == Operation.IS_NULL || op == Operation.NOT_NULL,
+    checkArgument(op == Operation.IS_NULL || op == Operation.NOT_NULL,
         "Cannot create %s predicate without a value", op);
     return new UnboundPredicate<>(op, ref(name));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.expressions;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -29,6 +28,8 @@ import java.util.Set;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.CharSequenceSet;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>> implements Unbound<T, Expression> {
   private static final Joiner COMMA = Joiner.on(", ");
@@ -70,7 +71,7 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>> implements
   }
 
   public Literal<T> literal() {
-    Preconditions.checkArgument(op() != Operation.IN && op() != Operation.NOT_IN,
+    checkArgument(op() != Operation.IN && op() != Operation.NOT_IN,
         "%s predicate cannot return a literal", op());
     return literals == null ? null : Iterables.getOnlyElement(literals);
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -19,13 +19,14 @@
 
 package org.apache.iceberg.transforms;
 
-import com.google.common.base.Preconditions;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Factory methods for transforms.
@@ -150,7 +151,7 @@ public class Transforms {
    */
   @SuppressWarnings("unchecked")
   public static <T> Transform<T, Integer> hour(Type type) {
-    Preconditions.checkArgument(type.typeId() == Type.TypeID.TIMESTAMP,
+    checkArgument(type.typeId() == Type.TypeID.TIMESTAMP,
         "Cannot partition type %s by hour", type);
     return (Transform<T, Integer>) Timestamps.HOUR;
   }

--- a/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   private final Schema sourceSchema;
   private Type sourceType;
@@ -46,7 +48,7 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   @Override
   public Type struct(Types.StructType struct, Iterable<Type> fieldTypes) {
     Preconditions.checkNotNull(sourceType, "Evaluation must start with a schema.");
-    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
+    checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     Types.StructType sourceStruct = sourceType.asStructType();
     List<Types.NestedField> fields = struct.fields();
@@ -69,7 +71,7 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type field(Types.NestedField field, Supplier<Type> future) {
-    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
+    checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     Types.StructType sourceStruct = sourceType.asStructType();
     Types.NestedField sourceField = sourceStruct.field(field.name());
@@ -87,7 +89,7 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type list(Types.ListType list, Supplier<Type> elementTypeFuture) {
-    Preconditions.checkArgument(sourceType.isListType(), "Not a list: %s", sourceType);
+    checkArgument(sourceType.isListType(), "Not a list: %s", sourceType);
 
     Types.ListType sourceList = sourceType.asListType();
     int sourceElementId = sourceList.elementId();
@@ -107,7 +109,7 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type map(Types.MapType map, Supplier<Type> keyTypeFuture, Supplier<Type> valueTypeFuture) {
-    Preconditions.checkArgument(sourceType.isMapType(), "Not a map: %s", sourceType);
+    checkArgument(sourceType.isMapType(), "Not a map: %s", sourceType);
 
     Types.MapType sourceMap = sourceType.asMapType();
     int sourceKeyId = sourceMap.keyId();

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -34,6 +34,8 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class TypeUtil {
 
   private TypeUtil() {}
@@ -386,13 +388,13 @@ public class TypeUtil {
   }
 
   static int decimalMaxPrecision(int numBytes) {
-    Preconditions.checkArgument(numBytes >= 0 && numBytes < 24,
+    checkArgument(numBytes >= 0 && numBytes < 24,
         "Unsupported decimal length: %s", numBytes);
     return MAX_PRECISION[numBytes];
   }
 
   public static int decimalRequiredBytes(int precision) {
-    Preconditions.checkArgument(precision >= 0 && precision < 40,
+    checkArgument(precision >= 0 && precision < 40,
         "Unsupported decimal precision: %s", precision);
     return REQUIRED_LENGTH[precision];
   }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -34,6 +34,8 @@ import java.util.regex.Pattern;
 import org.apache.iceberg.types.Type.NestedType;
 import org.apache.iceberg.types.Type.PrimitiveType;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class Types {
 
   private Types() {}
@@ -367,7 +369,7 @@ public class Types {
     private final int precision;
 
     private DecimalType(int precision, int scale) {
-      Preconditions.checkArgument(precision <= 38,
+      checkArgument(precision <= 38,
           "Decimals with precision larger than 38 are not supported: %s", precision);
       this.scale = scale;
       this.precision = precision;

--- a/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
@@ -19,9 +19,10 @@
 
 package org.apache.iceberg.util;
 
-import com.google.common.base.Preconditions;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.expressions.Literal;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class BinaryUtil {
   // not meant to be instantiated
@@ -32,7 +33,7 @@ public class BinaryUtil {
    * Truncates the input byte buffer to the given length
    */
   public static ByteBuffer truncateBinary(ByteBuffer input, int length) {
-    Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+    checkArgument(length > 0, "Truncate length should be positive");
     if (length >= input.remaining()) {
       return input;
     }

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -19,8 +19,9 @@
 
 package org.apache.iceberg.util;
 
-import com.google.common.base.Preconditions;
 import org.apache.iceberg.expressions.Literal;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class UnicodeUtil {
   // not meant to be instantiated
@@ -40,7 +41,7 @@ public class UnicodeUtil {
    * and the number of unicode characters in the truncated charSequence is lesser than or equal to length
    */
   public static CharSequence truncateString(CharSequence input, int length) {
-    Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+    checkArgument(length > 0, "Truncate length should be positive");
     StringBuilder sb = new StringBuilder(input);
     // Get the number of unicode characters in the input
     int numUniCodeCharacters = sb.codePointCount(0, sb.length());

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
@@ -21,13 +21,14 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.parquet.Preconditions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.bitpacking.BytePacker;
 import org.apache.parquet.column.values.bitpacking.Packer;
 import org.apache.parquet.io.ParquetDecodingException;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * A values reader for Parquet's run-length encoded data that reads column data in batches instead of one value at a
@@ -120,7 +121,7 @@ public class BaseVectorizedParquetValuesReader extends ValuesReader {
    * Initializes the internal state for decoding ints of `bitWidth`.
    */
   private void init(int bw) {
-    Preconditions.checkArgument(bw >= 0 && bw <= 32, "bitWidth must be >= 0 and <= 32");
+    checkArgument(bw >= 0 && bw <= 32, "bitWidth must be >= 0 and <= 32");
     this.bitWidth = bw;
     this.bytesWidth = BytesUtils.paddedByteCountFromBits(bw);
     this.packer = Packer.LITTLE_ENDIAN.newBytePacker(bw);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.arrow.vectorized.parquet;
 
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
@@ -28,6 +27,8 @@ import org.apache.iceberg.parquet.BasePageIterator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.page.PageReader;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Vectorized version of the ColumnIterator that reads column values in data pages of a column in a row group in a
@@ -41,7 +42,7 @@ public class VectorizedColumnIterator extends BaseColumnIterator {
   public VectorizedColumnIterator(ColumnDescriptor desc, String writerVersion, int batchSize,
                                   boolean setArrowValidityVector) {
     super(desc);
-    Preconditions.checkArgument(desc.getMaxRepetitionLevel() == 0,
+    checkArgument(desc.getMaxRepetitionLevel() == 0,
         "Only non-nested columns are supported for vectorized reads");
     this.batchSize = batchSize;
     this.vectorizedPageIterator = new VectorizedPageIterator(desc, writerVersion, setArrowValidityVector);

--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.common;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -29,6 +28,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Copied from parquet-common
@@ -79,7 +79,7 @@ public class DynConstructors {
     @Override
     @SuppressWarnings("unchecked")
     public <R> R invoke(Object target, Object... args) {
-      Preconditions.checkArgument(target == null,
+      checkArgument(target == null,
           "Invalid call to constructor: target must be null");
       return (R) newInstance(args);
     }
@@ -87,7 +87,7 @@ public class DynConstructors {
     @Override
     @SuppressWarnings("unchecked")
     public <R> R invokeChecked(Object target, Object... args) throws Exception {
-      Preconditions.checkArgument(target == null,
+      checkArgument(target == null,
           "Invalid call to constructor: target must be null");
       return (R) newInstanceChecked(args);
     }

--- a/common/src/main/java/org/apache/iceberg/common/DynFields.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynFields.java
@@ -30,6 +30,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class DynFields {
 
@@ -87,7 +88,7 @@ public class DynFields {
     public BoundField<T> bind(Object target) {
       Preconditions.checkState(!isStatic() || this == AlwaysNull.INSTANCE,
           "Cannot bind static field %s", name);
-      Preconditions.checkArgument(
+      checkArgument(
           field.getDeclaringClass().isAssignableFrom(target.getClass()),
           "Cannot bind field %s to instance of %s",
               name,

--- a/common/src/main/java/org/apache/iceberg/common/DynMethods.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynMethods.java
@@ -28,6 +28,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
 
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Copied from parquet-common
@@ -91,7 +92,7 @@ public class DynMethods {
     public BoundMethod bind(Object receiver) {
       Preconditions.checkState(!isStatic(),
           "Cannot bind static method %s",  method.toGenericString());
-      Preconditions.checkArgument(
+      checkArgument(
           method.getDeclaringClass().isAssignableFrom(receiver.getClass()),
           "Cannot bind %s to instance of %s",
               method.toGenericString(),

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
@@ -40,6 +39,8 @@ import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public abstract class BaseMetastoreCatalog implements Catalog {
   private static final Logger LOG = LoggerFactory.getLogger(BaseMetastoreCatalog.class);
 
@@ -50,7 +51,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       PartitionSpec spec,
       String location,
       Map<String, String> properties) {
-    Preconditions.checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
+    checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
 
     TableOperations ops = newTableOps(identifier);
     if (ops.current() != null) {
@@ -83,7 +84,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       PartitionSpec spec,
       String location,
       Map<String, String> properties) {
-    Preconditions.checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
+    checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
 
     TableOperations ops = newTableOps(identifier);
     if (ops.current() != null) {

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +28,8 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> implements OverwriteFiles {
   private boolean validateAddedFilesMatchOverwriteFilter = false;
@@ -75,7 +76,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
 
   @Override
   public OverwriteFiles validateNoConflictingAppends(Long newReadSnapshotId, Expression newConflictDetectionFilter) {
-    Preconditions.checkArgument(newConflictDetectionFilter != null, "Conflict detection filter cannot be null");
+    checkArgument(newConflictDetectionFilter != null, "Conflict detection filter cannot be null");
     this.readSnapshotId = newReadSnapshotId;
     this.conflictDetectionFilter = newConflictDetectionFilter;
     failMissingDeletePaths();

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -19,8 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   BaseRewriteFiles(TableOperations ops) {
@@ -42,9 +43,9 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   @Override
   public RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd) {
-    Preconditions.checkArgument(filesToDelete != null && !filesToDelete.isEmpty(),
+    checkArgument(filesToDelete != null && !filesToDelete.isEmpty(),
         "Files to delete cannot be null or empty");
-    Preconditions.checkArgument(filesToAdd != null && !filesToAdd.isEmpty(),
+    checkArgument(filesToAdd != null && !filesToAdd.isEmpty(),
         "Files to add can not be null or empty");
 
     for (DataFile toDelete : filesToDelete) {

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
 import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
@@ -138,9 +139,9 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
 
   @Override
   public RewriteManifests addManifest(ManifestFile manifest) {
-    Preconditions.checkArgument(!manifest.hasAddedFiles(), "Cannot add manifest with added files");
-    Preconditions.checkArgument(!manifest.hasDeletedFiles(), "Cannot add manifest with deleted files");
-    Preconditions.checkArgument(
+    checkArgument(!manifest.hasAddedFiles(), "Cannot add manifest with added files");
+    checkArgument(!manifest.hasDeletedFiles(), "Cannot add manifest with deleted files");
+    checkArgument(
         manifest.snapshotId() == null || manifest.snapshotId() == -1,
         "Snapshot id must be assigned during commit");
 

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
@@ -42,6 +41,8 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.BinPacking;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Base class for {@link TableScan} implementations.
@@ -130,9 +131,9 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public TableScan useSnapshot(long scanSnapshotId) {
-    Preconditions.checkArgument(this.snapshotId == null,
+    checkArgument(this.snapshotId == null,
         "Cannot override snapshot, already set to id=%s", snapshotId);
-    Preconditions.checkArgument(ops.current().snapshot(scanSnapshotId) != null,
+    checkArgument(ops.current().snapshot(scanSnapshotId) != null,
         "Cannot find snapshot with ID %s", scanSnapshotId);
     return newRefinedScan(
         ops, table, scanSnapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
@@ -140,7 +141,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public TableScan asOfTime(long timestampMillis) {
-    Preconditions.checkArgument(this.snapshotId == null,
+    checkArgument(this.snapshotId == null,
         "Cannot override snapshot, already set to id=%s", snapshotId);
 
     Long lastSnapshotId = null;
@@ -152,7 +153,7 @@ abstract class BaseTableScan implements TableScan {
 
     // the snapshot ID could be null if no entries were older than the requested time. in that case,
     // there is no valid snapshot to read.
-    Preconditions.checkArgument(lastSnapshotId != null,
+    checkArgument(lastSnapshotId != null,
         "Cannot find a snapshot older than %s", formatTimestampMillis(timestampMillis));
 
     return useSnapshot(lastSnapshotId);

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -32,6 +31,8 @@ import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.util.ByteBuffers;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class DataFiles {
 
@@ -63,17 +64,17 @@ public class DataFiles {
     }
 
     String[] partitions = partitionPath.split("/", -1);
-    Preconditions.checkArgument(partitions.length <= spec.fields().size(),
+    checkArgument(partitions.length <= spec.fields().size(),
         "Invalid partition data, too many fields (expecting %s): %s",
         spec.fields().size(), partitionPath);
-    Preconditions.checkArgument(partitions.length >= spec.fields().size(),
+    checkArgument(partitions.length >= spec.fields().size(),
         "Invalid partition data, not enough fields (expecting %s): %s",
         spec.fields().size(), partitionPath);
 
     for (int i = 0; i < partitions.length; i += 1) {
       PartitionField field = spec.fields().get(i);
       String[] parts = partitions[i].split("=", 2);
-      Preconditions.checkArgument(
+      checkArgument(
           parts.length == 2 &&
               parts[0] != null &&
               field.name().equals(parts[0]),
@@ -151,7 +152,7 @@ public class DataFiles {
   }
 
   public static DataFile fromManifest(ManifestFile manifest) {
-    Preconditions.checkArgument(
+    checkArgument(
         manifest.addedFilesCount() != null && manifest.existingFilesCount() != null,
         "Cannot create data file from manifest: data file counts are missing.");
 
@@ -291,7 +292,7 @@ public class DataFiles {
     }
 
     public Builder withPartitionPath(String newPartitionPath) {
-      Preconditions.checkArgument(isPartitioned || newPartitionPath.isEmpty(),
+      checkArgument(isPartitioned || newPartitionPath.isEmpty(),
           "Cannot add partition data for an unpartitioned table");
       if (!newPartitionPath.isEmpty()) {
         this.partitionData = fillFromPath(spec, newPartitionPath, partitionData);
@@ -329,13 +330,13 @@ public class DataFiles {
     }
 
     public DataFile build() {
-      Preconditions.checkArgument(filePath != null, "File path is required");
+      checkArgument(filePath != null, "File path is required");
       if (format == null) {
         this.format = FileFormat.fromFileName(filePath);
       }
-      Preconditions.checkArgument(format != null, "File format is required");
-      Preconditions.checkArgument(fileSizeInBytes >= 0, "File size is required");
-      Preconditions.checkArgument(recordCount >= 0, "Record count is required");
+      checkArgument(format != null, "File format is required");
+      checkArgument(fileSizeInBytes >= 0, "File size is required");
+      checkArgument(recordCount >= 0, "Record count is required");
 
       return new GenericDataFile(
           filePath, format, isPartitioned ? partitionData.copy() : null,

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -31,6 +30,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
 import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT;
 
@@ -90,9 +90,9 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
 
   @Override
   public FastAppend appendManifest(ManifestFile manifest) {
-    Preconditions.checkArgument(!manifest.hasExistingFiles(), "Cannot append manifest with existing files");
-    Preconditions.checkArgument(!manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
-    Preconditions.checkArgument(
+    checkArgument(!manifest.hasExistingFiles(), "Cannot append manifest with existing files");
+    checkArgument(!manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
+    checkArgument(
         manifest.snapshotId() == null || manifest.snapshotId() == -1,
         "Snapshot id must be assigned during commit");
 

--- a/core/src/main/java/org/apache/iceberg/FindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/FindFiles.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -29,6 +28,8 @@ import java.util.List;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class FindFiles {
   private FindFiles() {
@@ -71,9 +72,9 @@ public class FindFiles {
      * @return this for method chaining
      */
     public Builder inSnapshot(long findSnapshotId) {
-      Preconditions.checkArgument(this.snapshotId == null,
+      checkArgument(this.snapshotId == null,
           "Cannot set snapshot multiple times, already set to id=%s", findSnapshotId);
-      Preconditions.checkArgument(table.snapshot(findSnapshotId) != null,
+      checkArgument(table.snapshot(findSnapshotId) != null,
           "Cannot find snapshot for id=%s", findSnapshotId);
       this.snapshotId = findSnapshotId;
       return this;
@@ -86,7 +87,7 @@ public class FindFiles {
      * @return this for method chaining
      */
     public Builder asOfTime(long timestampMillis) {
-      Preconditions.checkArgument(this.snapshotId == null,
+      checkArgument(this.snapshotId == null,
           "Cannot set snapshot multiple times, already set to id=%s", snapshotId);
 
       Long lastSnapshotId = null;
@@ -101,7 +102,7 @@ public class FindFiles {
 
       // the snapshot ID could be null if no entries were older than the requested time. in that
       // case, there is no valid snapshot to read.
-      Preconditions.checkArgument(lastSnapshotId != null,
+      checkArgument(lastSnapshotId != null,
           "Cannot find a snapshot older than %s",
           DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(timestampMillis), ZoneId.systemDefault())));
       return inSnapshot(lastSnapshotId);
@@ -160,7 +161,7 @@ public class FindFiles {
      * @return this for method chaining
      */
     public Builder inPartitions(PartitionSpec spec, List<StructLike> partitions) {
-      Preconditions.checkArgument(spec.equals(ops.current().spec(spec.specId())),
+      checkArgument(spec.equals(ops.current().spec(spec.specId())),
           "Partition spec does not belong to table: %s", table);
 
       Expression partitionSetFilter = Expressions.alwaysFalse();

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -33,6 +33,8 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.ThreadPools;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 class IncrementalDataTableScan extends DataTableScan {
   private long fromSnapshotId;
   private long toSnapshotId;
@@ -139,23 +141,23 @@ class IncrementalDataTableScan extends DataTableScan {
         SnapshotUtil.snapshotIdsBetween(table(), fromSnapshotId, toSnapshotId));
     // since snapshotIdsBetween return ids in range (fromSnapshotId, toSnapshotId]
     snapshotIdsRange.add(fromSnapshotId);
-    Preconditions.checkArgument(
+    checkArgument(
         snapshotIdsRange.contains(newFromSnapshotId),
         "from snapshot id %s not in existing snapshot ids range (%s, %s]",
         newFromSnapshotId, fromSnapshotId, newToSnapshotId);
-    Preconditions.checkArgument(
+    checkArgument(
         snapshotIdsRange.contains(newToSnapshotId),
         "to snapshot id %s not in existing snapshot ids range (%s, %s]",
         newToSnapshotId, fromSnapshotId, toSnapshotId);
   }
 
   private static void validateSnapshotIds(Table table, long fromSnapshotId, long toSnapshotId) {
-    Preconditions.checkArgument(fromSnapshotId != toSnapshotId, "from and to snapshot ids cannot be the same");
-    Preconditions.checkArgument(
+    checkArgument(fromSnapshotId != toSnapshotId, "from and to snapshot ids cannot be the same");
+    checkArgument(
         table.snapshot(fromSnapshotId) != null, "from snapshot %s does not exist", fromSnapshotId);
-    Preconditions.checkArgument(
+    checkArgument(
         table.snapshot(toSnapshotId) != null, "to snapshot %s does not exist", toSnapshotId);
-    Preconditions.checkArgument(SnapshotUtil.ancestorOf(table, toSnapshotId, fromSnapshotId),
+    checkArgument(SnapshotUtil.ancestorOf(table, toSnapshotId, fromSnapshotId),
         "from snapshot %s is not an ancestor of to snapshot  %s", fromSnapshotId, toSnapshotId);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -40,6 +39,7 @@ import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 
 /**
@@ -241,7 +241,7 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
 
   CloseableIterable<ManifestEntry> entries(Schema fileProjection) {
     FileFormat format = FileFormat.fromFileName(file.location());
-    Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file);
+    checkArgument(format != null, "Unable to determine format of manifest: %s", file);
 
     switch (format) {
       case AVRO:

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -30,6 +30,8 @@ import org.apache.iceberg.io.OutputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Writer for manifest files.
  */
@@ -48,7 +50,7 @@ public class ManifestWriter implements FileAppender<DataFile> {
     boolean threw = true;
     try {
       for (ManifestEntry entry : reader.entries()) {
-        Preconditions.checkArgument(
+        checkArgument(
             allowedEntryStatuses.contains(entry.status()),
             "Invalid manifest entry status: %s (allowed statuses: %s)",
             entry.status(), allowedEntryStatuses);

--- a/core/src/main/java/org/apache/iceberg/MergeAppend.java
+++ b/core/src/main/java/org/apache/iceberg/MergeAppend.java
@@ -19,8 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import org.apache.iceberg.exceptions.CommitFailedException;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Append implementation that produces a minimal number of manifest files.
@@ -50,9 +51,9 @@ class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements Append
 
   @Override
   public AppendFiles appendManifest(ManifestFile manifest) {
-    Preconditions.checkArgument(!manifest.hasExistingFiles(), "Cannot append manifest with existing files");
-    Preconditions.checkArgument(!manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
-    Preconditions.checkArgument(
+    checkArgument(!manifest.hasExistingFiles(), "Cannot append manifest with existing files");
+    checkArgument(!manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
+    checkArgument(
         manifest.snapshotId() == null || manifest.snapshotId() == -1,
         "Snapshot id must be assigned during commit");
     add(manifest);

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -19,13 +19,14 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * This class defines different metrics modes, which allow users to control the collection of
@@ -100,7 +101,7 @@ public class MetricsModes {
     }
 
     public static Truncate withLength(int length) {
-      Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+      checkArgument(length > 0, "Truncate length should be positive");
       return new Truncate(length);
     }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import java.io.Serializable;
@@ -35,6 +34,8 @@ import org.apache.avro.util.Utf8;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 class PartitionData
     implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
@@ -62,7 +63,7 @@ class PartitionData
 
   PartitionData(Types.StructType partitionType) {
     for (Types.NestedField field : partitionType.fields()) {
-      Preconditions.checkArgument(field.type().isPrimitiveType(),
+      checkArgument(field.type().isPrimitiveType(),
           "Partitions cannot contain nested types: %s", field.type());
     }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Iterator;
@@ -31,6 +30,8 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 import org.apache.iceberg.util.Pair;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class PartitionSpecParser {
   private PartitionSpecParser() {
@@ -71,7 +72,7 @@ public class PartitionSpecParser {
   }
 
   public static PartitionSpec fromJson(Schema schema, JsonNode json) {
-    Preconditions.checkArgument(json.isObject(), "Cannot parse spec from non-object: %s", json);
+    checkArgument(json.isObject(), "Cannot parse spec from non-object: %s", json);
     int specId = JsonUtil.getInt(SPEC_ID, json);
     PartitionSpec.Builder builder = PartitionSpec.builderFor(schema).withSpecId(specId);
     buildFromJsonFields(builder, json.get(FIELDS));
@@ -134,13 +135,13 @@ public class PartitionSpecParser {
   }
 
   private static void buildFromJsonFields(PartitionSpec.Builder builder, JsonNode json) {
-    Preconditions.checkArgument(json.isArray(),
+    checkArgument(json.isArray(),
         "Cannot parse partition spec fields, not an array: %s", json);
 
     Iterator<JsonNode> elements = json.elements();
     while (elements.hasNext()) {
       JsonNode element = elements.next();
-      Preconditions.checkArgument(element.isObject(),
+      checkArgument(element.isObject(),
           "Cannot parse partition field, not an object: %s", element);
 
       String name = JsonUtil.getString(NAME, element);

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.util.Tasks;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
@@ -51,7 +52,7 @@ class PropertiesUpdate implements UpdateProperties {
   public UpdateProperties set(String key, String value) {
     Preconditions.checkNotNull(key, "Key cannot be null");
     Preconditions.checkNotNull(key, "Value cannot be null");
-    Preconditions.checkArgument(!removals.contains(key),
+    checkArgument(!removals.contains(key),
         "Cannot remove and update the same key: %s", key);
 
     updates.put(key, value);
@@ -62,7 +63,7 @@ class PropertiesUpdate implements UpdateProperties {
   @Override
   public UpdateProperties remove(String key) {
     Preconditions.checkNotNull(key, "Key cannot be null");
-    Preconditions.checkArgument(!updates.keySet().contains(key),
+    checkArgument(!updates.keySet().contains(key),
         "Cannot remove and update the same key: %s", key);
 
     removals.add(key);

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.IOException;
@@ -40,6 +39,7 @@ import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
@@ -87,7 +87,7 @@ class RemoveSnapshots implements ExpireSnapshots {
 
   @Override
   public ExpireSnapshots retainLast(int numSnapshots) {
-    Preconditions.checkArgument(1 <= numSnapshots,
+    checkArgument(1 <= numSnapshots,
             "Number of snapshots to retain must be at least 1, cannot be: %s", numSnapshots);
     idsToRetain.clear();
     List<Long> ancestorIds = SnapshotUtil.ancestorIds(base.currentSnapshot(), base::snapshot);

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -33,6 +32,8 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class SchemaParser {
 
@@ -177,14 +178,14 @@ public class SchemaParser {
 
   private static Types.StructType structFromJson(JsonNode json) {
     JsonNode fieldArray = json.get(FIELDS);
-    Preconditions.checkArgument(fieldArray.isArray(),
+    checkArgument(fieldArray.isArray(),
         "Cannot parse struct fields from non-array: %s", fieldArray);
 
     List<Types.NestedField> fields = Lists.newArrayListWithExpectedSize(fieldArray.size());
     Iterator<JsonNode> iterator = fieldArray.elements();
     while (iterator.hasNext()) {
       JsonNode field = iterator.next();
-      Preconditions.checkArgument(field.isObject(),
+      checkArgument(field.isObject(),
           "Cannot parse struct field from non-object: %s", field);
 
       int id = JsonUtil.getInt(ID, field);
@@ -234,7 +235,7 @@ public class SchemaParser {
 
   public static Schema fromJson(JsonNode json) {
     Type type  = typeFromJson(json);
-    Preconditions.checkArgument(type.isNestedType() && type.asNestedType().isStructType(),
+    checkArgument(type.isNestedType() && type.asNestedType().isStructType(),
         "Cannot create schema, not a struct type: %s", type);
     return new Schema(type.asNestedType().asStructType().fields());
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -27,6 +27,8 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.WapUtil;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class SnapshotManager extends MergingSnapshotProducer<ManageSnapshots> implements ManageSnapshots {
 
   private enum SnapshotManagerOperation {
@@ -107,7 +109,7 @@ public class SnapshotManager extends MergingSnapshotProducer<ManageSnapshots> im
   public ManageSnapshots rollbackToTime(long timestampMillis) {
     // find the latest snapshot by timestamp older than timestampMillis
     Snapshot snapshot = findLatestAncestorOlderThan(current(), timestampMillis);
-    Preconditions.checkArgument(snapshot != null,
+    checkArgument(snapshot != null,
         "Cannot roll back, no valid snapshot older than: %s", timestampMillis);
 
     this.managerOperation = SnapshotManagerOperation.ROLLBACK;

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -32,6 +31,8 @@ import java.util.Map;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.util.JsonUtil;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class SnapshotParser {
 
@@ -100,7 +101,7 @@ public class SnapshotParser {
   }
 
   static Snapshot fromJson(FileIO io, JsonNode node) {
-    Preconditions.checkArgument(node.isObject(),
+    checkArgument(node.isObject(),
         "Cannot parse table version from a non-object: %s", node);
 
     long versionId = JsonUtil.getLong(SNAPSHOT_ID, node);
@@ -114,7 +115,7 @@ public class SnapshotParser {
     String operation = null;
     if (node.has(SUMMARY)) {
       JsonNode sNode = node.get(SUMMARY);
-      Preconditions.checkArgument(sNode != null && !sNode.isNull() && sNode.isObject(),
+      checkArgument(sNode != null && !sNode.isNull() && sNode.isObject(),
           "Cannot parse summary from non-object value: %s", sNode);
 
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -43,6 +42,7 @@ import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
@@ -105,7 +105,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   @Override
   public ThisT deleteWith(Consumer<String> deleteCallback) {
-    Preconditions.checkArgument(this.deleteFunc == defaultDelete, "Cannot set delete callback more than once");
+    checkArgument(this.deleteFunc == defaultDelete, "Cannot set delete callback more than once");
     this.deleteFunc = deleteCallback;
     return self();
   }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -38,6 +37,8 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Metadata for a table.
@@ -218,7 +219,7 @@ public class TableMetadata {
     HistoryEntry last = null;
     for (HistoryEntry logEntry : snapshotLog) {
       if (last != null) {
-        Preconditions.checkArgument(
+        checkArgument(
             (logEntry.timestampMillis() - last.timestampMillis()) >= 0,
             "[BUG] Expected sorted snapshot log entries.");
       }
@@ -228,14 +229,14 @@ public class TableMetadata {
     MetadataLogEntry previous = null;
     for (MetadataLogEntry metadataEntry : previousFiles) {
       if (previous != null) {
-        Preconditions.checkArgument(
+        checkArgument(
             (metadataEntry.timestampMillis() - previous.timestampMillis()) >= 0,
             "[BUG] Expected sorted previous metadata log entries.");
       }
       previous = metadataEntry;
     }
 
-    Preconditions.checkArgument(
+    checkArgument(
         currentSnapshotId < 0 || snapshotsById.containsKey(currentSnapshotId),
         "Invalid table metadata: Cannot find current version");
   }
@@ -364,7 +365,7 @@ public class TableMetadata {
       }
     }
 
-    Preconditions.checkArgument(defaultSpecId != newDefaultSpecId,
+    checkArgument(defaultSpecId != newDefaultSpecId,
         "Cannot set default partition spec to the current default");
 
     ImmutableList.Builder<PartitionSpec> builder = ImmutableList.<PartitionSpec>builder()

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -47,6 +46,8 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.JsonUtil;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class TableMetadataParser {
 
   public enum Codec {
@@ -60,12 +61,12 @@ public class TableMetadataParser {
     }
 
     public static Codec fromName(String codecName) {
-      Preconditions.checkArgument(codecName != null, "Codec name is null");
+      checkArgument(codecName != null, "Codec name is null");
       return Codec.valueOf(codecName.toUpperCase(Locale.ENGLISH));
     }
 
     public static Codec fromFileName(String fileName) {
-      Preconditions.checkArgument(fileName.contains(".metadata.json"),
+      checkArgument(fileName.contains(".metadata.json"),
           "%s is not a valid metadata file", fileName);
       // we have to be backward-compatible with .metadata.json.gz files
       if (fileName.endsWith(".metadata.json.gz")) {
@@ -222,11 +223,11 @@ public class TableMetadataParser {
   }
 
   static TableMetadata fromJson(FileIO io, InputFile file, JsonNode node) {
-    Preconditions.checkArgument(node.isObject(),
+    checkArgument(node.isObject(),
         "Cannot parse metadata from a non-object: %s", node);
 
     int formatVersion = JsonUtil.getInt(FORMAT_VERSION, node);
-    Preconditions.checkArgument(formatVersion == TableMetadata.TABLE_FORMAT_VERSION,
+    checkArgument(formatVersion == TableMetadata.TABLE_FORMAT_VERSION,
         "Cannot read unsupported version %s", formatVersion);
 
     String uuid = JsonUtil.getStringOrNull(TABLE_UUID, node);
@@ -238,7 +239,7 @@ public class TableMetadataParser {
     List<PartitionSpec> specs;
     int defaultSpecId;
     if (specArray != null) {
-      Preconditions.checkArgument(specArray.isArray(),
+      checkArgument(specArray.isArray(),
           "Cannot parse partition specs from non-array: %s", specArray);
       // default spec ID is required when the spec array is present
       defaultSpecId = JsonUtil.getInt(DEFAULT_SPEC_ID, node);
@@ -264,7 +265,7 @@ public class TableMetadataParser {
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
 
     JsonNode snapshotArray = node.get(SNAPSHOTS);
-    Preconditions.checkArgument(snapshotArray.isArray(),
+    checkArgument(snapshotArray.isArray(),
         "Cannot parse snapshots from non-array: %s", snapshotArray);
 
     List<Snapshot> snapshots = Lists.newArrayListWithExpectedSize(snapshotArray.size());

--- a/core/src/main/java/org/apache/iceberg/Transactions.java
+++ b/core/src/main/java/org/apache/iceberg/Transactions.java
@@ -19,8 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import org.apache.iceberg.BaseTransaction.TransactionType;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public final class Transactions {
   private Transactions() {}
@@ -34,7 +35,7 @@ public final class Transactions {
   }
 
   public static Transaction createTableTransaction(TableOperations ops, TableMetadata start) {
-    Preconditions.checkArgument(ops.current() == null,
+    checkArgument(ops.current() == null,
             "Cannot start create table transaction: table already exists");
     return new BaseTransaction(ops, TransactionType.CREATE_TABLE, start);
   }

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.mapping.NameMapping;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION_DEFAULT;
 
@@ -63,7 +64,7 @@ public class Avro {
     }
 
     public CodecFactory get() {
-      Preconditions.checkArgument(avroCodec != null, "Missing implementation for codec %s", this);
+      checkArgument(avroCodec != null, "Missing implementation for codec %s", this);
       return avroCodec;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -36,6 +36,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class AvroSchemaUtil {
 
   private AvroSchemaUtil() {}
@@ -132,7 +134,7 @@ public class AvroSchemaUtil {
 
   static Schema toOption(Schema schema) {
     if (schema.getType() == UNION) {
-      Preconditions.checkArgument(isOptionSchema(schema),
+      checkArgument(isOptionSchema(schema),
           "Union schemas are not supported: %s", schema);
       return schema;
     } else {
@@ -141,9 +143,9 @@ public class AvroSchemaUtil {
   }
 
   static Schema fromOption(Schema schema) {
-    Preconditions.checkArgument(schema.getType() == UNION,
+    checkArgument(schema.getType() == UNION,
         "Expected union schema but was passed: %s", schema);
-    Preconditions.checkArgument(schema.getTypes().size() == 2,
+    checkArgument(schema.getTypes().size() == 2,
         "Expected optional schema, but was passed: %s", schema);
     if (schema.getTypes().get(0).getType() == Schema.Type.NULL) {
       return schema.getTypes().get(1);
@@ -153,7 +155,7 @@ public class AvroSchemaUtil {
   }
 
   static Schema fromOptions(List<Schema> options) {
-    Preconditions.checkArgument(options.size() == 2,
+    checkArgument(options.size() == 2,
         "Expected two schemas, but was passed: %s options", options.size());
     if (options.get(0).getType() == Schema.Type.NULL) {
       return options.get(1);
@@ -240,13 +242,13 @@ public class AvroSchemaUtil {
   }
 
   public static int getKeyId(Schema schema) {
-    Preconditions.checkArgument(schema.getType() == MAP,
+    checkArgument(schema.getType() == MAP,
         "Cannot get map key id for non-map schema: %s", schema);
     return getId(schema, KEY_ID_PROP);
   }
 
   static Integer getKeyId(Schema schema, NameMapping nameMapping, Iterable<String> parentFieldNames) {
-    Preconditions.checkArgument(schema.getType() == MAP,
+    checkArgument(schema.getType() == MAP,
         "Cannot get map key id for non-map schema: %s", schema);
     List<String> names = Lists.newArrayList(parentFieldNames);
     names.add("key");
@@ -254,13 +256,13 @@ public class AvroSchemaUtil {
   }
 
   public static int getValueId(Schema schema) {
-    Preconditions.checkArgument(schema.getType() == MAP,
+    checkArgument(schema.getType() == MAP,
         "Cannot get map value id for non-map schema: %s", schema);
     return getId(schema, VALUE_ID_PROP);
   }
 
   static Integer getValueId(Schema schema, NameMapping nameMapping, Iterable<String> parentFieldNames) {
-    Preconditions.checkArgument(schema.getType() == MAP,
+    checkArgument(schema.getType() == MAP,
         "Cannot get map value id for non-map schema: %s", schema);
     List<String> names = Lists.newArrayList(parentFieldNames);
     names.add("value");
@@ -268,13 +270,13 @@ public class AvroSchemaUtil {
   }
 
   public static int getElementId(Schema schema) {
-    Preconditions.checkArgument(schema.getType() == ARRAY,
+    checkArgument(schema.getType() == ARRAY,
         "Cannot get array element id for non-array schema: %s", schema);
     return getId(schema, ELEMENT_ID_PROP);
   }
 
   static Integer getElementId(Schema schema, NameMapping nameMapping, Iterable<String> parentFieldNames) {
-    Preconditions.checkArgument(schema.getType() == ARRAY,
+    checkArgument(schema.getType() == ARRAY,
         "Cannot get array element id for non-array schema: %s", schema);
     List<String> names = Lists.newArrayList(parentFieldNames);
     names.add("element");
@@ -361,7 +363,7 @@ public class AvroSchemaUtil {
 
   static boolean validAvroName(String name) {
     int length = name.length();
-    Preconditions.checkArgument(length > 0, "Empty name");
+    checkArgument(length > 0, "Empty name");
     char first = name.charAt(0);
     if (!(Character.isLetter(first) || first == '_')) {
       return false;

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -30,6 +30,8 @@ import org.apache.avro.Schema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Renames and aliases fields in an Avro schema based on the current table schema.
  * <p>
@@ -49,7 +51,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
   @Override
   public Schema record(Schema record, List<String> names, Iterable<Schema.Field> schemaIterable) {
-    Preconditions.checkArgument(
+    checkArgument(
         current.isNestedType() && current.asNestedType().isStructType(),
         "Cannot project non-struct: %s", current);
 
@@ -93,7 +95,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
         updatedFields.add(avroField);
 
       } else {
-        Preconditions.checkArgument(field.isOptional(), "Missing required field: %s", field.name());
+        checkArgument(field.isOptional(), "Missing required field: %s", field.name());
         // Create a field that will be defaulted to null. We assign a unique suffix to the field
         // to make sure that even if records in the file have the field it is not projected.
         Schema.Field newField = new Schema.Field(
@@ -160,7 +162,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
   public Schema array(Schema array, Supplier<Schema> element) {
     if (array.getLogicalType() instanceof LogicalMap ||
         (current.isMapType() && AvroSchemaUtil.isKeyValueSchema(array.getElementType()))) {
-      Preconditions.checkArgument(current.isMapType(), "Incompatible projected type: %s", current);
+      checkArgument(current.isMapType(), "Incompatible projected type: %s", current);
       Types.MapType asMapType = current.asNestedType().asMapType();
       this.current = Types.StructType.of(asMapType.fields()); // create a struct to correspond to element
       try {
@@ -187,7 +189,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
       }
 
     } else {
-      Preconditions.checkArgument(current.isListType(),
+      checkArgument(current.isListType(),
           "Incompatible projected type: %s", current);
       Types.ListType list = current.asNestedType().asListType();
       this.current = list.elementType();
@@ -209,10 +211,10 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
   @Override
   public Schema map(Schema map, Supplier<Schema> value) {
-    Preconditions.checkArgument(current.isNestedType() && current.asNestedType().isMapType(),
+    checkArgument(current.isNestedType() && current.asNestedType().isMapType(),
         "Incompatible projected type: %s", current);
     Types.MapType asMapType = current.asNestedType().asMapType();
-    Preconditions.checkArgument(asMapType.keyType() == Types.StringType.get(),
+    checkArgument(asMapType.keyType() == Types.StringType.get(),
         "Incompatible projected type: key type %s is not string", asMapType.keyType());
     this.current = asMapType.valueType();
     try {

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroWriter.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.avro;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import org.apache.avro.LogicalType;
@@ -27,6 +26,8 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 class GenericAvroWriter<T> implements DatumWriter<T> {
   private ValueWriter<T> writer = null;
@@ -57,9 +58,9 @@ class GenericAvroWriter<T> implements DatumWriter<T> {
 
     @Override
     public ValueWriter<?> union(Schema union, List<ValueWriter<?>> options) {
-      Preconditions.checkArgument(options.contains(ValueWriters.nulls()),
+      checkArgument(options.contains(ValueWriters.nulls()),
           "Cannot create writer for non-option union: %s", union);
-      Preconditions.checkArgument(options.size() == 2,
+      checkArgument(options.size() == 2,
           "Cannot create writer for non-option union: %s", union);
       if (union.getTypes().get(0).getType() == Schema.Type.NULL) {
         return ValueWriters.option(0, options.get(1));

--- a/core/src/main/java/org/apache/iceberg/avro/LogicalMap.java
+++ b/core/src/main/java/org/apache/iceberg/avro/LogicalMap.java
@@ -19,9 +19,10 @@
 
 package org.apache.iceberg.avro;
 
-import com.google.common.base.Preconditions;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class LogicalMap extends LogicalType {
   static final String NAME = "map";
@@ -38,9 +39,9 @@ public class LogicalMap extends LogicalType {
   @Override
   public void validate(Schema schema) {
     super.validate(schema);
-    Preconditions.checkArgument(schema.getType() == Schema.Type.ARRAY,
+    checkArgument(schema.getType() == Schema.Type.ARRAY,
         "Invalid type for map, must be an array: %s", schema);
-    Preconditions.checkArgument(AvroSchemaUtil.isKeyValueSchema(schema.getElementType()),
+    checkArgument(AvroSchemaUtil.isKeyValueSchema(schema.getElementType()),
         "Invalid key-value record: %s", schema.getElementType());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.mapping.NameMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 class PruneColumns extends AvroSchemaVisitor<Schema> {
   private static final Logger LOG = LoggerFactory.getLogger(PruneColumns.class);
 
@@ -256,7 +258,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
 
     if (AvroSchemaUtil.hasFieldId(field)) {
       int existingFieldId = AvroSchemaUtil.getFieldId(field);
-      Preconditions.checkArgument(existingFieldId == fieldId,
+      checkArgument(existingFieldId == fieldId,
           "Existing field does match with that fetched from name mapping");
     } else {
       // field may not have a fieldId if the fieldId was fetched from nameMapping

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.avro;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.List;
 import org.apache.avro.LogicalType;
@@ -27,6 +26,8 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 class SchemaToType extends AvroSchemaVisitor<Type> {
   private final Schema root;
@@ -104,7 +105,7 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
 
   @Override
   public Type union(Schema union, List<Type> options) {
-    Preconditions.checkArgument(AvroSchemaUtil.isOptionSchema(union),
+    checkArgument(AvroSchemaUtil.isOptionSchema(union),
         "Unsupported type: non-option union: %s", union);
     // records, arrays, and maps will check nullability later
     if (options.get(0) == null) {
@@ -119,7 +120,7 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
     if (array.getLogicalType() instanceof LogicalMap) {
       // map stored as an array
       Schema keyValueSchema = array.getElementType();
-      Preconditions.checkArgument(AvroSchemaUtil.isKeyValueSchema(keyValueSchema),
+      checkArgument(AvroSchemaUtil.isKeyValueSchema(keyValueSchema),
           "Invalid key-value pair schema: %s", keyValueSchema);
 
       Types.StructType keyValueType = elementType.asStructType();
@@ -182,7 +183,7 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
           logical instanceof LogicalTypes.TimestampMillis ||
           logical instanceof LogicalTypes.TimestampMicros) {
         Object adjustToUTC = primitive.getObjectProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP);
-        Preconditions.checkArgument(adjustToUTC instanceof Boolean,
+        checkArgument(adjustToUTC instanceof Boolean,
             "Invalid value for adjust-to-utc: %s", adjustToUTC);
         if ((Boolean) adjustToUTC) {
           return Types.TimestampType.withZone();

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.avro;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
@@ -35,6 +34,8 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.types.TypeUtil;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class ValueWriters {
   private ValueWriters() {
@@ -258,7 +259,7 @@ public class ValueWriters {
 
     @Override
     public void write(byte[] bytes, Encoder encoder) throws IOException {
-      Preconditions.checkArgument(bytes.length == length,
+      checkArgument(bytes.length == length,
           "Cannot write byte array of length %s as fixed[%s]", bytes.length, length);
       encoder.writeFixed(bytes);
     }
@@ -273,7 +274,7 @@ public class ValueWriters {
 
     @Override
     public void write(GenericData.Fixed datum, Encoder encoder) throws IOException {
-      Preconditions.checkArgument(datum.bytes().length == length,
+      checkArgument(datum.bytes().length == length,
           "Cannot write byte array of length %s as fixed[%s]", datum.bytes().length, length);
       encoder.writeFixed(datum.bytes());
     }
@@ -318,9 +319,9 @@ public class ValueWriters {
 
     @Override
     public void write(BigDecimal decimal, Encoder encoder) throws IOException {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       byte fillByte = (byte) (decimal.signum() < 0 ? 0xFF : 0x00);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.hadoop;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.Closeable;
@@ -44,6 +43,8 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * HadoopCatalog provides a way to use table names like db.table to work with path-based tables under a common
@@ -72,7 +73,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
    * @param warehouseLocation The location used as warehouse directory
    */
   public HadoopCatalog(Configuration conf, String warehouseLocation) {
-    Preconditions.checkArgument(warehouseLocation != null && !warehouseLocation.equals(""),
+    checkArgument(warehouseLocation != null && !warehouseLocation.equals(""),
         "no location provided for warehouse");
 
     this.conf = conf;
@@ -98,7 +99,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    Preconditions.checkArgument(namespace.levels().length >= 1,
+    checkArgument(namespace.levels().length >= 1,
         "Missing database in table identifier: %s", namespace);
 
     Joiner slash = Joiner.on("/");
@@ -137,7 +138,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable {
   @Override
   public Table createTable(
       TableIdentifier identifier, Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
-    Preconditions.checkArgument(location == null, "Cannot set a custom location for a path-based table");
+    checkArgument(location == null, "Cannot set a custom location for a path-based table");
     return super.createTable(identifier, schema, spec, null, properties);
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hadoop;
 
-import com.google.common.base.Preconditions;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
@@ -30,6 +29,8 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * {@link InputFile} implementation using the Hadoop {@link FileSystem} API.
@@ -112,7 +113,7 @@ public class HadoopInputFile implements InputFile {
   }
 
   private HadoopInputFile(FileSystem fs, Path path, long length, Configuration conf) {
-    Preconditions.checkArgument(length >= 0, "Invalid file length: %s", length);
+    checkArgument(length >= 0, "Invalid file length: %s", length);
     this.fs = fs;
     this.path = path;
     this.conf = conf;

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -46,6 +46,8 @@ import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * TableOperations implementation for file systems that support atomic rename.
  * <p>
@@ -118,9 +120,9 @@ public class HadoopTableOperations implements TableOperations {
       return;
     }
 
-    Preconditions.checkArgument(base == null || base.location().equals(metadata.location()),
+    checkArgument(base == null || base.location().equals(metadata.location()),
         "Hadoop path-based tables cannot be relocated");
-    Preconditions.checkArgument(
+    checkArgument(
         !metadata.properties().containsKey(TableProperties.WRITE_METADATA_LOCATION),
         "Hadoop path-based tables cannot relocate metadata");
 

--- a/core/src/main/java/org/apache/iceberg/mapping/NameMappingParser.java
+++ b/core/src/main/java/org/apache/iceberg/mapping/NameMappingParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.mapping;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -30,6 +29,8 @@ import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.util.JsonUtil;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Parses external name mappings from a JSON representation.
@@ -111,7 +112,7 @@ public class NameMappingParser {
   }
 
   private static MappedFields fieldsFromJson(JsonNode node) {
-    Preconditions.checkArgument(node.isArray(), "Cannot parse non-array mapping fields: %s", node);
+    checkArgument(node.isArray(), "Cannot parse non-array mapping fields: %s", node);
 
     List<MappedField> fields = Lists.newArrayList();
     node.elements().forEachRemaining(fieldNode -> fields.add(fieldFromJson(fieldNode)));
@@ -120,7 +121,7 @@ public class NameMappingParser {
   }
 
   private static MappedField fieldFromJson(JsonNode node) {
-    Preconditions.checkArgument(node != null && !node.isNull() && node.isObject(),
+    checkArgument(node != null && !node.isNull() && node.isObject(),
         "Cannot parse non-object mapping field: %s", node);
 
     Integer id = JsonUtil.getIntOrNull(FIELD_ID, node);

--- a/core/src/main/java/org/apache/iceberg/util/BinPacking.java
+++ b/core/src/main/java/org/apache/iceberg/util/BinPacking.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.util;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -31,6 +30,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class BinPacking {
   public static class ListPacker<T> {
@@ -69,7 +70,7 @@ public class BinPacking {
 
     public PackingIterable(Iterable<T> iterable, long targetWeight, int lookback,
                            Function<T, Long> weightFunc, boolean largestBinFirst) {
-      Preconditions.checkArgument(lookback > 0,
+      checkArgument(lookback > 0,
           "Bin look-back size must be greater than 0: %s", lookback);
       this.iterable = iterable;
       this.targetWeight = targetWeight;

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -22,12 +22,13 @@ package org.apache.iceberg.util;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class JsonUtil {
 
@@ -45,9 +46,9 @@ public class JsonUtil {
   }
 
   public static int getInt(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing int %s", property);
+    checkArgument(node.has(property), "Cannot parse missing int %s", property);
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
         "Cannot parse %s from non-numeric value: %s", property, pNode);
     return pNode.asInt();
   }
@@ -57,31 +58,31 @@ public class JsonUtil {
       return null;
     }
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isIntegralNumber() && pNode.canConvertToInt(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isIntegralNumber() && pNode.canConvertToInt(),
         "Cannot parse %s from non-string value: %s", property, pNode);
     return pNode.asInt();
   }
 
   public static long getLong(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing int %s", property);
+    checkArgument(node.has(property), "Cannot parse missing int %s", property);
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
         "Cannot parse %s from non-numeric value: %s", property, pNode);
     return pNode.asLong();
   }
 
   public static boolean getBool(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing boolean %s", property);
+    checkArgument(node.has(property), "Cannot parse missing boolean %s", property);
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isBoolean(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isBoolean(),
         "Cannot parse %s from non-boolean value: %s", property, pNode);
     return pNode.asBoolean();
   }
 
   public static String getString(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing string %s", property);
+    checkArgument(node.has(property), "Cannot parse missing string %s", property);
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isTextual(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isTextual(),
         "Cannot parse %s from non-string value: %s", property, pNode);
     return pNode.asText();
   }
@@ -94,15 +95,15 @@ public class JsonUtil {
     if (pNode != null && pNode.isNull()) {
       return null;
     }
-    Preconditions.checkArgument(pNode != null && pNode.isTextual(),
+    checkArgument(pNode != null && pNode.isTextual(),
         "Cannot parse %s from non-string value: %s", property, pNode);
     return pNode.asText();
   }
 
   public static Map<String, String> getStringMap(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing map %s", property);
+    checkArgument(node.has(property), "Cannot parse missing map %s", property);
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isObject(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isObject(),
         "Cannot parse %s from non-object value: %s", property, pNode);
 
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
@@ -115,16 +116,16 @@ public class JsonUtil {
   }
 
   public static List<String> getStringList(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing list %s", property);
+    checkArgument(node.has(property), "Cannot parse missing list %s", property);
     JsonNode pNode = node.get(property);
-    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isArray(),
+    checkArgument(pNode != null && !pNode.isNull() && pNode.isArray(),
         "Cannot parse %s from non-array value: %s", property, pNode);
 
     ImmutableList.Builder<String> builder = ImmutableList.builder();
     Iterator<JsonNode> elements = pNode.elements();
     while (elements.hasNext()) {
       JsonNode element = elements.next();
-      Preconditions.checkArgument(element.isTextual(),
+      checkArgument(element.isTextual(),
           "Cannot parse string from non-text value: %s", element);
       builder.add(element.asText());
     }

--- a/data/src/main/java/org/apache/iceberg/data/GenericRecord.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericRecord.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.data;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.Arrays;
 import java.util.List;
@@ -31,6 +30,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class GenericRecord implements Record, StructLike {
   private static final LoadingCache<StructType, Map<String, Integer>> NAME_MAP_CACHE =
@@ -100,7 +101,7 @@ public class GenericRecord implements Record, StructLike {
   @Override
   public void setField(String name, Object value) {
     Integer pos = nameToPos.get(name);
-    Preconditions.checkArgument(pos != null, "Cannot set unknown field named: %s", name);
+    checkArgument(pos != null, "Cannot set unknown field named: %s", name);
     values[pos] = value;
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.data;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.Closeable;
@@ -46,6 +45,8 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 class TableScanIterable extends CloseableGroup implements CloseableIterable<Record> {
   private final TableOperations ops;
   private final Schema projection;
@@ -54,7 +55,7 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
   private final CloseableIterable<CombinedScanTask> tasks;
 
   TableScanIterable(TableScan scan, boolean reuseContainers) {
-    Preconditions.checkArgument(scan.table() instanceof HasTableOperations,
+    checkArgument(scan.table() instanceof HasTableOperations,
         "Cannot scan table that doesn't expose its TableOperations");
     this.ops = ((HasTableOperations) scan.table()).operations();
     this.projection = scan.schema();

--- a/data/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/data/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.data.avro;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import org.apache.avro.LogicalType;
@@ -32,6 +31,8 @@ import org.apache.iceberg.avro.AvroSchemaVisitor;
 import org.apache.iceberg.avro.LogicalMap;
 import org.apache.iceberg.avro.ValueWriter;
 import org.apache.iceberg.avro.ValueWriters;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class DataWriter<T> implements DatumWriter<T> {
   private ValueWriter<T> writer = null;
@@ -66,9 +67,9 @@ public class DataWriter<T> implements DatumWriter<T> {
 
     @Override
     public ValueWriter<?> union(Schema union, List<ValueWriter<?>> options) {
-      Preconditions.checkArgument(options.contains(ValueWriters.nulls()),
+      checkArgument(options.contains(ValueWriters.nulls()),
           "Cannot create writer for non-option union: %s", union);
-      Preconditions.checkArgument(options.size() == 2,
+      checkArgument(options.size() == 2,
           "Cannot create writer for non-option union: %s", union);
       if (union.getTypes().get(0).getType() == Schema.Type.NULL) {
         return ValueWriters.option(0, options.get(1));

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -53,6 +53,8 @@ import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
 import org.apache.orc.storage.ql.exec.vector.TimestampColumnVector;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * ORC reader for Generic Record.
  */
@@ -316,7 +318,7 @@ public class GenericOrcReader implements OrcValueReader<Record> {
     private final Converter childConverter;
 
     ListConverter(Types.NestedField icebergField, TypeDescription schema) {
-      Preconditions.checkArgument(icebergField.type().isListType());
+      checkArgument(icebergField.type().isListType());
       TypeDescription child = schema.getChildren().get(0);
 
       childConverter = buildConverter(icebergField
@@ -353,7 +355,7 @@ public class GenericOrcReader implements OrcValueReader<Record> {
     private final Converter valueConvert;
 
     MapConverter(Types.NestedField icebergField, TypeDescription schema) {
-      Preconditions.checkArgument(icebergField.type().isMapType());
+      checkArgument(icebergField.type().isMapType());
       TypeDescription keyType = schema.getChildren().get(0);
       TypeDescription valueType = schema.getChildren().get(1);
       List<Types.NestedField> mapFields = icebergField.type().asMapType().fields();
@@ -392,7 +394,7 @@ public class GenericOrcReader implements OrcValueReader<Record> {
     private final Schema icebergStructSchema;
 
     StructConverter(final Types.NestedField icebergField, final TypeDescription schema) {
-      Preconditions.checkArgument(icebergField.type().isStructType());
+      checkArgument(icebergField.type().isStructType());
       icebergStructSchema = new Schema(icebergField.type().asStructType().fields());
       List<Types.NestedField> icebergChildren = icebergField.type().asStructType().fields();
       children = new Converter[schema.getChildren().size()];

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -41,6 +41,8 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
@@ -58,7 +60,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    Preconditions.checkArgument(namespace.levels().length == 1,
+    checkArgument(namespace.levels().length == 1,
         "Missing database in namespace: %s", namespace);
     String database = namespace.level(0);
 
@@ -132,7 +134,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
     if (!isValidIdentifier(from)) {
       throw new NoSuchTableException("Invalid identifier: %s", from);
     }
-    Preconditions.checkArgument(isValidIdentifier(to), "Invalid identifier: %s", to);
+    checkArgument(isValidIdentifier(to), "Invalid identifier: %s", to);
 
     String toDatabase = to.namespace().level(0);
     String fromDatabase = from.namespace().level(0);

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -36,6 +36,8 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Utilities for mapping Iceberg to ORC schemas.
  */
@@ -294,7 +296,7 @@ public final class ORCSchemaUtil {
           if (promotedType.isPresent()) {
             orcType = promotedType.get();
           } else {
-            Preconditions.checkArgument(isSameType(originalType, type),
+            checkArgument(isSameType(originalType, type),
                 "Can not promote %s type to %s",
                 originalType.getCategory(), type.typeId().name());
             orcType = originalType.clone();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.parquet.Preconditions;
 import org.apache.parquet.schema.DecimalMetadata;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
@@ -34,6 +33,7 @@ import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type.Repetition;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -69,9 +69,9 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     for (int i = 0; i < parquetFields.size(); i += 1) {
       org.apache.parquet.schema.Type field = parquetFields.get(i);
 
-      Preconditions.checkArgument(
+      checkArgument(
           !field.isRepetition(Repetition.REPEATED),
-          "Fields cannot have repetition REPEATED: {}", field);
+          "Fields cannot have repetition REPEATED: %s", field);
 
       int fieldId = getId(field);
 
@@ -92,9 +92,9 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     GroupType repeated = array.getType(0).asGroupType();
     org.apache.parquet.schema.Type element = repeated.getType(0);
 
-    Preconditions.checkArgument(
+    checkArgument(
         !element.isRepetition(Repetition.REPEATED),
-        "Elements cannot have repetition REPEATED: {}", element);
+        "Elements cannot have repetition REPEATED: %s", element);
 
     int elementFieldId = getId(element);
 
@@ -113,9 +113,9 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     org.apache.parquet.schema.Type key = keyValue.getType(0);
     org.apache.parquet.schema.Type value = keyValue.getType(1);
 
-    Preconditions.checkArgument(
+    checkArgument(
         !value.isRepetition(Repetition.REPEATED),
-        "Values cannot have repetition REPEATED: {}", value);
+        "Values cannot have repetition REPEATED: %s", value);
 
     int keyFieldId = getId(key);
     int valueFieldId = getId(value);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import org.apache.parquet.CorruptDeltaByteArrays;
 import org.apache.parquet.bytes.ByteBufferInputStream;
@@ -33,6 +32,8 @@ import org.apache.parquet.column.values.RequiresPreviousReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 abstract class PageIterator<T> extends BasePageIterator implements TripleIterator<T> {
   @SuppressWarnings("unchecked")
@@ -98,7 +99,7 @@ abstract class PageIterator<T> extends BasePageIterator implements TripleIterato
 
   @Override
   public int currentDefinitionLevel() {
-    Preconditions.checkArgument(currentDL >= 0, "Should not read definition, past page end");
+    checkArgument(currentDL >= 0, "Should not read definition, past page end");
     return currentDL;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -56,6 +56,7 @@ import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION_LEVEL;
@@ -209,7 +210,7 @@ public class Parquet {
       MessageType type = ParquetSchemaUtil.convert(schema, name);
 
       if (createWriterFunc != null) {
-        Preconditions.checkArgument(writeSupport == null,
+        checkArgument(writeSupport == null,
             "Cannot write with both write support and Parquet value writer");
         Configuration conf;
         if (file instanceof HadoopOutputFile) {
@@ -360,14 +361,14 @@ public class Parquet {
     }
 
     public ReadBuilder createReaderFunc(Function<MessageType, ParquetValueReader<?>> newReaderFunction) {
-      Preconditions.checkArgument(this.batchedReaderFunc == null,
+      checkArgument(this.batchedReaderFunc == null,
           "Reader function cannot be set since the batched version is already set");
       this.readerFunc = newReaderFunction;
       return this;
     }
 
     public ReadBuilder createBatchedReaderFunc(Function<MessageType, VectorizedReader<?>> func) {
-      Preconditions.checkArgument(this.readerFunc == null,
+      checkArgument(this.readerFunc == null,
           "Batched reader function cannot be set since the non-batched version is already set");
       this.batchedReaderFunc = func;
       return this;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvro.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvro.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.math.BigDecimal;
 import java.util.List;
@@ -35,6 +34,8 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaVisitor;
 import org.apache.iceberg.avro.UUIDConversion;
 import org.apache.iceberg.types.TypeUtil;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 class ParquetAvro {
 
@@ -83,11 +84,11 @@ class ParquetAvro {
       super.validate(schema);
       switch (schema.getType()) {
         case INT:
-          Preconditions.checkArgument(precision <= 9,
+          checkArgument(precision <= 9,
               "Int cannot hold decimal precision: %s", precision);
           break;
         case LONG:
-          Preconditions.checkArgument(precision <= 18,
+          checkArgument(precision <= 18,
               "Long cannot hold decimal precision: %s", precision);
           break;
         case FIXED:
@@ -95,8 +96,8 @@ class ParquetAvro {
         default:
           throw new IllegalArgumentException("Invalid base type for decimal: " + schema);
       }
-      Preconditions.checkArgument(scale >= 0, "Scale %s cannot be negative", scale);
-      Preconditions.checkArgument(scale <= precision,
+      checkArgument(scale >= 0, "Scale %s cannot be negative", scale);
+      checkArgument(scale <= precision,
           "Scale %s cannot be less than precision %s", scale, precision);
     }
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeVisitor.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.Deque;
 import java.util.List;
@@ -28,6 +27,8 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class ParquetTypeVisitor<T> {
   @SuppressWarnings("checkstyle:VisibilityModifier")
@@ -48,15 +49,15 @@ public class ParquetTypeVisitor<T> {
       if (annotation != null) {
         switch (annotation) {
           case LIST:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
                 "Invalid list: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
+            checkArgument(group.getFieldCount() == 1,
                 "Invalid list: does not contain single repeated field: %s", group);
 
             GroupType repeatedElement = group.getFields().get(0).asGroupType();
-            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
                 "Invalid list: inner group is not repeated");
-            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+            checkArgument(repeatedElement.getFieldCount() <= 1,
                 "Invalid list: repeated group is not a single field: %s", group);
 
             visitor.fieldNames.push(repeatedElement.getName());
@@ -73,15 +74,15 @@ public class ParquetTypeVisitor<T> {
             }
 
           case MAP:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
                 "Invalid map: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
+            checkArgument(group.getFieldCount() == 1,
                 "Invalid map: does not contain single repeated field: %s", group);
 
             GroupType repeatedKeyValue = group.getType(0).asGroupType();
-            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
                 "Invalid map: inner group is not repeated");
-            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+            checkArgument(repeatedKeyValue.getFieldCount() <= 2,
                 "Invalid map: repeated group does not have 2 fields");
 
             visitor.fieldNames.push(repeatedKeyValue.getName());

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
@@ -34,6 +33,8 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.Type;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class ParquetValueWriters {
   private ParquetValueWriters() {
@@ -150,9 +151,9 @@ public class ParquetValueWriters {
 
     @Override
     public void write(int repetitionLevel, BigDecimal decimal) {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       column.writeInteger(repetitionLevel, decimal.unscaledValue().intValue());
@@ -171,9 +172,9 @@ public class ParquetValueWriters {
 
     @Override
     public void write(int repetitionLevel, BigDecimal decimal) {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       column.writeLong(repetitionLevel, decimal.unscaledValue().longValue());
@@ -196,9 +197,9 @@ public class ParquetValueWriters {
 
     @Override
     public void write(int repetitionLevel, BigDecimal decimal) {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       byte fillByte = (byte) (decimal.signum() < 0 ? 0xFF : 0x00);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,6 +28,8 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Visitor for traversing a Parquet type with a companion Iceberg type.
@@ -58,15 +59,15 @@ public class TypeWithSchemaVisitor<T> {
       if (annotation != null) {
         switch (annotation) {
           case LIST:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
                 "Invalid list: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
+            checkArgument(group.getFieldCount() == 1,
                 "Invalid list: does not contain single repeated field: %s", group);
 
             GroupType repeatedElement = group.getFields().get(0).asGroupType();
-            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
                 "Invalid list: inner group is not repeated");
-            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+            checkArgument(repeatedElement.getFieldCount() <= 1,
                 "Invalid list: repeated group is not a single field: %s", group);
 
             Types.ListType list = null;
@@ -89,15 +90,15 @@ public class TypeWithSchemaVisitor<T> {
             }
 
           case MAP:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
                 "Invalid map: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
+            checkArgument(group.getFieldCount() == 1,
                 "Invalid map: does not contain single repeated field: %s", group);
 
             GroupType repeatedKeyValue = group.getType(0).asGroupType();
-            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
+            checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
                 "Invalid map: inner group is not repeated");
-            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+            checkArgument(repeatedKeyValue.getFieldCount() <= 2,
                 "Invalid map: repeated group does not have 2 fields");
 
             Types.MapType map = null;

--- a/spark/src/main/java/org/apache/iceberg/spark/FixupTypes.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/FixupTypes.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.function.Supplier;
@@ -27,6 +26,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * This is used to fix primitive types to match a table schema. Some types, like binary and fixed,
@@ -55,7 +56,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type struct(Types.StructType struct, Iterable<Type> fieldTypes) {
-    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
+    checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     List<Types.NestedField> fields = struct.fields();
     int length = fields.size();
@@ -89,7 +90,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type field(Types.NestedField field, Supplier<Type> future) {
-    Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
+    checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     Types.StructType sourceStruct = sourceType.asStructType();
     this.sourceType = sourceStruct.field(field.fieldId()).type();
@@ -102,7 +103,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type list(Types.ListType list, Supplier<Type> elementTypeFuture) {
-    Preconditions.checkArgument(sourceType.isListType(), "Not a list: %s", sourceType);
+    checkArgument(sourceType.isListType(), "Not a list: %s", sourceType);
 
     Types.ListType sourceList = sourceType.asListType();
     this.sourceType = sourceList.elementType();
@@ -125,7 +126,7 @@ class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type map(Types.MapType map, Supplier<Type> keyTypeFuture, Supplier<Type> valueTypeFuture) {
-    Preconditions.checkArgument(sourceType.isMapType(), "Not a map: %s", sourceType);
+    checkArgument(sourceType.isMapType(), "Not a map: %s", sourceType);
 
     Types.MapType sourceMap = sourceType.asMapType();
     try {

--- a/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
@@ -48,6 +48,8 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.TimestampType;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   private final StructType requestedType;
   private final Set<Integer> filterRefs;
@@ -71,7 +73,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
   @Override
   public Type struct(Types.StructType struct, Iterable<Type> fieldResults) {
     Preconditions.checkNotNull(struct, "Cannot prune null struct. Pruning must start with a schema.");
-    Preconditions.checkArgument(current instanceof StructType, "Not a struct: %s", current);
+    checkArgument(current instanceof StructType, "Not a struct: %s", current);
     StructType requestedStruct = (StructType) current;
 
     List<Types.NestedField> fields = struct.fields();
@@ -130,7 +132,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
 
   @Override
   public Type field(Types.NestedField field, Supplier<Type> fieldResult) {
-    Preconditions.checkArgument(current instanceof StructType, "Not a struct: %s", current);
+    checkArgument(current instanceof StructType, "Not a struct: %s", current);
     StructType requestedStruct = (StructType) current;
 
     // fields are resolved by name because Spark only sees the current table schema.
@@ -145,7 +147,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
     int fieldIndex = requestedStruct.fieldIndex(field.name());
     StructField requestedField = requestedStruct.fields()[fieldIndex];
 
-    Preconditions.checkArgument(requestedField.nullable() || field.isRequired(),
+    checkArgument(requestedField.nullable() || field.isRequired(),
         "Cannot project an optional field as non-null: %s", field.name());
 
     this.current = requestedField.dataType();
@@ -161,10 +163,10 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
 
   @Override
   public Type list(Types.ListType list, Supplier<Type> elementResult) {
-    Preconditions.checkArgument(current instanceof ArrayType, "Not an array: %s", current);
+    checkArgument(current instanceof ArrayType, "Not an array: %s", current);
     ArrayType requestedArray = (ArrayType) current;
 
-    Preconditions.checkArgument(requestedArray.containsNull() || !list.isElementOptional(),
+    checkArgument(requestedArray.containsNull() || !list.isElementOptional(),
         "Cannot project an array of optional elements as required elements: %s", requestedArray);
 
     this.current = requestedArray.elementType();
@@ -187,12 +189,12 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
 
   @Override
   public Type map(Types.MapType map, Supplier<Type> keyResult, Supplier<Type> valueResult) {
-    Preconditions.checkArgument(current instanceof MapType, "Not a map: %s", current);
+    checkArgument(current instanceof MapType, "Not a map: %s", current);
     MapType requestedMap = (MapType) current;
 
-    Preconditions.checkArgument(requestedMap.valueContainsNull() || !map.isValueOptional(),
+    checkArgument(requestedMap.valueContainsNull() || !map.isValueOptional(),
         "Cannot project a map of optional values as required values: %s", map);
-    Preconditions.checkArgument(StringType.class.isInstance(requestedMap.keyType()),
+    checkArgument(StringType.class.isInstance(requestedMap.keyType()),
         "Invalid map key type (not string): %s", requestedMap.keyType());
 
     this.current = requestedMap.valueType();
@@ -215,7 +217,7 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
   @Override
   public Type primitive(Type.PrimitiveType primitive) {
     Class<? extends DataType> expectedType = TYPES.get(primitive.typeId());
-    Preconditions.checkArgument(expectedType != null && expectedType.isInstance(current),
+    checkArgument(expectedType != null && expectedType.isInstance(current),
         "Cannot project %s to incompatible type: %s", primitive, current);
 
     // additional checks based on type
@@ -223,15 +225,15 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         DecimalType requestedDecimal = (DecimalType) current;
-        Preconditions.checkArgument(requestedDecimal.scale() == decimal.scale(),
+        checkArgument(requestedDecimal.scale() == decimal.scale(),
             "Cannot project decimal with incompatible scale: %s != %s", requestedDecimal.scale(), decimal.scale());
-        Preconditions.checkArgument(requestedDecimal.precision() >= decimal.precision(),
+        checkArgument(requestedDecimal.precision() >= decimal.precision(),
             "Cannot project decimal with incompatible precision: %s < %s",
             requestedDecimal.precision(), decimal.precision());
         break;
       case TIMESTAMP:
         Types.TimestampType timestamp = (Types.TimestampType) primitive;
-        Preconditions.checkArgument(timestamp.shouldAdjustToUTC(),
+        checkArgument(timestamp.shouldAdjustToUTC(),
             "Cannot project timestamp (without time zone) as timestamptz (with time zone)");
         break;
       default:

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.data;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
@@ -37,6 +36,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.unsafe.types.UTF8String;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class SparkAvroWriter implements DatumWriter<InternalRow> {
   private final org.apache.iceberg.Schema schema;
@@ -77,9 +78,9 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
 
     @Override
     public ValueWriter<?> union(Schema union, List<ValueWriter<?>> options) {
-      Preconditions.checkArgument(options.contains(ValueWriters.nulls()),
+      checkArgument(options.contains(ValueWriters.nulls()),
           "Cannot create writer for non-option union: %s", union);
-      Preconditions.checkArgument(options.size() == 2,
+      checkArgument(options.size() == 2,
           "Cannot create writer for non-option union: %s", union);
       if (union.getTypes().get(0).getType() == Schema.Type.NULL) {
         return ValueWriters.option(0, options.get(1));

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.data;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.math.BigDecimal;
 import java.util.Iterator;
@@ -49,6 +48,8 @@ import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class SparkParquetWriters {
   private SparkParquetWriters() {
@@ -259,9 +260,9 @@ public class SparkParquetWriters {
 
     @Override
     public void write(int repetitionLevel, Decimal decimal) {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       column.writeInteger(repetitionLevel, (int) decimal.toUnscaledLong());
@@ -280,9 +281,9 @@ public class SparkParquetWriters {
 
     @Override
     public void write(int repetitionLevel, Decimal decimal) {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       column.writeLong(repetitionLevel, decimal.toUnscaledLong());
@@ -305,9 +306,9 @@ public class SparkParquetWriters {
 
     @Override
     public void write(int repetitionLevel, Decimal decimal) {
-      Preconditions.checkArgument(decimal.scale() == scale,
+      checkArgument(decimal.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, decimal);
-      Preconditions.checkArgument(decimal.precision() <= precision,
+      checkArgument(decimal.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, decimal);
 
       BigDecimal bigDecimal = decimal.toJavaBigDecimal();

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.data;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
@@ -37,6 +36,8 @@ import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class SparkValueWriters {
 
@@ -126,9 +127,9 @@ public class SparkValueWriters {
 
     @Override
     public void write(Decimal d, Encoder encoder) throws IOException {
-      Preconditions.checkArgument(d.scale() == scale,
+      checkArgument(d.scale() == scale,
           "Cannot write value as decimal(%s,%s), wrong scale: %s", precision, scale, d);
-      Preconditions.checkArgument(d.precision() <= precision,
+      checkArgument(d.precision() <= precision,
           "Cannot write value as decimal(%s,%s), too large: %s", precision, scale, d);
 
       BigDecimal decimal = d.toJavaBigDecimal();

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.encryption.EncryptedFiles;
@@ -36,6 +35,8 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Base class of readers of type {@link InputPartitionReader} to read data as objects of type @param &lt;T&gt;
@@ -104,7 +105,7 @@ abstract class BaseDataReader<T> implements InputPartitionReader<T> {
   }
 
   InputFile getInputFile(FileScanTask task) {
-    Preconditions.checkArgument(!task.isDataTask(), "Invalid task type");
+    checkArgument(!task.isDataTask(), "Invalid task type");
     return inputFiles.get(task.file().path().toString());
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.source;
 
-import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +56,8 @@ import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.SerializableConfiguration;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, DataSourceRegister, StreamWriteSupport {
 
@@ -96,7 +97,7 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
   @Override
   public Optional<DataSourceWriter> createWriter(String jobId, StructType dsStruct, SaveMode mode,
                                                  DataSourceOptions options) {
-    Preconditions.checkArgument(mode == SaveMode.Append || mode == SaveMode.Overwrite,
+    checkArgument(mode == SaveMode.Append || mode == SaveMode.Overwrite,
         "Save mode %s is not supported", mode);
     Configuration conf = new Configuration(lazyBaseConf());
     Table table = getTableAndResolveHadoopConfiguration(options, conf);
@@ -116,7 +117,7 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
   @Override
   public StreamWriter createStreamWriter(String runId, StructType dsStruct,
                                          OutputMode mode, DataSourceOptions options) {
-    Preconditions.checkArgument(
+    checkArgument(
         mode == OutputMode.Append() || mode == OutputMode.Complete(),
         "Output mode %s is not supported", mode);
     Configuration conf = new Configuration(lazyBaseConf());
@@ -137,7 +138,7 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
 
   protected Table findTable(DataSourceOptions options, Configuration conf) {
     Optional<String> path = options.get("path");
-    Preconditions.checkArgument(path.isPresent(), "Cannot open table: path is not set");
+    checkArgument(path.isPresent(), "Cannot open table: path is not set");
 
     if (path.get().contains("/")) {
       HadoopTables tables = new HadoopTables(conf);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.source;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -37,6 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.avro.Schema.Type.UNION;
 
 public abstract class TestReadProjection {
@@ -567,9 +567,9 @@ public abstract class TestReadProjection {
   }
 
   private static org.apache.avro.Schema fromOption(org.apache.avro.Schema schema) {
-    Preconditions.checkArgument(schema.getType() == UNION,
+    checkArgument(schema.getType() == UNION,
         "Expected union schema but was passed: %s", schema);
-    Preconditions.checkArgument(schema.getTypes().size() == 2,
+    checkArgument(schema.getTypes().size() == 2,
         "Expected optional schema, but was passed: %s", schema);
     if (schema.getTypes().get(0).getType() == org.apache.avro.Schema.Type.NULL) {
       return schema.getTypes().get(1);


### PR DESCRIPTION
1. static import the method of Preconditions.checkArgument to reduce code and make code cleaner

2. replace org.apache.parquet.Preconditions.checkArgument to com.google.common.base.Preconditions.checkArgument

3. replace org.apache.arrow.util.Preconditions.checkArgument to com.google.common.base.Preconditions.checkArgument