### PR TITLE
Prepare metadata writers for format v2

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Writer for manifest files.
  */
-public class ManifestWriter implements FileAppender<DataFile> {
+public abstract class ManifestWriter implements FileAppender<DataFile> {
   private static final Logger LOG = LoggerFactory.getLogger(ManifestWriter.class);
 
   static ManifestFile copyAppendManifest(ManifestReader reader, OutputFile outputFile, long snapshotId,
@@ -44,7 +44,7 @@ public class ManifestWriter implements FileAppender<DataFile> {
   static ManifestFile copyManifest(ManifestReader reader, OutputFile outputFile, long snapshotId,
                                    SnapshotSummary.Builder summaryBuilder,
                                    Set<ManifestEntry.Status> allowedEntryStatuses) {
-    ManifestWriter writer = new ManifestWriter(reader.spec(), outputFile, snapshotId);
+    ManifestWriter writer = new V1Writer(reader.spec(), outputFile, snapshotId);
     boolean threw = true;
     try {
       for (ManifestEntry entry : reader.entries()) {
@@ -93,7 +93,15 @@ public class ManifestWriter implements FileAppender<DataFile> {
    * @return a manifest writer
    */
   public static ManifestWriter write(PartitionSpec spec, OutputFile outputFile) {
-    return new ManifestWriter(spec, outputFile, null);
+    // always use a v1 writer for appended manifests because sequence number must be inherited
+    return write(1, spec, outputFile, null);
+  }
+
+  static ManifestWriter write(int formatVersion, PartitionSpec spec, OutputFile outputFile, Long snapshotId) {
+    if (formatVersion == 1) {
+      return new V1Writer(spec, outputFile, snapshotId);
+    }
+    throw new UnsupportedOperationException("Cannot write manifest for table version: " + formatVersion);
   }
 
   private final OutputFile file;
@@ -111,7 +119,7 @@ public class ManifestWriter implements FileAppender<DataFile> {
   private int deletedFiles = 0;
   private long deletedRows = 0L;
 
-  ManifestWriter(PartitionSpec spec, OutputFile file, Long snapshotId) {
+  private ManifestWriter(PartitionSpec spec, OutputFile file, Long snapshotId) {
     this.file = file;
     this.specId = spec.specId();
     this.writer = newAppender(FileFormat.AVRO, spec, file);
@@ -229,6 +237,12 @@ public class ManifestWriter implements FileAppender<DataFile> {
       }
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to create manifest writer for path: " + file);
+    }
+  }
+
+  private static class V1Writer extends ManifestWriter {
+    V1Writer(PartitionSpec spec, OutputFile file, Long snapshotId) {
+      super(spec, file, snapshotId);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -149,8 +149,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     if (base.propertyAsBoolean(MANIFEST_LISTS_ENABLED, MANIFEST_LISTS_ENABLED_DEFAULT)) {
       OutputFile manifestList = manifestListPath();
 
-      try (ManifestListWriter writer = new ManifestListWriter(
-          manifestList, snapshotId(), parentSnapshotId)) {
+      try (ManifestListWriter writer = ManifestListWriter.write(
+          ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId)) {
 
         // keep track of the manifest lists created
         manifestLists.add(manifestList.location());

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -48,12 +48,6 @@ public class TableMetadata {
 
   public static TableMetadata newTableMetadata(Schema schema,
                                                PartitionSpec spec,
-                                               String location) {
-    return newTableMetadata(schema, spec, location, ImmutableMap.of());
-  }
-
-  public static TableMetadata newTableMetadata(Schema schema,
-                                               PartitionSpec spec,
                                                String location,
                                                Map<String, String> properties) {
     // reassign all column ids to ensure consistency

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -43,7 +43,8 @@ import org.apache.iceberg.util.PropertyUtil;
  * Metadata for a table.
  */
 public class TableMetadata {
-  static final int TABLE_FORMAT_VERSION = 1;
+  static final int DEFAULT_TABLE_FORMAT_VERSION = 1;
+  static final int SUPPORTED_TABLE_FORMAT_VERSION = 2;
   static final int INITIAL_SPEC_ID = 0;
 
   public static TableMetadata newTableMetadata(Schema schema,
@@ -67,7 +68,7 @@ public class TableMetadata {
     }
     PartitionSpec freshSpec = specBuilder.build();
 
-    return new TableMetadata(null, UUID.randomUUID().toString(), location,
+    return new TableMetadata(null, DEFAULT_TABLE_FORMAT_VERSION, UUID.randomUUID().toString(), location,
         System.currentTimeMillis(),
         lastColumnId.get(), freshSchema, INITIAL_SPEC_ID, ImmutableList.of(freshSpec),
         ImmutableMap.copyOf(properties), -1, ImmutableList.of(),
@@ -164,6 +165,7 @@ public class TableMetadata {
   private final InputFile file;
 
   // stored metadata
+  private final int formatVersion;
   private final String uuid;
   private final String location;
   private final long lastUpdatedMillis;
@@ -180,6 +182,7 @@ public class TableMetadata {
   private final List<MetadataLogEntry> previousFiles;
 
   TableMetadata(InputFile file,
+                int formatVersion,
                 String uuid,
                 String location,
                 long lastUpdatedMillis,
@@ -192,6 +195,13 @@ public class TableMetadata {
                 List<Snapshot> snapshots,
                 List<HistoryEntry> snapshotLog,
                 List<MetadataLogEntry> previousFiles) {
+    Preconditions.checkArgument(formatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
+        "Unsupported format version: v%s", formatVersion);
+    if (formatVersion > 1) {
+      Preconditions.checkArgument(uuid != null, "UUID is required in format v%s", formatVersion);
+    }
+
+    this.formatVersion = formatVersion;
     this.file = file;
     this.uuid = uuid;
     this.location = location;
@@ -232,6 +242,10 @@ public class TableMetadata {
     Preconditions.checkArgument(
         currentSnapshotId < 0 || snapshotsById.containsKey(currentSnapshotId),
         "Invalid table metadata: Cannot find current version");
+  }
+
+  public int formatVersion() {
+    return formatVersion;
   }
 
   public InputFile file() {
@@ -322,16 +336,10 @@ public class TableMetadata {
     if (uuid != null) {
       return this;
     } else {
-      return new TableMetadata(null, UUID.randomUUID().toString(), location,
+      return new TableMetadata(null, formatVersion, UUID.randomUUID().toString(), location,
           lastUpdatedMillis, lastColumnId, schema, defaultSpecId, specs, properties,
           currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
     }
-  }
-
-  public TableMetadata updateTableLocation(String newLocation) {
-    return new TableMetadata(null, uuid, newLocation,
-        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
-        currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
 
   public TableMetadata updateSchema(Schema newSchema, int newLastColumnId) {
@@ -339,7 +347,7 @@ public class TableMetadata {
     // rebuild all of the partition specs for the new current schema
     List<PartitionSpec> updatedSpecs = Lists.transform(specs,
         spec -> updateSpecSchema(newSchema, spec));
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         System.currentTimeMillis(), newLastColumnId, newSchema, defaultSpecId, updatedSpecs, properties,
         currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
@@ -368,7 +376,7 @@ public class TableMetadata {
       builder.add(freshSpec(newDefaultSpecId, schema, newPartitionSpec));
     }
 
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         System.currentTimeMillis(), lastColumnId, schema, newDefaultSpecId,
         builder.build(), properties,
         currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
@@ -379,7 +387,7 @@ public class TableMetadata {
         .addAll(snapshots)
         .add(snapshot)
         .build();
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         snapshot.timestampMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
         currentSnapshotId, newSnapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
@@ -398,7 +406,7 @@ public class TableMetadata {
         .addAll(snapshotLog)
         .add(new SnapshotLogEntry(snapshot.timestampMillis(), snapshot.snapshotId()))
         .build();
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         snapshot.timestampMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
         snapshot.snapshotId(), newSnapshots, newSnapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
@@ -429,7 +437,7 @@ public class TableMetadata {
       }
     }
 
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
         currentSnapshotId, filtered, ImmutableList.copyOf(newSnapshotLog),
         addPreviousFile(file, lastUpdatedMillis));
@@ -450,14 +458,14 @@ public class TableMetadata {
         .add(new SnapshotLogEntry(nowMillis, snapshot.snapshotId()))
         .build();
 
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         nowMillis, lastColumnId, schema, defaultSpecId, specs, properties,
         snapshot.snapshotId(), snapshots, newSnapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
 
   public TableMetadata replaceProperties(Map<String, String> newProperties) {
     ValidationException.check(newProperties != null, "Cannot set properties to null");
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, newProperties,
         currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis, newProperties));
   }
@@ -474,7 +482,7 @@ public class TableMetadata {
     ValidationException.check(currentSnapshotId < 0 || // not set
             Iterables.getLast(newSnapshotLog).snapshotId() == currentSnapshotId,
         "Cannot set invalid snapshot log: latest entry is not the current snapshot");
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
         currentSnapshotId, snapshots, newSnapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
@@ -513,14 +521,30 @@ public class TableMetadata {
     newProperties.putAll(this.properties);
     newProperties.putAll(updatedProperties);
 
-    return new TableMetadata(null, uuid, location,
+    return new TableMetadata(null, formatVersion, uuid, location,
         System.currentTimeMillis(), nextLastColumnId.get(), freshSchema,
         specId, builder.build(), ImmutableMap.copyOf(newProperties),
         -1, snapshots, ImmutableList.of(), addPreviousFile(file, lastUpdatedMillis, newProperties));
   }
 
   public TableMetadata updateLocation(String newLocation) {
-    return new TableMetadata(null, uuid, newLocation,
+    return new TableMetadata(null, formatVersion, uuid, newLocation,
+        System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
+        currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
+  }
+
+  public TableMetadata upgradeToFormatVersion(int newFormatVersion) {
+    Preconditions.checkArgument(newFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,
+        "Cannot upgrade table to unsupported format version: v%s (supported: v%s)",
+        newFormatVersion, SUPPORTED_TABLE_FORMAT_VERSION);
+    Preconditions.checkArgument(newFormatVersion >= formatVersion,
+        "Cannot downgrade v%s table to v%s", formatVersion, newFormatVersion);
+
+    if (newFormatVersion == formatVersion) {
+      return this;
+    }
+
+    return new TableMetadata(null, newFormatVersion, uuid, location,
         System.currentTimeMillis(), lastColumnId, schema, defaultSpecId, specs, properties,
         currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }

--- a/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestFormatVersions extends TableTestBase {
+  @Test
+  public void testDefaultFormatVersion() {
+    Assert.assertEquals("Should default to v1", 1, table.ops().current().formatVersion());
+  }
+
+  @Test
+  public void testFormatVersionUpgrade() {
+    TableOperations ops = table.ops();
+    TableMetadata base = ops.current();
+    ops.commit(base, base.upgradeToFormatVersion(2));
+
+    Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
+  }
+
+  @Test
+  public void testFormatVersionDowngrade() {
+    TableOperations ops = table.ops();
+    TableMetadata base = ops.current();
+    ops.commit(base, base.upgradeToFormatVersion(2));
+
+    Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
+
+    AssertHelpers.assertThrows("Should reject a version downgrade",
+        IllegalArgumentException.class, "Cannot downgrade",
+        () -> ops.current().upgradeToFormatVersion(1));
+
+    Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
+  }
+
+  @Test
+  public void testFormatVersionUpgradeNotSupported() {
+    TableOperations ops = table.ops();
+    TableMetadata base = ops.current();
+    AssertHelpers.assertThrows("Should reject an unsupported version upgrade",
+        IllegalArgumentException.class, "Cannot upgrade table to unsupported format version",
+        () -> ops.commit(base, base.upgradeToFormatVersion(TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION + 1)));
+
+    Assert.assertEquals("Should report v1", 1, ops.current().formatVersion());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -95,8 +95,7 @@ public class TestSnapshotJson {
     Assert.assertTrue(manifestList.delete());
     manifestList.deleteOnExit();
 
-    try (ManifestListWriter writer = new ManifestListWriter(
-        Files.localOutput(manifestList), id, parentId)) {
+    try (ManifestListWriter writer = ManifestListWriter.write(1, Files.localOutput(manifestList), id, parentId)) {
       writer.addAll(manifests);
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -43,7 +43,7 @@ public class TestTables {
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
-    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString()));
+    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString(), ImmutableMap.of()));
     return new TestTable(ops, name);
   }
 
@@ -53,7 +53,7 @@ public class TestTables {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, temp.toString());
+    TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, temp.toString(), ImmutableMap.of());
 
     return Transactions.createTableTransaction(ops, metadata);
   }

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -677,3 +677,17 @@ This serialization scheme is for storing single values as individual binary valu
 | **`map`**                    | Not supported                                                                                                |
 
 
+## Format version changes
+
+### Version 2
+
+Writing metadata:
+* Table metadata field `sequence-number` is required.
+* Table metadata field `table-uuid` is required.
+* Table metadata field `partition-specs` is required.
+* Table metadata field `default-spec-id` is required.
+* Table metadata field `partition-spec` is no longer required and may be omitted.
+* Snapshot field `manifest-list` is required.
+* Snapshot field `manifests` is not allowed.
+
+Note that these requirements apply when writing data to a v2 table. Tables that are upgraded from v1 may contain metadata that does not follow these requirements. Implementations should remain backward-compatible with v1 metadata requirements.

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.File;
 import java.util.Map;
@@ -49,7 +50,7 @@ class TestTables {
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
-    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString()));
+    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString(), ImmutableMap.of()));
     return new TestTable(ops, name);
   }
 


### PR DESCRIPTION
Adding support for row-level deletes requires a new format version, v2. Previously, table format was checked when reading metadata, but not used anywhere else. This adds the format version to `TableMetadata` and updates metadata writes to pass the format version. This makes it possible to maintain v1 and iterate on v2 metadata in parallel.