### PR TITLE
Spark: Add ORC to parameterized tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,6 +299,7 @@ project(':iceberg-spark') {
       exclude group: 'org.apache.avro', module: 'avro'
     }
 
+    testCompile project(':iceberg-data')
     testCompile "org.apache.hadoop:hadoop-hdfs::tests"
     testCompile "org.apache.hadoop:hadoop-common::tests"
     testCompile("org.apache.hadoop:hadoop-minicluster") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2048m

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,3 @@
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2048m

--- a/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -50,6 +50,9 @@ import static scala.collection.JavaConverters.mapAsJavaMapConverter;
 import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
 public class GenericsHelpers {
+  private GenericsHelpers() {
+  }
+
   private static final OffsetDateTime EPOCH = Instant.ofEpochMilli(0L).atOffset(ZoneOffset.UTC);
   private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
 
@@ -229,10 +232,12 @@ public class GenericsHelpers {
       case FLOAT:
       case DOUBLE:
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        break;
       case DATE:
         Assert.assertTrue("Should expect a LocalDate", expected instanceof LocalDate);
         long expectedDays = ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
         Assert.assertEquals("Primitive value should be equal to expected", expectedDays, actual);
+        break;
       case TIMESTAMP:
         Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
         long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import com.google.common.collect.Lists;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.Assert;
+import scala.collection.Seq;
+
+import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
+import static scala.collection.JavaConverters.mapAsJavaMapConverter;
+import static scala.collection.JavaConverters.seqAsJavaListConverter;
+
+public class GenericsHelpers {
+  private static final OffsetDateTime EPOCH = Instant.ofEpochMilli(0L).atOffset(ZoneOffset.UTC);
+  private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
+
+  public static void assertEqualsSafe(Types.StructType struct, Record rec, Row row) {
+    List<Types.NestedField> fields = struct.fields();
+    for (int i = 0; i < fields.size(); i += 1) {
+      Type fieldType = fields.get(i).type();
+
+      Object expectedValue = rec.get(i);
+      Object actualValue = row.get(i);
+
+      assertEqualsSafe(fieldType, expectedValue, actualValue);
+    }
+  }
+
+  private static void assertEqualsSafe(Types.ListType list, Collection<?> expected, List<?> actual) {
+    Type elementType = list.elementType();
+    List<?> expectedElements = Lists.newArrayList(expected);
+    for (int i = 0; i < expectedElements.size(); i += 1) {
+      Object expectedValue = expectedElements.get(i);
+      Object actualValue = actual.get(i);
+
+      assertEqualsSafe(elementType, expectedValue, actualValue);
+    }
+  }
+
+  private static void assertEqualsSafe(Types.MapType map,
+                                       Map<?, ?> expected, Map<?, ?> actual) {
+    Type keyType = map.keyType();
+    Type valueType = map.valueType();
+
+    for (Object expectedKey : expected.keySet()) {
+      Object matchingKey = null;
+      for (Object actualKey : actual.keySet()) {
+        try {
+          assertEqualsSafe(keyType, expectedKey, actualKey);
+          matchingKey = actualKey;
+        } catch (AssertionError e) {
+          // failed
+        }
+      }
+
+      Assert.assertNotNull("Should have a matching key", matchingKey);
+      assertEqualsSafe(valueType, expected.get(expectedKey), actual.get(matchingKey));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertEqualsSafe(Type type, Object expected, Object actual) {
+    if (expected == null && actual == null) {
+      return;
+    }
+
+    switch (type.typeId()) {
+      case BOOLEAN:
+      case INTEGER:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        break;
+      case DATE:
+        Assert.assertTrue("Should expect a LocalDate", expected instanceof LocalDate);
+        Assert.assertTrue("Should be a Date", actual instanceof Date);
+        Assert.assertEquals("ISO-8601 date should be equal", expected.toString(), actual.toString());
+        break;
+      case TIMESTAMP:
+        Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
+        Assert.assertTrue("Should be a Timestamp", actual instanceof Timestamp);
+        Timestamp ts = (Timestamp) actual;
+        // milliseconds from nanos has already been added by getTime
+        OffsetDateTime actualTs = EPOCH.plusNanos(
+            (ts.getTime() * 1_000_000) + (ts.getNanos() % 1_000_000));
+        Assert.assertEquals("Timestamp should be equal", expected, actualTs);
+        break;
+      case STRING:
+        Assert.assertTrue("Should be a String", actual instanceof String);
+        Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
+        break;
+      case UUID:
+        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
+        Assert.assertTrue("Should be a String", actual instanceof String);
+        Assert.assertEquals("UUID string representation should match",
+            expected.toString(), actual);
+        break;
+      case FIXED:
+        Assert.assertTrue("Should expect a byte[]", expected instanceof byte[]);
+        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assert.assertArrayEquals("Bytes should match",
+            (byte[]) expected, (byte[]) actual);
+        break;
+      case BINARY:
+        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
+        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assert.assertArrayEquals("Bytes should match",
+            ((ByteBuffer) expected).array(), (byte[]) actual);
+        break;
+      case DECIMAL:
+        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
+        Assert.assertTrue("Should be a BigDecimal", actual instanceof BigDecimal);
+        Assert.assertEquals("BigDecimals should be equal", expected, actual);
+        break;
+      case STRUCT:
+        Assert.assertTrue("Should expect a Record", expected instanceof Record);
+        Assert.assertTrue("Should be a Row", actual instanceof Row);
+        assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
+        break;
+      case LIST:
+        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
+        Assert.assertTrue("Should be a Seq", actual instanceof Seq);
+        List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
+        assertEqualsSafe(type.asNestedType().asListType(), (Collection<?>) expected, asList);
+        break;
+      case MAP:
+        Assert.assertTrue("Should expect a Collection", expected instanceof Map);
+        Assert.assertTrue("Should be a Map", actual instanceof scala.collection.Map);
+        Map<String, ?> asMap = mapAsJavaMapConverter(
+            (scala.collection.Map<String, ?>) actual).asJava();
+        assertEqualsSafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, asMap);
+        break;
+      case TIME:
+      default:
+        throw new IllegalArgumentException("Not a supported type: " + type);
+    }
+  }
+
+  public static void assertEqualsUnsafe(Types.StructType struct, Record rec, InternalRow row) {
+    List<Types.NestedField> fields = struct.fields();
+    for (int i = 0; i < fields.size(); i += 1) {
+      Type fieldType = fields.get(i).type();
+
+      Object expectedValue = rec.get(i);
+      Object actualValue = row.get(i, convert(fieldType));
+
+      assertEqualsUnsafe(fieldType, expectedValue, actualValue);
+    }
+  }
+
+  private static void assertEqualsUnsafe(Types.ListType list, Collection<?> expected, ArrayData actual) {
+    Type elementType = list.elementType();
+    List<?> expectedElements = Lists.newArrayList(expected);
+    for (int i = 0; i < expectedElements.size(); i += 1) {
+      Object expectedValue = expectedElements.get(i);
+      Object actualValue = actual.get(i, convert(elementType));
+
+      assertEqualsUnsafe(elementType, expectedValue, actualValue);
+    }
+  }
+
+  private static void assertEqualsUnsafe(Types.MapType map, Map<?, ?> expected, MapData actual) {
+    Type keyType = map.keyType();
+    Type valueType = map.valueType();
+
+    List<Map.Entry<?, ?>> expectedElements = Lists.newArrayList(expected.entrySet());
+    ArrayData actualKeys = actual.keyArray();
+    ArrayData actualValues = actual.valueArray();
+
+    for (int i = 0; i < expectedElements.size(); i += 1) {
+      Map.Entry<?, ?> expectedPair = expectedElements.get(i);
+      Object actualKey = actualKeys.get(i, convert(keyType));
+      Object actualValue = actualValues.get(i, convert(keyType));
+
+      assertEqualsUnsafe(keyType, expectedPair.getKey(), actualKey);
+      assertEqualsUnsafe(valueType, expectedPair.getValue(), actualValue);
+    }
+  }
+
+  private static void assertEqualsUnsafe(Type type, Object expected, Object actual) {
+    if (expected == null && actual == null) {
+      return;
+    }
+
+    switch (type.typeId()) {
+      case BOOLEAN:
+      case INTEGER:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+      case DATE:
+        Assert.assertTrue("Should expect a LocalDate", expected instanceof LocalDate);
+        long expectedDays = ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
+        Assert.assertEquals("Primitive value should be equal to expected", expectedDays, actual);
+      case TIMESTAMP:
+        Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
+        long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
+        Assert.assertEquals("Primitive value should be equal to expected", expectedMicros, actual);
+        break;
+      case STRING:
+        Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);
+        Assert.assertEquals("Strings should be equal", expected, actual.toString());
+        break;
+      case UUID:
+        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
+        Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);
+        Assert.assertEquals("UUID string representation should match",
+            expected.toString(), actual.toString());
+        break;
+      case FIXED:
+        Assert.assertTrue("Should expect a byte[]", expected instanceof byte[]);
+        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assert.assertArrayEquals("Bytes should match", (byte[]) expected, (byte[]) actual);
+        break;
+      case BINARY:
+        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
+        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assert.assertArrayEquals("Bytes should match",
+            ((ByteBuffer) expected).array(), (byte[]) actual);
+        break;
+      case DECIMAL:
+        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
+        Assert.assertTrue("Should be a Decimal", actual instanceof Decimal);
+        Assert.assertEquals("BigDecimals should be equal",
+            expected, ((Decimal) actual).toJavaBigDecimal());
+        break;
+      case STRUCT:
+        Assert.assertTrue("Should expect a Record", expected instanceof Record);
+        Assert.assertTrue("Should be an InternalRow", actual instanceof InternalRow);
+        assertEqualsUnsafe(type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
+        break;
+      case LIST:
+        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
+        Assert.assertTrue("Should be an ArrayData", actual instanceof ArrayData);
+        assertEqualsUnsafe(type.asNestedType().asListType(), (Collection<?>) expected, (ArrayData) actual);
+        break;
+      case MAP:
+        Assert.assertTrue("Should expect a Map", expected instanceof Map);
+        Assert.assertTrue("Should be an ArrayBasedMapData", actual instanceof MapData);
+        assertEqualsUnsafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, (MapData) actual);
+        break;
+      case TIME:
+      default:
+        throw new IllegalArgumentException("Not a supported type: " + type);
+    }
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -56,13 +56,13 @@ public class GenericsHelpers {
   private static final OffsetDateTime EPOCH = Instant.ofEpochMilli(0L).atOffset(ZoneOffset.UTC);
   private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
 
-  public static void assertEqualsSafe(Types.StructType struct, Record rec, Row row) {
+  public static void assertEqualsSafe(Types.StructType struct, Record expected, Row actual) {
     List<Types.NestedField> fields = struct.fields();
     for (int i = 0; i < fields.size(); i += 1) {
       Type fieldType = fields.get(i).type();
 
-      Object expectedValue = rec.get(i);
-      Object actualValue = row.get(i);
+      Object expectedValue = expected.get(i);
+      Object actualValue = actual.get(i);
 
       assertEqualsSafe(fieldType, expectedValue, actualValue);
     }
@@ -83,6 +83,7 @@ public class GenericsHelpers {
                                        Map<?, ?> expected, Map<?, ?> actual) {
     Type keyType = map.keyType();
     Type valueType = map.valueType();
+    Assert.assertEquals("Should have the same number of keys", expected.keySet().size(), actual.keySet().size());
 
     for (Object expectedKey : expected.keySet()) {
       Object matchingKey = null;
@@ -90,6 +91,7 @@ public class GenericsHelpers {
         try {
           assertEqualsSafe(keyType, expectedKey, actualKey);
           matchingKey = actualKey;
+          break;
         } catch (AssertionError e) {
           // failed
         }
@@ -179,13 +181,13 @@ public class GenericsHelpers {
     }
   }
 
-  public static void assertEqualsUnsafe(Types.StructType struct, Record rec, InternalRow row) {
+  public static void assertEqualsUnsafe(Types.StructType struct, Record expected, InternalRow actual) {
     List<Types.NestedField> fields = struct.fields();
     for (int i = 0; i < fields.size(); i += 1) {
       Type fieldType = fields.get(i).type();
 
-      Object expectedValue = rec.get(i);
-      Object actualValue = row.get(i, convert(fieldType));
+      Object expectedValue = expected.get(i);
+      Object actualValue = actual.get(i, convert(fieldType));
 
       assertEqualsUnsafe(fieldType, expectedValue, actualValue);
     }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.GenericData.Record;
@@ -161,11 +162,8 @@ public class TestDataFrameWrites extends AvroDataTest {
 
     table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
 
-    List<Record> expected = RandomData.generateList(tableSchema, 100, 0L);
-    Dataset<Row> df = createDataset(expected, tableSchema);
-    DataFrameWriter<?> writer = df.write().format("iceberg").mode("append");
-
-    writer.save(location.toString());
+    Iterable<Record> expected = RandomData.generate(tableSchema, 100, 0L);
+    writeData(expected, tableSchema, location.toString());
 
     table.refresh();
 
@@ -175,10 +173,12 @@ public class TestDataFrameWrites extends AvroDataTest {
 
     List<Row> actual = result.collectAsList();
 
-    Assert.assertEquals("Result size should match expected", expected.size(), actual.size());
-    for (int i = 0; i < expected.size(); i += 1) {
-      assertEqualsSafe(tableSchema.asStruct(), expected.get(i), actual.get(i));
+    Iterator<Record> expectedIter = expected.iterator();
+    Iterator<Row> actualIter = actual.iterator();
+    while (expectedIter.hasNext() && actualIter.hasNext()) {
+      assertEqualsSafe(tableSchema.asStruct(), expectedIter.next(), actualIter.next());
     }
+    Assert.assertEquals("Both iterators should be exhausted", expectedIter.hasNext(), actualIter.hasNext());
 
     table.currentSnapshot().addedFiles().forEach(dataFile ->
         Assert.assertTrue(
@@ -189,7 +189,13 @@ public class TestDataFrameWrites extends AvroDataTest {
             URI.create(dataFile.path().toString()).getPath().startsWith(expectedDataDir.getAbsolutePath())));
   }
 
-  private Dataset<Row> createDataset(List<Record> records, Schema schema) throws IOException {
+  private void writeData(Iterable<Record> records, Schema schema, String location) throws IOException {
+    Dataset<Row> df = createDataset(records, schema);
+    DataFrameWriter<?> writer = df.write().format("iceberg").mode("append");
+    writer.save(location);
+  }
+
+  private Dataset<Row> createDataset(Iterable<Record> records, Schema schema) throws IOException {
     // this uses the SparkAvroReader to create a DataFrame from the list of records
     // it assumes that SparkAvroReader is correct
     File testFile = temp.newFile();
@@ -204,17 +210,21 @@ public class TestDataFrameWrites extends AvroDataTest {
       }
     }
 
-    List<InternalRow> rows;
+    // make sure the dataframe matches the records before moving on
+    List<InternalRow> rows = Lists.newArrayList();
     try (AvroIterable<InternalRow> reader = Avro.read(Files.localInput(testFile))
         .createReaderFunc(SparkAvroReader::new)
         .project(schema)
         .build()) {
-      rows = Lists.newArrayList(reader);
-    }
 
-    // make sure the dataframe matches the records before moving on
-    for (int i = 0; i < records.size(); i += 1) {
-      assertEqualsUnsafe(schema.asStruct(), records.get(i), rows.get(i));
+      Iterator<Record> recordIter = records.iterator();
+      Iterator<InternalRow> readIter = reader.iterator();
+      while (recordIter.hasNext() && readIter.hasNext()) {
+        InternalRow row = readIter.next();
+        assertEqualsUnsafe(schema.asStruct(), recordIter.next(), row);
+        rows.add(row);
+      }
+      Assert.assertEquals("Both iterators should be exhausted", recordIter.hasNext(), readIter.hasNext());
     }
 
     JavaRDD<InternalRow> rdd = sc.parallelize(rows);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -72,7 +72,8 @@ public class TestDataFrameWrites extends AvroDataTest {
   public static Object[][] parameters() {
     return new Object[][] {
         new Object[] { "parquet" },
-        new Object[] { "avro" }
+        new Object[] { "avro" },
+        new Object[] { "orc" }
     };
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIdentityPartitionData.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIdentityPartitionData.java
@@ -54,7 +54,8 @@ public class TestIdentityPartitionData  {
   public static Object[][] parameters() {
     return new Object[][] {
         new Object[] { "parquet" },
-        new Object[] { "avro" }
+        new Object[] { "avro" },
+        new Object[] { "orc" }
     };
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -57,7 +57,8 @@ public class TestPartitionValues {
   public static Object[][] parameters() {
     return new Object[][] {
         new Object[] { "parquet" },
-        new Object[] { "avro" }
+        new Object[] { "avro" },
+        new Object[] { "orc" }
     };
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestReadProjection.java
@@ -27,9 +27,9 @@ import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -61,16 +61,16 @@ public abstract class TestReadProjection {
         Types.NestedField.optional(1, "data", Types.StringType.get())
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(schema, "table"));
-    record.put("id", 34L);
-    record.put("data", "test");
+    Record record = GenericRecord.create(schema);
+    record.setField("id", 34L);
+    record.setField("data", "test");
 
     Record projected = writeAndRead("full_projection", schema, schema, record);
 
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
 
     int cmp = Comparators.charSequences()
-        .compare("test", (CharSequence) projected.get("data"));
+        .compare("test", (CharSequence) projected.getField("data"));
     Assert.assertEquals("Should contain the correct data value", 0, cmp);
   }
 
@@ -85,9 +85,9 @@ public abstract class TestReadProjection {
         Types.NestedField.optional(1, "data", Types.StringType.get())
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(schema, "table"));
-    record.put("id", 34L);
-    record.put("data", "test");
+    Record record = GenericRecord.create(schema);
+    record.setField("id", 34L);
+    record.setField("data", "test");
 
     Schema reordered = new Schema(
         Types.NestedField.optional(1, "data", Types.StringType.get()),
@@ -111,9 +111,9 @@ public abstract class TestReadProjection {
         Types.NestedField.optional(1, "data", Types.StringType.get())
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(schema, "table"));
-    record.put("id", 34L);
-    record.put("data", "test");
+    Record record = GenericRecord.create(schema);
+    record.setField("id", 34L);
+    record.setField("data", "test");
 
     Schema reordered = new Schema(
         Types.NestedField.optional(2, "missing_1", Types.StringType.get()),
@@ -135,9 +135,9 @@ public abstract class TestReadProjection {
         Types.NestedField.optional(1, "data", Types.StringType.get())
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(schema, "table"));
-    record.put("id", 34L);
-    record.put("data", "test");
+    Record record = GenericRecord.create(schema);
+    record.setField("id", 34L);
+    record.setField("data", "test");
 
     Record projected = writeAndRead("empty_projection", schema, schema.select(), record);
 
@@ -157,17 +157,17 @@ public abstract class TestReadProjection {
         Types.NestedField.optional(1, "data", Types.StringType.get())
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    record.put("data", "test");
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    record.setField("data", "test");
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())
     );
 
     Record projected = writeAndRead("basic_projection_id", writeSchema, idOnly, record);
-    Assert.assertNull("Should not project data", projected.get("data"));
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
+    Assert.assertNull("Should not project data", projected.getField("data"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
 
     Schema dataOnly = new Schema(
         Types.NestedField.optional(1, "data", Types.StringType.get())
@@ -175,9 +175,9 @@ public abstract class TestReadProjection {
 
     projected = writeAndRead("basic_projection_data", writeSchema, dataOnly, record);
 
-    Assert.assertNull("Should not project id", projected.get("id"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
     int cmp = Comparators.charSequences()
-        .compare("test", (CharSequence) projected.get("data"));
+        .compare("test", (CharSequence) projected.getField("data"));
     Assert.assertEquals("Should contain the correct data value", 0, cmp);
   }
 
@@ -188,9 +188,9 @@ public abstract class TestReadProjection {
         Types.NestedField.optional(1, "data", Types.StringType.get())
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    record.put("data", "test");
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    record.setField("data", "test");
 
     Schema readSchema = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get()),
@@ -199,9 +199,9 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("project_and_rename", writeSchema, readSchema, record);
 
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
     int cmp = Comparators.charSequences()
-        .compare("test", (CharSequence) projected.get("renamed"));
+        .compare("test", (CharSequence) projected.getField("renamed"));
     Assert.assertEquals("Should contain the correct data/renamed value", 0, cmp);
   }
 
@@ -215,20 +215,20 @@ public abstract class TestReadProjection {
         ))
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    Record location = new Record(fromOption(record.getSchema().getField("location").schema()));
-    location.put("lat", 52.995143f);
-    location.put("long", -1.539054f);
-    record.put("location", location);
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    Record location = GenericRecord.create(writeSchema.findType("location").asStructType());
+    location.setField("lat", 52.995143f);
+    location.setField("long", -1.539054f);
+    record.setField("location", location);
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())
     );
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    Record projectedLocation = (Record) projected.get("location");
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
+    Record projectedLocation = (Record) projected.getField("location");
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
     Assert.assertNull("Should not project location", projectedLocation);
 
     Schema latOnly = new Schema(
@@ -238,12 +238,12 @@ public abstract class TestReadProjection {
     );
 
     projected = writeAndRead("latitude_only", writeSchema, latOnly, record);
-    projectedLocation = (Record) projected.get("location");
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project location", projected.get("location"));
-    Assert.assertNull("Should not project longitude", projectedLocation.get("long"));
+    projectedLocation = (Record) projected.getField("location");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project location", projected.getField("location"));
+    Assert.assertNull("Should not project longitude", projectedLocation.getField("long"));
     Assert.assertEquals("Should project latitude",
-        52.995143f, (float) projectedLocation.get("lat"), 0.000001f);
+        52.995143f, (float) projectedLocation.getField("lat"), 0.000001f);
 
     Schema longOnly = new Schema(
         Types.NestedField.optional(3, "location", Types.StructType.of(
@@ -252,22 +252,22 @@ public abstract class TestReadProjection {
     );
 
     projected = writeAndRead("longitude_only", writeSchema, longOnly, record);
-    projectedLocation = (Record) projected.get("location");
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project location", projected.get("location"));
-    Assert.assertNull("Should not project latitutde", projectedLocation.get("lat"));
+    projectedLocation = (Record) projected.getField("location");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project location", projected.getField("location"));
+    Assert.assertNull("Should not project latitutde", projectedLocation.getField("lat"));
     Assert.assertEquals("Should project longitude",
-        -1.539054f, (float) projectedLocation.get("long"), 0.000001f);
+        -1.539054f, (float) projectedLocation.getField("long"), 0.000001f);
 
     Schema locationOnly = writeSchema.select("location");
     projected = writeAndRead("location_only", writeSchema, locationOnly, record);
-    projectedLocation = (Record) projected.get("location");
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project location", projected.get("location"));
+    projectedLocation = (Record) projected.getField("location");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project location", projected.getField("location"));
     Assert.assertEquals("Should project latitude",
-        52.995143f, (float) projectedLocation.get("lat"), 0.000001f);
+        52.995143f, (float) projectedLocation.getField("lat"), 0.000001f);
     Assert.assertEquals("Should project longitude",
-        -1.539054f, (float) projectedLocation.get("long"), 0.000001f);
+        -1.539054f, (float) projectedLocation.getField("long"), 0.000001f);
   }
 
   @Test
@@ -280,35 +280,35 @@ public abstract class TestReadProjection {
 
     Map<String, String> properties = ImmutableMap.of("a", "A", "b", "B");
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    record.put("properties", properties);
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    record.setField("properties", properties);
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())
     );
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    Assert.assertNull("Should not project properties map", projected.get("properties"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
+    Assert.assertNull("Should not project properties map", projected.getField("properties"));
 
     Schema keyOnly = writeSchema.select("properties.key");
     projected = writeAndRead("key_only", writeSchema, keyOnly, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
     Assert.assertEquals("Should project entire map",
-        properties, toStringMap((Map) projected.get("properties")));
+        properties, toStringMap((Map) projected.getField("properties")));
 
     Schema valueOnly = writeSchema.select("properties.value");
     projected = writeAndRead("value_only", writeSchema, valueOnly, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
     Assert.assertEquals("Should project entire map",
-        properties, toStringMap((Map) projected.get("properties")));
+        properties, toStringMap((Map) projected.getField("properties")));
 
     Schema mapOnly = writeSchema.select("properties");
     projected = writeAndRead("map_only", writeSchema, mapOnly, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
     Assert.assertEquals("Should project entire map",
-        properties, toStringMap((Map) projected.get("properties")));
+        properties, toStringMap((Map) projected.getField("properties")));
   }
 
   private Map<String, ?> toStringMap(Map<?, ?> map) {
@@ -336,65 +336,64 @@ public abstract class TestReadProjection {
         ))
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    Record l1 = new Record(fromOption(
-        fromOption(record.getSchema().getField("locations").schema()).getValueType()));
-    l1.put("lat", 53.992811f);
-    l1.put("long", -1.542616f);
-    Record l2 = new Record(l1.getSchema());
-    l2.put("lat", 52.995143f);
-    l2.put("long", -1.539054f);
-    record.put("locations", ImmutableMap.of("L1", l1, "L2", l2));
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    Record l1 = GenericRecord.create(writeSchema.findType("locations.value").asStructType());
+    l1.setField("lat", 53.992811f);
+    l1.setField("long", -1.542616f);
+    Record l2 = GenericRecord.create(l1.struct());
+    l2.setField("lat", 52.995143f);
+    l2.setField("long", -1.539054f);
+    record.setField("locations", ImmutableMap.of("L1", l1, "L2", l2));
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())
     );
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    Assert.assertNull("Should not project locations map", projected.get("locations"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
+    Assert.assertNull("Should not project locations map", projected.getField("locations"));
 
     projected = writeAndRead("all_locations", writeSchema, writeSchema.select("locations"), record);
-    Assert.assertNull("Should not project id", projected.get("id"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
     Assert.assertEquals("Should project locations map",
-        record.get("locations"), toStringMap((Map) projected.get("locations")));
+        record.getField("locations"), toStringMap((Map) projected.getField("locations")));
 
     projected = writeAndRead("lat_only",
         writeSchema, writeSchema.select("locations.lat"), record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Map<String, ?> locations = toStringMap((Map) projected.get("locations"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Map<String, ?> locations = toStringMap((Map) projected.getField("locations"));
     Assert.assertNotNull("Should project locations map", locations);
     Assert.assertEquals("Should contain L1 and L2",
         Sets.newHashSet("L1", "L2"), locations.keySet());
     Record projectedL1 = (Record) locations.get("L1");
     Assert.assertNotNull("L1 should not be null", projectedL1);
     Assert.assertEquals("L1 should contain lat",
-        53.992811f, (float) projectedL1.get("lat"), 0.000001);
-    Assert.assertNull("L1 should not contain long", projectedL1.get("long"));
+        53.992811f, (float) projectedL1.getField("lat"), 0.000001);
+    Assert.assertNull("L1 should not contain long", projectedL1.getField("long"));
     Record projectedL2 = (Record) locations.get("L2");
     Assert.assertNotNull("L2 should not be null", projectedL2);
     Assert.assertEquals("L2 should contain lat",
-        52.995143f, (float) projectedL2.get("lat"), 0.000001);
-    Assert.assertNull("L2 should not contain long", projectedL2.get("long"));
+        52.995143f, (float) projectedL2.getField("lat"), 0.000001);
+    Assert.assertNull("L2 should not contain long", projectedL2.getField("long"));
 
     projected = writeAndRead("long_only",
         writeSchema, writeSchema.select("locations.long"), record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    locations = toStringMap((Map) projected.get("locations"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    locations = toStringMap((Map) projected.getField("locations"));
     Assert.assertNotNull("Should project locations map", locations);
     Assert.assertEquals("Should contain L1 and L2",
         Sets.newHashSet("L1", "L2"), locations.keySet());
     projectedL1 = (Record) locations.get("L1");
     Assert.assertNotNull("L1 should not be null", projectedL1);
-    Assert.assertNull("L1 should not contain lat", projectedL1.get("lat"));
+    Assert.assertNull("L1 should not contain lat", projectedL1.getField("lat"));
     Assert.assertEquals("L1 should contain long",
-        -1.542616f, (float) projectedL1.get("long"), 0.000001);
+        -1.542616f, (float) projectedL1.getField("long"), 0.000001);
     projectedL2 = (Record) locations.get("L2");
     Assert.assertNotNull("L2 should not be null", projectedL2);
-    Assert.assertNull("L2 should not contain lat", projectedL2.get("lat"));
+    Assert.assertNull("L2 should not contain lat", projectedL2.getField("lat"));
     Assert.assertEquals("L2 should contain long",
-        -1.539054f, (float) projectedL2.get("long"), 0.000001);
+        -1.539054f, (float) projectedL2.getField("long"), 0.000001);
 
     Schema latitiudeRenamed = new Schema(
         Types.NestedField.optional(5, "locations", Types.MapType.ofOptional(6, 7,
@@ -406,23 +405,23 @@ public abstract class TestReadProjection {
     );
 
     projected = writeAndRead("latitude_renamed", writeSchema, latitiudeRenamed, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    locations = toStringMap((Map) projected.get("locations"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    locations = toStringMap((Map) projected.getField("locations"));
     Assert.assertNotNull("Should project locations map", locations);
     Assert.assertEquals("Should contain L1 and L2",
         Sets.newHashSet("L1", "L2"), locations.keySet());
     projectedL1 = (Record) locations.get("L1");
     Assert.assertNotNull("L1 should not be null", projectedL1);
     Assert.assertEquals("L1 should contain latitude",
-        53.992811f, (float) projectedL1.get("latitude"), 0.000001);
-    Assert.assertNull("L1 should not contain lat", projectedL1.get("lat"));
-    Assert.assertNull("L1 should not contain long", projectedL1.get("long"));
+        53.992811f, (float) projectedL1.getField("latitude"), 0.000001);
+    Assert.assertNull("L1 should not contain lat", projectedL1.getField("lat"));
+    Assert.assertNull("L1 should not contain long", projectedL1.getField("long"));
     projectedL2 = (Record) locations.get("L2");
     Assert.assertNotNull("L2 should not be null", projectedL2);
     Assert.assertEquals("L2 should contain latitude",
-        52.995143f, (float) projectedL2.get("latitude"), 0.000001);
-    Assert.assertNull("L2 should not contain lat", projectedL2.get("lat"));
-    Assert.assertNull("L2 should not contain long", projectedL2.get("long"));
+        52.995143f, (float) projectedL2.getField("latitude"), 0.000001);
+    Assert.assertNull("L2 should not contain lat", projectedL2.getField("lat"));
+    Assert.assertNull("L2 should not contain long", projectedL2.getField("long"));
   }
 
   @Test
@@ -435,27 +434,27 @@ public abstract class TestReadProjection {
 
     List<Long> values = ImmutableList.of(56L, 57L, 58L);
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    record.put("values", values);
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    record.setField("values", values);
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())
     );
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    Assert.assertNull("Should not project values list", projected.get("values"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
+    Assert.assertNull("Should not project values list", projected.getField("values"));
 
     Schema elementOnly = writeSchema.select("values.element");
     projected = writeAndRead("element_only", writeSchema, elementOnly, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertEquals("Should project entire list", values, projected.get("values"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertEquals("Should project entire list", values, projected.getField("values"));
 
     Schema listOnly = writeSchema.select("values");
     projected = writeAndRead("list_only", writeSchema, listOnly, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertEquals("Should project entire list", values, projected.get("values"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertEquals("Should project entire list", values, projected.getField("values"));
   }
 
   @Test
@@ -471,53 +470,52 @@ public abstract class TestReadProjection {
         )
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
-    record.put("id", 34L);
-    Record p1 = new Record(fromOption(
-        fromOption(record.getSchema().getField("points").schema()).getElementType()));
-    p1.put("x", 1);
-    p1.put("y", 2);
-    Record p2 = new Record(p1.getSchema());
-    p2.put("x", 3);
-    p2.put("y", null);
-    record.put("points", ImmutableList.of(p1, p2));
+    Record record = GenericRecord.create(writeSchema);
+    record.setField("id", 34L);
+    Record p1 = GenericRecord.create(writeSchema.findType("points.element").asStructType());
+    p1.setField("x", 1);
+    p1.setField("y", 2);
+    Record p2 = GenericRecord.create(p1.struct());
+    p2.setField("x", 3);
+    p2.setField("y", null);
+    record.setField("points", ImmutableList.of(p1, p2));
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())
     );
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    Assert.assertNull("Should not project points list", projected.get("points"));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.getField("id"));
+    Assert.assertNull("Should not project points list", projected.getField("points"));
 
     projected = writeAndRead("all_points", writeSchema, writeSchema.select("points"), record);
-    Assert.assertNull("Should not project id", projected.get("id"));
+    Assert.assertNull("Should not project id", projected.getField("id"));
     Assert.assertEquals("Should project points list",
-        record.get("points"), projected.get("points"));
+        record.getField("points"), projected.getField("points"));
 
     projected = writeAndRead("x_only", writeSchema, writeSchema.select("points.x"), record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project points list", projected.get("points"));
-    List<Record> points = (List<Record>) projected.get("points");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project points list", projected.getField("points"));
+    List<Record> points = (List<Record>) projected.getField("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     Record projectedP1 = points.get(0);
-    Assert.assertEquals("Should project x", 1, (int) projectedP1.get("x"));
-    Assert.assertNull("Should not project y", projectedP1.get("y"));
+    Assert.assertEquals("Should project x", 1, (int) projectedP1.getField("x"));
+    Assert.assertNull("Should not project y", projectedP1.getField("y"));
     Record projectedP2 = points.get(1);
-    Assert.assertEquals("Should project x", 3, (int) projectedP2.get("x"));
-    Assert.assertNull("Should not project y", projectedP2.get("y"));
+    Assert.assertEquals("Should project x", 3, (int) projectedP2.getField("x"));
+    Assert.assertNull("Should not project y", projectedP2.getField("y"));
 
     projected = writeAndRead("y_only", writeSchema, writeSchema.select("points.y"), record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project points list", projected.get("points"));
-    points = (List<Record>) projected.get("points");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project points list", projected.getField("points"));
+    points = (List<Record>) projected.getField("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     projectedP1 = points.get(0);
-    Assert.assertNull("Should not project x", projectedP1.get("x"));
-    Assert.assertEquals("Should project y", 2, (int) projectedP1.get("y"));
+    Assert.assertNull("Should not project x", projectedP1.getField("x"));
+    Assert.assertEquals("Should project y", 2, (int) projectedP1.getField("y"));
     projectedP2 = points.get(1);
-    Assert.assertNull("Should not project x", projectedP2.get("x"));
-    Assert.assertNull("Should project null y", projectedP2.get("y"));
+    Assert.assertNull("Should not project x", projectedP2.getField("x"));
+    Assert.assertNull("Should project null y", projectedP2.getField("y"));
 
     Schema yRenamed = new Schema(
         Types.NestedField.optional(22, "points",
@@ -528,18 +526,18 @@ public abstract class TestReadProjection {
     );
 
     projected = writeAndRead("y_renamed", writeSchema, yRenamed, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project points list", projected.get("points"));
-    points = (List<Record>) projected.get("points");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project points list", projected.getField("points"));
+    points = (List<Record>) projected.getField("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     projectedP1 = points.get(0);
-    Assert.assertNull("Should not project x", projectedP1.get("x"));
-    Assert.assertNull("Should not project y", projectedP1.get("y"));
-    Assert.assertEquals("Should project z", 2, (int) projectedP1.get("z"));
+    Assert.assertNull("Should not project x", projectedP1.getField("x"));
+    Assert.assertNull("Should not project y", projectedP1.getField("y"));
+    Assert.assertEquals("Should project z", 2, (int) projectedP1.getField("z"));
     projectedP2 = points.get(1);
-    Assert.assertNull("Should not project x", projectedP2.get("x"));
-    Assert.assertNull("Should not project y", projectedP2.get("y"));
-    Assert.assertNull("Should project null z", projectedP2.get("z"));
+    Assert.assertNull("Should not project x", projectedP2.getField("x"));
+    Assert.assertNull("Should not project y", projectedP2.getField("y"));
+    Assert.assertNull("Should project null z", projectedP2.getField("z"));
 
     Schema zAdded = new Schema(
         Types.NestedField.optional(22, "points",
@@ -552,18 +550,18 @@ public abstract class TestReadProjection {
     );
 
     projected = writeAndRead("z_added", writeSchema, zAdded, record);
-    Assert.assertNull("Should not project id", projected.get("id"));
-    Assert.assertNotNull("Should project points list", projected.get("points"));
-    points = (List<Record>) projected.get("points");
+    Assert.assertNull("Should not project id", projected.getField("id"));
+    Assert.assertNotNull("Should project points list", projected.getField("points"));
+    points = (List<Record>) projected.getField("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     projectedP1 = points.get(0);
-    Assert.assertEquals("Should project x", 1, (int) projectedP1.get("x"));
-    Assert.assertEquals("Should project y", 2, (int) projectedP1.get("y"));
-    Assert.assertNull("Should contain null z", projectedP1.get("z"));
+    Assert.assertEquals("Should project x", 1, (int) projectedP1.getField("x"));
+    Assert.assertEquals("Should project y", 2, (int) projectedP1.getField("y"));
+    Assert.assertNull("Should contain null z", projectedP1.getField("z"));
     projectedP2 = points.get(1);
-    Assert.assertEquals("Should project x", 3, (int) projectedP2.get("x"));
-    Assert.assertNull("Should project null y", projectedP2.get("y"));
-    Assert.assertNull("Should contain null z", projectedP2.get("z"));
+    Assert.assertEquals("Should project x", 3, (int) projectedP2.getField("x"));
+    Assert.assertNull("Should project null y", projectedP2.getField("y"));
+    Assert.assertNull("Should contain null z", projectedP2.getField("z"));
   }
 
   private static org.apache.avro.Schema fromOption(org.apache.avro.Schema schema) {


### PR DESCRIPTION
This adds ORC to Spark tests that run for each file format.

This also updates `TestSparkReadProjection` and `TestFilteredScan` to use Iceberg generics instead of Avro generics for the test cases because ORC doesn't support Avro records. It's good to remove the use of Avro in favor of Iceberg generics as well.