### PR TITLE
Parquet: Support constant map for partition values

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -40,7 +40,6 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.ResolvingDecoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.common.DynConstructors;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 import static java.util.Collections.emptyIterator;
@@ -580,10 +579,9 @@ public class ValueReaders {
       List<Object> constantList = Lists.newArrayListWithCapacity(fields.size());
       for (int pos = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
-        Object constant = idToConstant.get(field.fieldId());
-        if (constant != null) {
+        if (idToConstant.containsKey(field.fieldId())) {
           positionList.add(pos);
-          constantList.add(prepareConstant(field.type(), constant));
+          constantList.add(idToConstant.get(field.fieldId()));
         }
       }
 
@@ -596,10 +594,6 @@ public class ValueReaders {
     protected abstract Object get(S struct, int pos);
 
     protected abstract void set(S struct, int pos, Object value);
-
-    protected Object prepareConstant(Type type, Object value) {
-      return value;
-    }
 
     public ValueReader<?> reader(int pos) {
       return readers[pos];

--- a/data/src/main/java/org/apache/iceberg/data/DateTimeUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/DateTimeUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+public class DateTimeUtil {
+  private DateTimeUtil() {
+  }
+
+  private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+  private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
+
+  public static LocalDate dateFromDays(int daysFromEpoch) {
+    return ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFromEpoch);
+  }
+
+  public static LocalTime timeFromMicros(long microFromMidnight) {
+    return LocalTime.ofNanoOfDay(microFromMidnight * 1000);
+  }
+
+  public static LocalDateTime timestampFromMicros(long microsFromEpoch) {
+    return ChronoUnit.MICROS.addTo(EPOCH, microsFromEpoch).toLocalDateTime();
+  }
+
+  public static OffsetDateTime timestamptzFromMicros(long microsFromEpoch) {
+    return ChronoUnit.MICROS.addTo(EPOCH, microsFromEpoch);
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/avro/GenericReaders.java
+++ b/data/src/main/java/org/apache/iceberg/data/avro/GenericReaders.java
@@ -20,18 +20,16 @@
 package org.apache.iceberg.data.avro;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.io.Decoder;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
+import org.apache.iceberg.data.DateTimeUtil;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types.StructType;
@@ -60,9 +58,6 @@ class GenericReaders {
     return new GenericRecordReader(readers, struct, idToConstant);
   }
 
-  private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
-  private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
-
   private static class DateReader implements ValueReader<LocalDate> {
     private static final DateReader INSTANCE = new DateReader();
 
@@ -71,7 +66,7 @@ class GenericReaders {
 
     @Override
     public LocalDate read(Decoder decoder, Object reuse) throws IOException {
-      return EPOCH_DAY.plusDays(decoder.readInt());
+      return DateTimeUtil.dateFromDays(decoder.readInt());
     }
   }
 
@@ -83,7 +78,7 @@ class GenericReaders {
 
     @Override
     public LocalTime read(Decoder decoder, Object reuse) throws IOException {
-      return LocalTime.ofNanoOfDay(decoder.readLong() * 1000);
+      return DateTimeUtil.timeFromMicros(decoder.readLong());
     }
   }
 
@@ -95,7 +90,7 @@ class GenericReaders {
 
     @Override
     public LocalDateTime read(Decoder decoder, Object reuse) throws IOException {
-      return EPOCH.plus(decoder.readLong(), ChronoUnit.MICROS).toLocalDateTime();
+      return DateTimeUtil.timestampFromMicros(decoder.readLong());
     }
   }
 
@@ -107,7 +102,7 @@ class GenericReaders {
 
     @Override
     public OffsetDateTime read(Decoder decoder, Object reuse) throws IOException {
-      return EPOCH.plus(decoder.readLong(), ChronoUnit.MICROS);
+      return DateTimeUtil.timestamptzFromMicros(decoder.readLong());
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.data;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.math.BigDecimal;
@@ -66,23 +67,29 @@ public class SparkParquetReaders {
   private SparkParquetReaders() {
   }
 
-  @SuppressWarnings("unchecked")
   public static ParquetValueReader<InternalRow> buildReader(Schema expectedSchema,
                                                             MessageType fileSchema) {
+    return buildReader(expectedSchema, fileSchema, ImmutableMap.of());
+  }
+
+  @SuppressWarnings("unchecked")
+  public static ParquetValueReader<InternalRow> buildReader(Schema expectedSchema,
+                                                            MessageType fileSchema,
+                                                            Map<Integer, ?> idToConstant) {
     if (ParquetSchemaUtil.hasIds(fileSchema)) {
       return (ParquetValueReader<InternalRow>)
           TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), fileSchema,
-              new ReadBuilder(fileSchema));
+              new ReadBuilder(fileSchema, idToConstant));
     } else {
       return (ParquetValueReader<InternalRow>)
           TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), fileSchema,
-              new FallbackReadBuilder(fileSchema));
+              new FallbackReadBuilder(fileSchema, idToConstant));
     }
   }
 
   private static class FallbackReadBuilder extends ReadBuilder {
-    FallbackReadBuilder(MessageType type) {
-      super(type);
+    FallbackReadBuilder(MessageType type, Map<Integer, ?> idToConstant) {
+      super(type, idToConstant);
     }
 
     @Override
@@ -113,9 +120,11 @@ public class SparkParquetReaders {
 
   private static class ReadBuilder extends TypeWithSchemaVisitor<ParquetValueReader<?>> {
     private final MessageType type;
+    private final Map<Integer, ?> idToConstant;
 
-    ReadBuilder(MessageType type) {
+    ReadBuilder(MessageType type, Map<Integer, ?> idToConstant) {
       this.type = type;
+      this.idToConstant = idToConstant;
     }
 
     @Override
@@ -146,13 +155,19 @@ public class SparkParquetReaders {
       List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
-        ParquetValueReader<?> reader = readersById.get(id);
-        if (reader != null) {
-          reorderedFields.add(reader);
-          types.add(typesById.get(id));
-        } else {
-          reorderedFields.add(ParquetValueReaders.nulls());
+        if (idToConstant.containsKey(id)) {
+          // containsKey is used because the constant may be null
+          reorderedFields.add(ParquetValueReaders.constant(idToConstant.get(id)));
           types.add(null);
+        } else {
+          ParquetValueReader<?> reader = readersById.get(id);
+          if (reader != null) {
+            reorderedFields.add(reader);
+            types.add(typesById.get(id));
+          } else {
+            reorderedFields.add(ParquetValueReaders.nulls());
+            types.add(null);
+          }
         }
       }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -29,14 +29,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
@@ -286,31 +283,6 @@ public class SparkValueReaders {
       } else {
         struct.setNullAt(pos);
       }
-    }
-
-    @Override
-    protected Object prepareConstant(Type type, Object value) {
-      switch (type.typeId()) {
-        case DECIMAL:
-          return Decimal.apply((BigDecimal) value);
-        case STRING:
-          if (value instanceof Utf8) {
-            Utf8 utf8 = (Utf8) value;
-            return UTF8String.fromBytes(utf8.getBytes(), 0, utf8.getByteLength());
-          }
-          return UTF8String.fromString(value.toString());
-        case FIXED:
-          if (value instanceof byte[]) {
-            return value;
-          } else if (value instanceof GenericData.Fixed) {
-            return ((GenericData.Fixed) value).bytes();
-          }
-          return ByteBuffers.toByteArray((ByteBuffer) value);
-        case BINARY:
-          return ByteBuffers.toByteArray((ByteBuffer) value);
-        default:
-      }
-      return value;
     }
   }
 }


### PR DESCRIPTION
This is a follow-up to #896, which added the same constant map support for Avro.

Fixes #575 for Parquet and replaces #585. Andrei did a lot of the work for this in #585.

Co-authored-by: Andrei Ionescu <webdev.andrei@gmail.com>