### PR TITLE
Fix metadata class loader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -167,6 +167,7 @@ public class AllManifestsTable extends BaseMetadataTable {
           .rename("partitions", GenericPartitionFieldSummary.class.getName())
           .rename("r508", GenericPartitionFieldSummary.class.getName())
           .project(ManifestFile.schema())
+          .classLoader(GenericManifestFile.class.getClassLoader())
           .reuseContainers(false)
           .build()) {
 

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -119,6 +119,7 @@ class BaseSnapshot implements Snapshot {
           .rename("manifest_file", GenericManifestFile.class.getName())
           .rename("partitions", GenericPartitionFieldSummary.class.getName())
           .rename("r508", GenericPartitionFieldSummary.class.getName())
+          .classLoader(GenericManifestFile.class.getClassLoader())
           .project(ManifestFile.schema())
           .reuseContainers(false)
           .build()) {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -252,6 +252,7 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
             .rename("r102", PartitionData.class.getName())
             .rename("data_file", GenericDataFile.class.getName())
             .rename("r2", GenericDataFile.class.getName())
+            .classLoader(ManifestEntry.class.getClassLoader())
             .reuseContainers()
             .build();
 

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -380,6 +380,7 @@ class RemoveSnapshots implements ExpireSnapshots {
     if (snapshot.manifestListLocation() != null) {
       return Avro.read(ops.io().newInputFile(snapshot.manifestListLocation()))
           .rename("manifest_file", GenericManifestFile.class.getName())
+          .classLoader(GenericManifestFile.class.getClassLoader())
           .project(MANIFEST_PROJECTION)
           .reuseContainers(true)
           .build();

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -169,9 +169,9 @@ public class Avro {
   }
 
   public static class ReadBuilder {
-    private final ClassLoader defaultLoader = Thread.currentThread().getContextClassLoader();
     private final InputFile file;
     private final Map<String, String> renames = Maps.newLinkedHashMap();
+    private ClassLoader loader = Thread.currentThread().getContextClassLoader();
     private NameMapping nameMapping;
     private boolean reuseContainers = false;
     private org.apache.iceberg.Schema schema = null;
@@ -179,7 +179,7 @@ public class Avro {
     private BiFunction<org.apache.iceberg.Schema, Schema, DatumReader<?>> createReaderBiFunc = null;
     private final Function<Schema, DatumReader<?>> defaultCreateReaderFunc = readSchema -> {
       GenericAvroReader<?> reader = new GenericAvroReader<>(readSchema);
-      reader.setClassLoader(defaultLoader);
+      reader.setClassLoader(loader);
       return reader;
     };
     private Long start = null;
@@ -237,6 +237,11 @@ public class Avro {
 
     public ReadBuilder nameMapping(NameMapping newNameMapping) {
       this.nameMapping = newNameMapping;
+      return this;
+    }
+
+    public ReadBuilder classLoader(ClassLoader classLoader) {
+      this.loader = classLoader;
       return this;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestGenericManifestFile.java
+++ b/core/src/test/java/org/apache/iceberg/TestGenericManifestFile.java
@@ -68,6 +68,7 @@ public class TestGenericManifestFile {
         .rename("manifest_file", GenericManifestFile.class.getName())
         .rename("partitions", GenericPartitionFieldSummary.class.getName())
         .rename("r508", GenericPartitionFieldSummary.class.getName())
+        .classLoader(GenericManifestFile.class.getClassLoader())
         .project(ManifestFile.schema())
         .reuseContainers(false)
         .build()) {


### PR DESCRIPTION
By default, the Avro read helper uses the current thread's classloader. In some cases, this may not be able to load Iceberg classes so internal Avro reads should explicitly use the right classloader to avoid `ClassCastException`.

Example stack trace:
```
Query 20200406_225951_00002_ph3d8 failed: org.apache.iceberg.bdp.shaded.org.apache.avro.generic.GenericData$Record cannot be cast to org.apache.iceberg.ManifestEntry
java.lang.ClassCastException: org.apache.iceberg.bdp.shaded.org.apache.avro.generic.GenericData$Record cannot be cast to org.apache.iceberg.ManifestEntry
	at org.apache.iceberg.bdp.shaded.com.google.common.collect.Iterators$5.computeNext(Iterators.java:637)
	at org.apache.iceberg.bdp.shaded.com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:141)
	at org.apache.iceberg.bdp.shaded.com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:136)
	at org.apache.iceberg.bdp.shaded.com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:42)
	at io.prestosql.plugin.iceberg.FilesPageSource.getNextPage(FilesPageSource.java:112)
	at io.prestosql.operator.TableScanOperator.getOutput(TableScanOperator.java:286)
	at io.prestosql.operator.Driver.processInternal(Driver.java:379)
```