### PR TITLE
Move manifest factory methods

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -261,7 +261,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         .executeWith(ThreadPools.getWorkerPool())
         .onFailure((item, exc) -> LOG.warn("Failed to get deleted files: this may cause orphaned data files", exc))
         .run(manifest -> {
-          try (ManifestReader reader = ManifestReader.read(manifest, io)) {
+          try (ManifestReader reader = ManifestFiles.read(manifest, io)) {
             for (ManifestEntry entry : reader.entries()) {
               // intern the file path because the weak key map uses identity (==) instead of equals
               String path = entry.file().path().toString().intern();

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -154,7 +154,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   }
 
   private ManifestFile copyManifest(ManifestFile manifest) {
-    try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), specsById)) {
+    try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), specsById)) {
       OutputFile newFile = newManifestOutput();
       return ManifestWriter.copyManifest(reader, newFile, snapshotId(), summaryBuilder, ALLOWED_ENTRY_STATUSES);
     } catch (IOException e) {
@@ -237,7 +237,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
               keptManifests.add(manifest);
             } else {
               rewrittenManifests.add(manifest);
-              try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+              try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
                 FilteredManifest filteredManifest = reader.select(Arrays.asList("*"));
                 filteredManifest.liveEntries().forEach(
                     entry -> appendEntry(entry, clusterByFunc.apply(entry.file()), manifest.partitionSpecId())

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -156,7 +156,8 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   private ManifestFile copyManifest(ManifestFile manifest) {
     try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), specsById)) {
       OutputFile newFile = newManifestOutput();
-      return ManifestWriter.copyManifest(reader, newFile, snapshotId(), summaryBuilder, ALLOWED_ENTRY_STATUSES);
+      return ManifestFiles.copyManifest(
+          ops.current().formatVersion(), reader, newFile, snapshotId(), summaryBuilder, ALLOWED_ENTRY_STATUSES);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
     }

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -131,7 +131,7 @@ public class DataFilesTable extends BaseMetadataTable {
     @Override
     public CloseableIterable<StructLike> rows() {
       return CloseableIterable.transform(
-          ManifestReader.read(manifest, io).project(schema),
+          ManifestFiles.read(manifest, io).project(schema),
           file -> (GenericDataFile) file);
     }
 

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -107,7 +107,7 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   }
 
   private ManifestFile copyManifest(ManifestFile manifest) {
-    try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+    try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
       OutputFile newManifestPath = newManifestOutput();
       return ManifestWriter.copyAppendManifest(reader, newManifestPath, snapshotId(), summaryBuilder);
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -109,7 +109,8 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   private ManifestFile copyManifest(ManifestFile manifest) {
     try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
       OutputFile newManifestPath = newManifestOutput();
-      return ManifestWriter.copyAppendManifest(reader, newManifestPath, snapshotId(), summaryBuilder);
+      return ManifestFiles.copyAppendManifest(
+          ops.current().formatVersion(), reader, newManifestPath, snapshotId(), summaryBuilder);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+
+public class ManifestFiles {
+  private ManifestFiles() {
+  }
+
+  /**
+   * Returns a new {@link ManifestReader} for a {@link ManifestFile}.
+   * <p>
+   * <em>Note:</em> Callers should use {@link ManifestFiles#read(ManifestFile, FileIO, Map)} to ensure
+   * the schema used by filters is the latest table schema. This should be used only when reading
+   * a manifest without filters.
+   *
+   * @param manifest a ManifestFile
+   * @param io a FileIO
+   * @return a manifest reader
+   */
+  public static ManifestReader read(ManifestFile manifest, FileIO io) {
+    return read(manifest, io, null);
+  }
+
+  /**
+   * Returns a new {@link ManifestReader} for a {@link ManifestFile}.
+   *
+   * @param manifest a {@link ManifestFile}
+   * @param io a {@link FileIO}
+   * @param specsById a Map from spec ID to partition spec
+   * @return a {@link ManifestReader}
+   */
+  public static ManifestReader read(ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
+    InputFile file = io.newInputFile(manifest.path());
+    InheritableMetadata inheritableMetadata = InheritableMetadataFactory.fromManifest(manifest);
+    return new ManifestReader(file, specsById, inheritableMetadata);
+  }
+
+  /**
+   * Create a new {@link ManifestWriter}.
+   * <p>
+   * Manifests created by this writer have all entry snapshot IDs set to null.
+   * All entries will inherit the snapshot ID that will be assigned to the manifest on commit.
+   *
+   * @param spec {@link PartitionSpec} used to produce {@link DataFile} partition tuples
+   * @param outputFile the destination file location
+   * @return a manifest writer
+   */
+  public static ManifestWriter write(PartitionSpec spec, OutputFile outputFile) {
+    // always use a v1 writer for appended manifests because sequence number must be inherited
+    return write(1, spec, outputFile, null);
+  }
+
+  /**
+   * Create a new {@link ManifestWriter} for the given format version.
+   *
+   * @param formatVersion a target format version
+   * @param spec a {@link PartitionSpec}
+   * @param outputFile an {@link OutputFile} where the manifest will be written
+   * @param snapshotId a snapshot ID for the manifest entries, or null for an inherited ID
+   * @return a manifest writer
+   */
+  static ManifestWriter write(int formatVersion, PartitionSpec spec, OutputFile outputFile, Long snapshotId) {
+    switch (formatVersion) {
+      case 1:
+        return new ManifestWriter.V1Writer(spec, outputFile, snapshotId);
+    }
+    throw new UnsupportedOperationException("Cannot write manifest for table version: " + formatVersion);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -209,7 +209,7 @@ class ManifestGroup {
     Iterable<CloseableIterable<T>> readers = Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader reader = ManifestReader.read(manifest, io, specsById);
+          ManifestReader reader = ManifestFiles.read(manifest, io, specsById);
 
           FilteredManifest filtered = reader
               .filterRows(dataFilter)

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -99,7 +99,7 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
 
   ManifestReader(InputFile file, Map<Integer, PartitionSpec> specsById,
                  InheritableMetadata inheritableMetadata) {
-    this(file, specsById::get, inheritableMetadata);
+    this(file, specsById != null ? specsById::get : null, inheritableMetadata);
   }
 
   private ManifestReader(InputFile file, Function<Integer, PartitionSpec> specLookup,

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -66,7 +66,7 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
    *
    * @param file an InputFile
    * @return a manifest reader
-   * @deprecated use {@link ManifestFiles#read(ManifestFile, FileIO, Map)}.
+   * @deprecated will be removed in 0.9.0; use {@link ManifestFiles#read(ManifestFile, FileIO, Map)} instead.
    */
   @Deprecated
   public static ManifestReader read(InputFile file) {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -45,8 +45,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 /**
  * Reader for manifest files.
  * <p>
- * The preferable way to create readers is using {@link #read(ManifestFile, FileIO, Map)} as
- * it allows entries to inherit manifest metadata such as snapshot id.
+ * Create readers using {@link ManifestFiles#read(ManifestFile, FileIO, Map)}.
  */
 public class ManifestReader extends CloseableGroup implements Filterable<FilteredManifest> {
   private static final Logger LOG = LoggerFactory.getLogger(ManifestReader.class);
@@ -62,61 +61,16 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
   /**
    * Returns a new {@link ManifestReader} for an {@link InputFile}.
    * <p>
-   * <em>Note:</em> Most callers should use {@link #read(ManifestFile, FileIO, Map)} to ensure that
+   * <em>Note:</em> Callers should use {@link ManifestFiles#read(ManifestFile, FileIO, Map)} to ensure that
    * manifest entries with partial metadata can inherit missing properties from the manifest metadata.
-   * <p>
-   * <em>Note:</em> Most callers should use {@link #read(InputFile, Map)} if all manifest entries
-   * contain full metadata and they want to ensure that the schema used by filters is the latest
-   * table schema. This should be used only when reading a manifest without filters.
    *
    * @param file an InputFile
    * @return a manifest reader
+   * @deprecated use {@link ManifestFiles#read(ManifestFile, FileIO, Map)}.
    */
+  @Deprecated
   public static ManifestReader read(InputFile file) {
     return new ManifestReader(file, null, InheritableMetadataFactory.empty());
-  }
-
-  /**
-   * Returns a new {@link ManifestReader} for an {@link InputFile}.
-   * <p>
-   * <em>Note:</em> Most callers should use {@link #read(ManifestFile, FileIO, Map)} to ensure that
-   * manifest entries with partial metadata can inherit missing properties from the manifest metadata.
-   *
-   * @param file an InputFile
-   * @param specsById a Map from spec ID to partition spec
-   * @return a manifest reader
-   */
-  public static ManifestReader read(InputFile file, Map<Integer, PartitionSpec> specsById) {
-    return new ManifestReader(file, specsById, InheritableMetadataFactory.empty());
-  }
-
-  /**
-   * Returns a new {@link ManifestReader} for a {@link ManifestFile}.
-   * <p>
-   * <em>Note:</em> Most callers should use {@link #read(ManifestFile, FileIO, Map)} to ensure
-   * the schema used by filters is the latest table schema. This should be used only when reading
-   * a manifest without filters.
-   *
-   * @param manifest a ManifestFile
-   * @param io a FileIO
-   * @return a manifest reader
-   */
-  public static ManifestReader read(ManifestFile manifest, FileIO io) {
-    return read(manifest, io, null);
-  }
-
-  /**
-   * Returns a new {@link ManifestReader} for a {@link ManifestFile}.
-   *
-   * @param manifest a ManifestFile
-   * @param io a FileIO
-   * @param specsById a Map from spec ID to partition spec
-   * @return a manifest reader
-   */
-  public static ManifestReader read(ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
-    InputFile file = io.newInputFile(manifest.path());
-    InheritableMetadata inheritableMetadata = InheritableMetadataFactory.fromManifest(manifest);
-    return new ManifestReader(file, specsById, inheritableMetadata);
   }
 
   private final InputFile file;
@@ -129,7 +83,7 @@ public class ManifestReader extends CloseableGroup implements Filterable<Filtere
   private List<ManifestEntry> cachedAdds = null;
   private List<ManifestEntry> cachedDeletes = null;
 
-  private ManifestReader(InputFile file, Map<Integer, PartitionSpec> specsById,
+  ManifestReader(InputFile file, Map<Integer, PartitionSpec> specsById,
                          InheritableMetadata inheritableMetadata) {
     this.file = file;
     this.inheritableMetadata = inheritableMetadata;

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -44,7 +44,9 @@ public abstract class ManifestWriter implements FileAppender<DataFile> {
    * @param spec {@link PartitionSpec} used to produce {@link DataFile} partition tuples
    * @param outputFile the destination file location
    * @return a manifest writer
+   * @deprecated will be removed in 0.9.0; use {@link ManifestFiles#write(PartitionSpec, OutputFile)} instead.
    */
+  @Deprecated
   public static ManifestWriter write(PartitionSpec spec, OutputFile outputFile) {
     return ManifestFiles.write(spec, outputFile);
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -94,15 +94,7 @@ public abstract class ManifestWriter implements FileAppender<DataFile> {
    * @return a manifest writer
    */
   public static ManifestWriter write(PartitionSpec spec, OutputFile outputFile) {
-    // always use a v1 writer for appended manifests because sequence number must be inherited
-    return write(1, spec, outputFile, null);
-  }
-
-  static ManifestWriter write(int formatVersion, PartitionSpec spec, OutputFile outputFile, Long snapshotId) {
-    if (formatVersion == 1) {
-      return new V1Writer(spec, outputFile, snapshotId);
-    }
-    throw new UnsupportedOperationException("Cannot write manifest for table version: " + formatVersion);
+    return ManifestFiles.write(spec, outputFile);
   }
 
   private final OutputFile file;
@@ -239,7 +231,7 @@ public abstract class ManifestWriter implements FileAppender<DataFile> {
     }
   }
 
-  private static class V1Writer extends ManifestWriter {
+  static class V1Writer extends ManifestWriter {
     V1Writer(PartitionSpec spec, OutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
     }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -229,7 +229,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   private ManifestFile copyManifest(ManifestFile manifest) {
     try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
       OutputFile newManifestPath = newManifestOutput();
-      return ManifestWriter.copyAppendManifest(reader, newManifestPath, snapshotId(), appendedManifestsSummary);
+      return ManifestFiles.copyAppendManifest(
+          ops.current().formatVersion(), reader, newManifestPath, snapshotId(), appendedManifestsSummary);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
     }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -227,7 +227,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   }
 
   private ManifestFile copyManifest(ManifestFile manifest) {
-    try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+    try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
       OutputFile newManifestPath = newManifestOutput();
       return ManifestWriter.copyAppendManifest(reader, newManifestPath, snapshotId(), appendedManifestsSummary);
     } catch (IOException e) {
@@ -481,7 +481,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       return manifest;
     }
 
-    try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+    try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
 
       // this is reused to compare file paths with the delete set
       CharSequenceWrapper pathWrapper = CharSequenceWrapper.wrap("");
@@ -655,7 +655,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     ManifestWriter writer = newManifestWriter(ops.current().spec());
     try {
       for (ManifestFile manifest : bin) {
-        try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+        try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
           for (ManifestEntry entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {
               // suppress deletes from previous snapshots. only files deleted by this snapshot

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -337,7 +337,7 @@ class RemoveSnapshots implements ExpireSnapshots {
         .onFailure((item, exc) -> LOG.warn("Failed to get deleted files: this may cause orphaned data files", exc))
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
-          try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+          try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
             for (ManifestEntry entry : reader.entries()) {
               // if the snapshot ID of the DELETE entry is no longer valid, the data can be deleted
               if (entry.status() == ManifestEntry.Status.DELETED &&
@@ -357,7 +357,7 @@ class RemoveSnapshots implements ExpireSnapshots {
         .onFailure((item, exc) -> LOG.warn("Failed to get added files: this may cause orphaned data files", exc))
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
-          try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+          try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
             for (ManifestEntry entry : reader.entries()) {
               // delete any ADDED file from manifests that were reverted
               if (entry.status() == ManifestEntry.Status.ADDED) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -318,7 +318,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   protected ManifestWriter newManifestWriter(PartitionSpec spec) {
-    return ManifestWriter.write(ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+    return ManifestFiles.write(ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
   }
 
   protected long snapshotId() {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -333,7 +333,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   private static ManifestFile addMetadata(TableOperations ops, ManifestFile manifest) {
-    try (ManifestReader reader = ManifestReader.read(manifest, ops.io(), ops.current().specsById())) {
+    try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
       PartitionSummary stats = new PartitionSummary(ops.current().spec(manifest.partitionSpecId()));
       int addedFiles = 0;
       long addedRows = 0L;

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -130,7 +130,7 @@ public class TableTestBase {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestWriter.write(table.spec(), outputFile);
+    ManifestWriter writer = ManifestFiles.write(table.spec(), outputFile);
     try {
       for (DataFile file : files) {
         writer.add(file);
@@ -147,7 +147,7 @@ public class TableTestBase {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestWriter.write(table.spec(), outputFile);
+    ManifestWriter writer = ManifestFiles.write(table.spec(), outputFile);
     try {
       for (ManifestEntry entry : entries) {
         writer.addEntry(entry);
@@ -164,7 +164,7 @@ public class TableTestBase {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestWriter.write(table.spec(), outputFile);
+    ManifestWriter writer = ManifestFiles.write(table.spec(), outputFile);
     try {
       for (DataFile file : files) {
         writer.add(file);

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -207,7 +207,7 @@ public class TableTestBase {
     long id = snap.snapshotId();
     Iterator<String> newPaths = paths(newFiles).iterator();
 
-    for (ManifestEntry entry : ManifestReader.read(manifest, FILE_IO).entries()) {
+    for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       Assert.assertEquals("Path should match expected", newPaths.next(), file.path().toString());
       Assert.assertEquals("File's snapshot ID should match", id, (long) entry.snapshotId());
@@ -239,7 +239,7 @@ public class TableTestBase {
   static void validateManifest(ManifestFile manifest,
                                Iterator<Long> ids,
                                Iterator<DataFile> expectedFiles) {
-    for (ManifestEntry entry : ManifestReader.read(manifest, FILE_IO).entries()) {
+    for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
       Assert.assertEquals("Path should match expected",
@@ -255,7 +255,7 @@ public class TableTestBase {
                                       Iterator<Long> ids,
                                       Iterator<DataFile> expectedFiles,
                                       Iterator<ManifestEntry.Status> expectedStatuses) {
-    for (ManifestEntry entry : ManifestReader.read(manifest, FILE_IO).entries()) {
+    for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
       final ManifestEntry.Status expectedStatus = expectedStatuses.next();
@@ -283,6 +283,6 @@ public class TableTestBase {
   }
 
   static Iterator<DataFile> files(ManifestFile manifest) {
-    return ManifestReader.read(manifest, FILE_IO).iterator();
+    return ManifestFiles.read(manifest, FILE_IO).iterator();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 public class TestManifestReader extends TableTestBase {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testManifestReaderWithEmptyInheritableMetadata() throws IOException {
     ManifestFile manifest = writeManifest("manifest.avro", manifestEntry(Status.EXISTING, 1000L, FILE_A));
     try (ManifestReader reader = ManifestReader.read(FILE_IO.newInputFile(manifest.path()))) {
@@ -41,6 +42,7 @@ public class TestManifestReader extends TableTestBase {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testInvalidUsage() throws IOException {
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
     try (ManifestReader reader = ManifestReader.read(FILE_IO.newInputFile(manifest.path()))) {

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -54,6 +54,7 @@ public class TestManifestReader extends TableTestBase {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testManifestReaderWithPartitionMetadata() throws IOException {
     ManifestFile manifest = writeManifest("manifest.avro", manifestEntry(Status.EXISTING, 123L, FILE_A));
     try (ManifestReader reader = ManifestReader.read(FILE_IO.newInputFile(manifest.path()))) {
@@ -69,6 +70,7 @@ public class TestManifestReader extends TableTestBase {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testManifestReaderWithUpdatedPartitionMetadataForV1Table() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(table.schema())
         .bucket("id", 8)

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -730,7 +730,7 @@ public class TestMergeAppend extends TableTestBase {
         initialManifest, pending.manifests().get(1));
 
     // field ids of manifest entries in two manifests with different specs of the same source field should be different
-    ManifestEntry entry = ManifestReader.read(pending.manifests().get(0), FILE_IO).entries().iterator().next();
+    ManifestEntry entry = ManifestFiles.read(pending.manifests().get(0), FILE_IO).entries().iterator().next();
     Types.NestedField field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
     Assert.assertEquals(1000, field.fieldId());
     Assert.assertEquals("id_bucket", field.name());
@@ -738,7 +738,7 @@ public class TestMergeAppend extends TableTestBase {
     Assert.assertEquals(1001, field.fieldId());
     Assert.assertEquals("data_bucket", field.name());
 
-    entry = ManifestReader.read(pending.manifests().get(1), FILE_IO).entries().iterator().next();
+    entry = ManifestFiles.read(pending.manifests().get(1), FILE_IO).entries().iterator().next();
     field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
     Assert.assertEquals(1000, field.fieldId());
     Assert.assertEquals("data_bucket", field.name());

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -102,7 +102,7 @@ public class TestRewriteManifests extends TableTestBase {
     // get the correct file order
     List<DataFile> files;
     List<Long> ids;
-    try (ManifestReader reader = ManifestReader.read(manifests.get(0), table.io())) {
+    try (ManifestReader reader = ManifestFiles.read(manifests.get(0), table.io())) {
       if (reader.iterator().next().path().equals(FILE_A.path())) {
         files = Arrays.asList(FILE_A, FILE_B);
         ids = Arrays.asList(manifestAppendId, fileAppendId);
@@ -176,7 +176,7 @@ public class TestRewriteManifests extends TableTestBase {
     // get the file order correct
     List<DataFile> files;
     List<Long> ids;
-    try (ManifestReader reader = ManifestReader.read(manifests.get(0), table.io())) {
+    try (ManifestReader reader = ManifestFiles.read(manifests.get(0), table.io())) {
       if (reader.iterator().next().path().equals(FILE_A.path())) {
         files = Arrays.asList(FILE_A, FILE_B);
         ids = Arrays.asList(appendIdA, appendIdB);
@@ -218,7 +218,7 @@ public class TestRewriteManifests extends TableTestBase {
     table.rewriteManifests()
       .clusterBy(file -> "file")
       .rewriteIf(manifest -> {
-        try (ManifestReader reader = ManifestReader.read(manifest, table.io())) {
+        try (ManifestReader reader = ManifestFiles.read(manifest, table.io())) {
           return !reader.iterator().next().path().equals(FILE_A.path());
         } catch (IOException x) {
           throw new RuntimeIOException(x);
@@ -232,7 +232,7 @@ public class TestRewriteManifests extends TableTestBase {
     // get the file order correct
     List<DataFile> files;
     List<Long> ids;
-    try (ManifestReader reader = ManifestReader.read(manifests.get(0), table.io())) {
+    try (ManifestReader reader = ManifestFiles.read(manifests.get(0), table.io())) {
       if (reader.iterator().next().path().equals(FILE_B.path())) {
         files = Arrays.asList(FILE_B, FILE_C);
         ids = Arrays.asList(appendIdB, appendIdC);
@@ -302,7 +302,7 @@ public class TestRewriteManifests extends TableTestBase {
     table.rewriteManifests()
       .clusterBy(file -> "file")
       .rewriteIf(manifest -> {
-        try (ManifestReader reader = ManifestReader.read(manifest, table.io())) {
+        try (ManifestReader reader = ManifestFiles.read(manifest, table.io())) {
           return !reader.iterator().next().path().equals(FILE_A.path());
         } catch (IOException x) {
           throw new RuntimeIOException(x);
@@ -322,7 +322,7 @@ public class TestRewriteManifests extends TableTestBase {
     // get the file order correct
     List<DataFile> files;
     List<Long> ids;
-    try (ManifestReader reader = ManifestReader.read(manifests.get(0), table.io())) {
+    try (ManifestReader reader = ManifestFiles.read(manifests.get(0), table.io())) {
       if (reader.iterator().next().path().equals(FILE_A.path())) {
         files = Arrays.asList(FILE_A, FILE_B);
         ids = Arrays.asList(appendIdA, appendIdB);
@@ -885,7 +885,7 @@ public class TestRewriteManifests extends TableTestBase {
         .addManifest(newManifest)
         .clusterBy(dataFile -> "const-value")
         .rewriteIf(manifest -> {
-          try (ManifestReader reader = ManifestReader.read(manifest, table.io())) {
+          try (ManifestReader reader = ManifestFiles.read(manifest, table.io())) {
             return !reader.iterator().next().path().equals(FILE_B.path());
           } catch (IOException x) {
             throw new RuntimeIOException(x);

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -487,7 +487,7 @@ public class TestTransaction extends TableTestBase {
 
     // create a manifest append
     OutputFile manifestLocation = Files.localOutput("/tmp/" + UUID.randomUUID().toString() + ".avro");
-    ManifestWriter writer = ManifestWriter.write(table.spec(), manifestLocation);
+    ManifestWriter writer = ManifestFiles.write(table.spec(), manifestLocation);
     try {
       writer.add(FILE_D);
     } finally {

--- a/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
+++ b/spark/src/main/scala/org/apache/iceberg/spark/SparkTableUtil.scala
@@ -22,7 +22,7 @@ package org.apache.iceberg.spark
 import com.google.common.collect.Maps
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, PathFilter}
-import org.apache.iceberg.{DataFile, DataFiles, FileFormat, ManifestFile, ManifestWriter}
+import org.apache.iceberg.{DataFile, DataFiles, FileFormat, ManifestFile, ManifestFiles}
 import org.apache.iceberg.{Metrics, MetricsConfig, PartitionSpec, Table, TableProperties}
 import org.apache.iceberg.exceptions.NoSuchTableException
 import org.apache.iceberg.hadoop.{HadoopFileIO, HadoopInputFile, SerializableConfiguration}
@@ -324,7 +324,7 @@ object SparkTableUtil {
       val ctx = TaskContext.get()
       val location = new Path(basePath, s"stage-${ctx.stageId()}-task-${ctx.taskAttemptId()}-manifest")
       val outputFile = io.newOutputFile(FileFormat.AVRO.addExtension(location.toString))
-      val writer = ManifestWriter.write(spec, outputFile)
+      val writer = ManifestFiles.write(spec, outputFile)
       try {
         files.foreach(writer.add)
       } finally {

--- a/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
@@ -155,7 +155,7 @@ public class TestManifestFileSerialization {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = FILE_IO.newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestWriter.write(SPEC, outputFile);
+    ManifestWriter writer = ManifestFiles.write(SPEC, outputFile);
     try {
       for (DataFile file : files) {
         writer.add(file);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -184,7 +185,7 @@ public class TestForwardCompatibility {
         .build();
 
     OutputFile manifestFile = localOutput(FileFormat.AVRO.addExtension(temp.newFile().toString()));
-    ManifestWriter manifestWriter = ManifestWriter.write(FAKE_SPEC, manifestFile);
+    ManifestWriter manifestWriter = ManifestFiles.write(FAKE_SPEC, manifestFile);
     try {
       manifestWriter.add(file);
     } finally {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManifestFile;
-import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -121,7 +121,7 @@ public class TestSparkDataWrite {
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
-      for (DataFile file : ManifestReader.read(manifest, table.io())) {
+      for (DataFile file : ManifestFiles.read(manifest, table.io())) {
         // TODO: avro not support split
         if (!format.equals(FileFormat.AVRO)) {
           Assert.assertNotNull("Split offsets not present", file.splitOffsets());
@@ -316,7 +316,7 @@ public class TestSparkDataWrite {
 
     List<DataFile> files = Lists.newArrayList();
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
-      for (DataFile file : ManifestReader.read(manifest, table.io())) {
+      for (DataFile file : ManifestFiles.read(manifest, table.io())) {
         files.add(file);
       }
     }
@@ -365,7 +365,7 @@ public class TestSparkDataWrite {
 
     List<DataFile> files = Lists.newArrayList();
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
-      for (DataFile file : ManifestReader.read(manifest, table.io())) {
+      for (DataFile file : ManifestFiles.read(manifest, table.io())) {
         files.add(file);
       }
     }


### PR DESCRIPTION
This is a refactor that was part of #913, but causes that commit to change lots of files. Separating it out should be cleaner.