### PR TITLE
Avro: Support partition values using a constants map

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -153,7 +153,7 @@ public class ManifestWriter implements FileAppender<DataFile> {
     addEntry(reused.wrapAppend(snapshotId, addedFile));
   }
 
-  public void add(ManifestEntry entry) {
+  void add(ManifestEntry entry) {
     addEntry(reused.wrapAppend(snapshotId, entry.file()));
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -576,19 +576,19 @@ public class ValueReaders {
       this.readers = readers.toArray(new ValueReader[0]);
 
       List<Types.NestedField> fields = struct.fields();
-      List<Integer> positions = Lists.newArrayListWithCapacity(fields.size());
-      List<Object> constants = Lists.newArrayListWithCapacity(fields.size());
+      List<Integer> positionList = Lists.newArrayListWithCapacity(fields.size());
+      List<Object> constantList = Lists.newArrayListWithCapacity(fields.size());
       for (int pos = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
         Object constant = idToConstant.get(field.fieldId());
         if (constant != null) {
-          positions.add(pos);
-          constants.add(prepareConstant(field.type(), constant));
+          positionList.add(pos);
+          constantList.add(prepareConstant(field.type(), constant));
         }
       }
 
-      this.positions = positions.stream().mapToInt(Integer::intValue).toArray();
-      this.constants = constants.toArray();
+      this.positions = positionList.stream().mapToInt(Integer::intValue).toArray();
+      this.constants = constantList.toArray();
     }
 
     protected abstract S reuseOrCreate(Object reuse);

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -40,6 +40,8 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.ResolvingDecoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 
 import static java.util.Collections.emptyIterator;
 
@@ -561,12 +563,32 @@ public class ValueReaders {
 
   public abstract static class StructReader<S> implements ValueReader<S> {
     private final ValueReader<?>[] readers;
+    private final int[] positions;
+    private final Object[] constants;
 
     protected StructReader(List<ValueReader<?>> readers) {
-      this.readers = new ValueReader[readers.size()];
-      for (int i = 0; i < this.readers.length; i += 1) {
-        this.readers[i] = readers.get(i);
+      this.readers = readers.toArray(new ValueReader[0]);
+      this.positions = new int[0];
+      this.constants = new Object[0];
+    }
+
+    protected StructReader(List<ValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
+      this.readers = readers.toArray(new ValueReader[0]);
+
+      List<Types.NestedField> fields = struct.fields();
+      List<Integer> positions = Lists.newArrayListWithCapacity(fields.size());
+      List<Object> constants = Lists.newArrayListWithCapacity(fields.size());
+      for (int pos = 0; pos < fields.size(); pos += 1) {
+        Types.NestedField field = fields.get(pos);
+        Object constant = idToConstant.get(field.fieldId());
+        if (constant != null) {
+          positions.add(pos);
+          constants.add(prepareConstant(field.type(), constant));
+        }
       }
+
+      this.positions = positions.stream().mapToInt(Integer::intValue).toArray();
+      this.constants = constants.toArray();
     }
 
     protected abstract S reuseOrCreate(Object reuse);
@@ -574,6 +596,10 @@ public class ValueReaders {
     protected abstract Object get(S struct, int pos);
 
     protected abstract void set(S struct, int pos, Object value);
+
+    protected Object prepareConstant(Type type, Object value) {
+      return value;
+    }
 
     public ValueReader<?> reader(int pos) {
       return readers[pos];
@@ -595,6 +621,10 @@ public class ValueReaders {
           Object reusedValue = get(struct, i);
           set(struct, i, readers[i].read(decoder, reusedValue));
         }
+      }
+
+      for (int i = 0; i < positions.length; i += 1) {
+        set(struct, positions[i], constants[i]);
       }
 
       return struct;

--- a/core/src/main/java/org/apache/iceberg/util/ByteBuffers.java
+++ b/core/src/main/java/org/apache/iceberg/util/ByteBuffers.java
@@ -41,7 +41,7 @@ public class ByteBuffers {
       }
     } else {
       byte[] bytes = new byte[buffer.remaining()];
-      buffer.get(bytes);
+      buffer.asReadOnlyBuffer().get(bytes);
       return bytes;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+
+public class PartitionUtil {
+  private PartitionUtil() {
+  }
+
+  public static Map<Integer, ?> constantsMap(FileScanTask task) {
+    return constantsMap(task.spec(), task.file().partition());
+  }
+
+  private static Map<Integer, ?> constantsMap(PartitionSpec spec, StructLike partitionData) {
+    // use java.util.HashMap because partition data may contain null values
+    Map<Integer, Object> idToConstant = new HashMap<>();
+    List<PartitionField> fields = spec.fields();
+    for (int pos = 0; pos < fields.size(); pos += 1) {
+      PartitionField field = fields.get(pos);
+      idToConstant.put(field.sourceId(), partitionData.get(pos, Object.class));
+    }
+    return idToConstant;
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.data.avro;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapMaker;
 import java.io.IOException;
 import java.util.HashMap;
@@ -45,7 +46,12 @@ public class DataReader<T> implements DatumReader<T> {
       ThreadLocal.withInitial(() -> new MapMaker().weakKeys().makeMap());
 
   public static <D> DataReader<D> create(org.apache.iceberg.Schema expectedSchema, Schema readSchema) {
-    return new DataReader<>(expectedSchema, readSchema);
+    return create(expectedSchema, readSchema, ImmutableMap.of());
+  }
+
+  public static <D> DataReader<D> create(org.apache.iceberg.Schema expectedSchema, Schema readSchema,
+                                         Map<Integer, ?> constants) {
+    return new DataReader<>(expectedSchema, readSchema, constants);
   }
 
   private final Schema readSchema;
@@ -53,9 +59,10 @@ public class DataReader<T> implements DatumReader<T> {
   private Schema fileSchema = null;
 
   @SuppressWarnings("unchecked")
-  private DataReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema) {
+  private DataReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema, Map<Integer, ?> idToConstant) {
     this.readSchema = readSchema;
-    this.reader = (ValueReader<T>) AvroSchemaWithTypeVisitor.visit(expectedSchema, readSchema, new ReadBuilder());
+    this.reader = (ValueReader<T>) AvroSchemaWithTypeVisitor
+        .visit(expectedSchema, readSchema, new ReadBuilder(idToConstant));
   }
 
   @Override
@@ -96,14 +103,16 @@ public class DataReader<T> implements DatumReader<T> {
   }
 
   private static class ReadBuilder extends AvroSchemaWithTypeVisitor<ValueReader<?>> {
+    private final Map<Integer, ?> idToConstant;
 
-    private ReadBuilder() {
+    private ReadBuilder(Map<Integer, ?> idToConstant) {
+      this.idToConstant = idToConstant;
     }
 
     @Override
     public ValueReader<?> record(Types.StructType struct, Schema record,
                                  List<String> names, List<ValueReader<?>> fields) {
-      return GenericReaders.struct(struct, fields);
+      return GenericReaders.struct(struct, fields, idToConstant);
     }
 
     @Override

--- a/data/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -50,8 +50,8 @@ public class DataReader<T> implements DatumReader<T> {
   }
 
   public static <D> DataReader<D> create(org.apache.iceberg.Schema expectedSchema, Schema readSchema,
-                                         Map<Integer, ?> constants) {
-    return new DataReader<>(expectedSchema, readSchema, constants);
+                                         Map<Integer, ?> idToConstant) {
+    return new DataReader<>(expectedSchema, readSchema, idToConstant);
   }
 
   private final Schema readSchema;

--- a/data/src/main/java/org/apache/iceberg/data/avro/GenericReaders.java
+++ b/data/src/main/java/org/apache/iceberg/data/avro/GenericReaders.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.io.Decoder;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
@@ -55,8 +56,8 @@ class GenericReaders {
     return TimestamptzReader.INSTANCE;
   }
 
-  static ValueReader<Record> struct(StructType struct, List<ValueReader<?>> readers) {
-    return new GenericRecordReader(readers, struct);
+  static ValueReader<Record> struct(StructType struct, List<ValueReader<?>> readers, Map<Integer, ?> idToConstant) {
+    return new GenericRecordReader(readers, struct, idToConstant);
   }
 
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
@@ -113,8 +114,8 @@ class GenericReaders {
   private static class GenericRecordReader extends ValueReaders.StructReader<Record> {
     private final StructType structType;
 
-    private GenericRecordReader(List<ValueReader<?>> readers, StructType struct) {
-      super(readers);
+    private GenericRecordReader(List<ValueReader<?>> readers, StructType struct, Map<Integer, ?> idToConstant) {
+      super(readers, struct, idToConstant);
       this.structType = struct;
     }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.data;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapMaker;
 import java.io.IOException;
 import java.util.HashMap;
@@ -31,10 +32,12 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.ResolvingDecoder;
-import org.apache.iceberg.avro.AvroSchemaVisitor;
+import org.apache.iceberg.avro.AvroSchemaWithTypeVisitor;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 
@@ -47,10 +50,15 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
   private final ValueReader<InternalRow> reader;
   private Schema fileSchema = null;
 
+  public SparkAvroReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema) {
+    this(expectedSchema, readSchema, ImmutableMap.of());
+  }
+
   @SuppressWarnings("unchecked")
-  public SparkAvroReader(Schema readSchema) {
+  public SparkAvroReader(org.apache.iceberg.Schema expectedSchema, Schema readSchema, Map<Integer, ?> constants) {
     this.readSchema = readSchema;
-    this.reader = (ValueReader<InternalRow>) AvroSchemaVisitor.visit(readSchema, new ReadBuilder());
+    this.reader = (ValueReader<InternalRow>) AvroSchemaWithTypeVisitor
+        .visit(expectedSchema, readSchema, new ReadBuilder(constants));
   }
 
   @Override
@@ -90,38 +98,40 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
     }
   }
 
-  private static class ReadBuilder extends AvroSchemaVisitor<ValueReader<?>> {
-    private ReadBuilder() {
+  private static class ReadBuilder extends AvroSchemaWithTypeVisitor<ValueReader<?>> {
+    private final Map<Integer, ?> idToConstant;
+
+    private ReadBuilder(Map<Integer, ?> idToConstant) {
+      this.idToConstant = idToConstant;
     }
 
     @Override
-    public ValueReader<?> record(Schema record, List<String> names, List<ValueReader<?>> fields) {
-      return SparkValueReaders.struct(fields);
+    public ValueReader<?> record(Types.StructType expected, Schema record, List<String> names, List<ValueReader<?>> fields) {
+      return SparkValueReaders.struct(fields, expected, idToConstant);
     }
 
     @Override
-    public ValueReader<?> union(Schema union, List<ValueReader<?>> options) {
+    public ValueReader<?> union(Type expected, Schema union, List<ValueReader<?>> options) {
       return ValueReaders.union(options);
     }
 
     @Override
-    public ValueReader<?> array(Schema array, ValueReader<?> elementReader) {
-      LogicalType logical = array.getLogicalType();
-      if (logical != null && "map".equals(logical.getName())) {
-        ValueReader<?>[] keyValueReaders = ((SparkValueReaders.StructReader) elementReader).readers();
-        return SparkValueReaders.arrayMap(keyValueReaders[0], keyValueReaders[1]);
-      }
-
+    public ValueReader<?> array(Types.ListType expected, Schema array, ValueReader<?> elementReader) {
       return SparkValueReaders.array(elementReader);
     }
 
     @Override
-    public ValueReader<?> map(Schema map, ValueReader<?> valueReader) {
+    public ValueReader<?> map(Types.MapType expected, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
+      return SparkValueReaders.arrayMap(keyReader, valueReader);
+    }
+
+    @Override
+    public ValueReader<?> map(Types.MapType expected, Schema map, ValueReader<?> valueReader) {
       return SparkValueReaders.map(SparkValueReaders.strings(), valueReader);
     }
 
     @Override
-    public ValueReader<?> primitive(Schema primitive) {
+    public ValueReader<?> primitive(Type.PrimitiveType expected, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -106,7 +106,8 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
     }
 
     @Override
-    public ValueReader<?> record(Types.StructType expected, Schema record, List<String> names, List<ValueReader<?>> fields) {
+    public ValueReader<?> record(Types.StructType expected, Schema record, List<String> names,
+                                 List<ValueReader<?>> fields) {
       return SparkValueReaders.struct(fields, expected, idToConstant);
     }
 
@@ -121,7 +122,8 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
     }
 
     @Override
-    public ValueReader<?> map(Types.MapType expected, Schema map, ValueReader<?> keyReader, ValueReader<?> valueReader) {
+    public ValueReader<?> map(Types.MapType expected, Schema map,
+                              ValueReader<?> keyReader, ValueReader<?> valueReader) {
       return SparkValueReaders.arrayMap(keyReader, valueReader);
     }
 


### PR DESCRIPTION
This updates Avro readers to support passing a map from field IDs to constants. This is used to inject constant values from partition data.

Unlike similar changes for Parquet (see #585), this doesn't replace the reader for a field because the readers still need to be called to update the decoder state by consuming a value from the stream. Instead, this adds a phase after reading a struct when the constants are set. This happens whether or not the data file contained a given field.

This is needed for partition values in InputFormats, #843, and is the Avro part of fixing #575.