### PR TITLE
Add failure handling in cleanup while reading snapshot manifest-list files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -201,112 +201,121 @@ class RemoveSnapshots implements ExpireSnapshots {
     // find manifests to clean up that are still referenced by a valid snapshot, but written by an expired snapshot
     Set<String> validManifests = Sets.newHashSet();
     Set<ManifestFile> manifestsToScan = Sets.newHashSet();
-    for (Snapshot snapshot : snapshots) {
-      try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
-        for (ManifestFile manifest : manifests) {
-          validManifests.add(manifest.path());
+    Tasks.foreach(snapshots).noRetry().suppressFailureWhenFinished()
+        .onFailure((snapshot, exc) -> LOG.warn("Failed on snapshot {} while reading manifest list: {}",
+            snapshot.snapshotId(), snapshot.manifestListLocation(), exc))
+        .run(
+            snapshot -> {
+              try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
+                for (ManifestFile manifest : manifests) {
+                  validManifests.add(manifest.path());
 
-          long snapshotId = manifest.snapshotId();
-          // whether the manifest was created by a valid snapshot (true) or an expired snapshot (false)
-          boolean fromValidSnapshots = validIds.contains(snapshotId);
-          // whether the snapshot that created the manifest was an ancestor of the table state
-          boolean isFromAncestor = ancestorIds.contains(snapshotId);
-          // whether the changes in this snapshot have been picked into the current table state
-          boolean isPicked = pickedAncestorSnapshotIds.contains(snapshotId);
-          // if the snapshot that wrote this manifest is no longer valid (has expired), then delete its deleted files.
-          // note that this is only for expired snapshots that are in the current table state
-          if (!fromValidSnapshots && (isFromAncestor || isPicked) && manifest.hasDeletedFiles()) {
-            manifestsToScan.add(manifest.copy());
-          }
-        }
+                  long snapshotId = manifest.snapshotId();
+                  // whether the manifest was created by a valid snapshot (true) or an expired snapshot (false)
+                  boolean fromValidSnapshots = validIds.contains(snapshotId);
+                  // whether the snapshot that created the manifest was an ancestor of the table state
+                  boolean isFromAncestor = ancestorIds.contains(snapshotId);
+                  // whether the changes in this snapshot have been picked into the current table state
+                  boolean isPicked = pickedAncestorSnapshotIds.contains(snapshotId);
+                  // if the snapshot that wrote this manifest is no longer valid (has expired),
+                  // then delete its deleted files. note that this is only for expired snapshots that are in the
+                  // current table state
+                  if (!fromValidSnapshots && (isFromAncestor || isPicked) && manifest.hasDeletedFiles()) {
+                    manifestsToScan.add(manifest.copy());
+                  }
+                }
 
-      } catch (IOException e) {
-        throw new RuntimeIOException(e,
-            "Failed to close manifest list: %s", snapshot.manifestListLocation());
-      }
-    }
+              } catch (IOException e) {
+                throw new RuntimeIOException(e,
+                    "Failed to close manifest list: %s", snapshot.manifestListLocation());
+              }
+            });
 
     // find manifests to clean up that were only referenced by snapshots that have expired
     Set<String> manifestListsToDelete = Sets.newHashSet();
     Set<String> manifestsToDelete = Sets.newHashSet();
     Set<ManifestFile> manifestsToRevert = Sets.newHashSet();
-    for (Snapshot snapshot : base.snapshots()) {
-      long snapshotId = snapshot.snapshotId();
-      if (!validIds.contains(snapshotId)) {
-        // determine whether the changes in this snapshot are in the current table state
-        if (pickedAncestorSnapshotIds.contains(snapshotId)) {
-          // this snapshot was cherry-picked into the current table state, so skip cleaning it up. its changes will
-          // expire when the picked snapshot expires.
-          // A -- C -- D (source=B)
-          //  `- B <-- this commit
-          continue;
-        }
+    Tasks.foreach(base.snapshots()).noRetry().suppressFailureWhenFinished()
+        .onFailure((snapshot, exc) -> LOG.warn("Failed on snapshot {} while reading manifest list: {}",
+            snapshot.snapshotId(), snapshot.manifestListLocation(), exc))
+        .run(
+            snapshot -> {
+              long snapshotId = snapshot.snapshotId();
+              if (!validIds.contains(snapshotId)) {
+                // determine whether the changes in this snapshot are in the current table state
+                if (pickedAncestorSnapshotIds.contains(snapshotId)) {
+                  // this snapshot was cherry-picked into the current table state, so skip cleaning it up.
+                  // its changes will expire when the picked snapshot expires.
+                  // A -- C -- D (source=B)
+                  //  `- B <-- this commit
+                  return;
+                }
 
-        long sourceSnapshotId = PropertyUtil.propertyAsLong(
-            snapshot.summary(), SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, -1);
-        if (ancestorIds.contains(sourceSnapshotId)) {
-          // this commit was cherry-picked from a commit that is in the current table state. do not clean up its
-          // changes because it would revert data file additions that are in the current table.
-          // A -- B -- C
-          //  `- D (source=B) <-- this commit
-          continue;
-        }
+                long sourceSnapshotId = PropertyUtil.propertyAsLong(
+                    snapshot.summary(), SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, -1);
+                if (ancestorIds.contains(sourceSnapshotId)) {
+                  // this commit was cherry-picked from a commit that is in the current table state. do not clean up its
+                  // changes because it would revert data file additions that are in the current table.
+                  // A -- B -- C
+                  //  `- D (source=B) <-- this commit
+                  return;
+                }
 
-        if (pickedAncestorSnapshotIds.contains(sourceSnapshotId)) {
-          // this commit was cherry-picked from a commit that is in the current table state. do not clean up its
-          // changes because it would revert data file additions that are in the current table.
-          // A -- C -- E (source=B)
-          //  `- B `- D (source=B) <-- this commit
-          continue;
-        }
+                if (pickedAncestorSnapshotIds.contains(sourceSnapshotId)) {
+                  // this commit was cherry-picked from a commit that is in the current table state. do not clean up its
+                  // changes because it would revert data file additions that are in the current table.
+                  // A -- C -- E (source=B)
+                  //  `- B `- D (source=B) <-- this commit
+                  return;
+                }
 
-        // find any manifests that are no longer needed
-        try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
-          for (ManifestFile manifest : manifests) {
-            if (!validManifests.contains(manifest.path())) {
-              manifestsToDelete.add(manifest.path());
+                // find any manifests that are no longer needed
+                try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
+                  for (ManifestFile manifest : manifests) {
+                    if (!validManifests.contains(manifest.path())) {
+                      manifestsToDelete.add(manifest.path());
 
-              boolean isFromAncestor = ancestorIds.contains(manifest.snapshotId());
-              boolean isFromExpiringSnapshot = expiredIds.contains(manifest.snapshotId());
+                      boolean isFromAncestor = ancestorIds.contains(manifest.snapshotId());
+                      boolean isFromExpiringSnapshot = expiredIds.contains(manifest.snapshotId());
 
-              if (isFromAncestor && manifest.hasDeletedFiles()) {
-                // Only delete data files that were deleted in by an expired snapshot if that
-                // snapshot is an ancestor of the current table state. Otherwise, a snapshot that
-                // deleted files and was rolled back will delete files that could be in the current
-                // table state.
-                manifestsToScan.add(manifest.copy());
+                      if (isFromAncestor && manifest.hasDeletedFiles()) {
+                        // Only delete data files that were deleted in by an expired snapshot if that
+                        // snapshot is an ancestor of the current table state. Otherwise, a snapshot that
+                        // deleted files and was rolled back will delete files that could be in the current
+                        // table state.
+                        manifestsToScan.add(manifest.copy());
+                      }
+
+                      if (!isFromAncestor && isFromExpiringSnapshot && manifest.hasAddedFiles()) {
+                        // Because the manifest was written by a snapshot that is not an ancestor of the
+                        // current table state, the files added in this manifest can be removed. The extra
+                        // check whether the manifest was written by a known snapshot that was expired in
+                        // this commit ensures that the full ancestor list between when the snapshot was
+                        // written and this expiration is known and there is no missing history. If history
+                        // were missing, then the snapshot could be an ancestor of the table state but the
+                        // ancestor ID set would not contain it and this would be unsafe.
+                        manifestsToRevert.add(manifest.copy());
+                      }
+                    }
+                  }
+                } catch (IOException e) {
+                  throw new RuntimeIOException(e,
+                      "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                }
+
+                // add the manifest list to the delete set, if present
+                if (snapshot.manifestListLocation() != null) {
+                  manifestListsToDelete.add(snapshot.manifestListLocation());
+                }
               }
-
-              if (!isFromAncestor && isFromExpiringSnapshot && manifest.hasAddedFiles()) {
-                // Because the manifest was written by a snapshot that is not an ancestor of the
-                // current table state, the files added in this manifest can be removed. The extra
-                // check whether the manifest was written by a known snapshot that was expired in
-                // this commit ensures that the full ancestor list between when the snapshot was
-                // written and this expiration is known and there is no missing history. If history
-                // were missing, then the snapshot could be an ancestor of the table state but the
-                // ancestor ID set would not contain it and this would be unsafe.
-                manifestsToRevert.add(manifest.copy());
-              }
-            }
-          }
-        } catch (IOException e) {
-          throw new RuntimeIOException(e,
-              "Failed to close manifest list: %s", snapshot.manifestListLocation());
-        }
-
-        // add the manifest list to the delete set, if present
-        if (snapshot.manifestListLocation() != null) {
-          manifestListsToDelete.add(snapshot.manifestListLocation());
-        }
-      }
-    }
-
+            });
     deleteDataFiles(manifestsToScan, manifestsToRevert, validIds);
     deleteMetadataFiles(manifestsToDelete, manifestListsToDelete);
   }
 
   private void deleteMetadataFiles(Set<String> manifestsToDelete, Set<String> manifestListsToDelete) {
     LOG.warn("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
+    LOG.warn("Manifests Lists to delete: {}", Joiner.on(", ").join(manifestListsToDelete));
 
     Tasks.foreach(manifestsToDelete)
         .noRetry().suppressFailureWhenFinished()

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -201,9 +201,10 @@ class RemoveSnapshots implements ExpireSnapshots {
     // find manifests to clean up that are still referenced by a valid snapshot, but written by an expired snapshot
     Set<String> validManifests = Sets.newHashSet();
     Set<ManifestFile> manifestsToScan = Sets.newHashSet();
-    Tasks.foreach(snapshots).noRetry().suppressFailureWhenFinished()
-        .onFailure((snapshot, exc) -> LOG.warn("Failed on snapshot {} while reading manifest list: {}",
-            snapshot.snapshotId(), snapshot.manifestListLocation(), exc))
+    Tasks.foreach(snapshots).retry(3).suppressFailureWhenFinished()
+        .onFailure((snapshot, exc) ->
+            LOG.warn("Failed on snapshot {} while reading manifest list: {}", snapshot.snapshotId(),
+                snapshot.manifestListLocation(), exc))
         .run(
             snapshot -> {
               try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
@@ -235,9 +236,10 @@ class RemoveSnapshots implements ExpireSnapshots {
     Set<String> manifestListsToDelete = Sets.newHashSet();
     Set<String> manifestsToDelete = Sets.newHashSet();
     Set<ManifestFile> manifestsToRevert = Sets.newHashSet();
-    Tasks.foreach(base.snapshots()).noRetry().suppressFailureWhenFinished()
-        .onFailure((snapshot, exc) -> LOG.warn("Failed on snapshot {} while reading manifest list: {}",
-            snapshot.snapshotId(), snapshot.manifestListLocation(), exc))
+    Tasks.foreach(base.snapshots()).retry(3).suppressFailureWhenFinished()
+        .onFailure((snapshot, exc) ->
+            LOG.warn("Failed on snapshot {} while reading manifest list: {}", snapshot.snapshotId(),
+                snapshot.manifestListLocation(), exc))
         .run(
             snapshot -> {
               long snapshotId = snapshot.snapshotId();


### PR DESCRIPTION
https://github.com/apache/incubator-iceberg/issues/822 reported a gap in failure handling during `Snapshot` expiry cleanup. If any snapshot's manifest-list file is unreadable/has temporary io issues none of the  snapshots from then would be cleaned up. This adds `Tasks` based handling where even if one of them fails the rest are still tried.

**More context**: the try-with-resource block doesn't handle it coz `AvroIterable` throws a `RuntimeIOException` which bypasses any `IOException` handling up the trace. `Tasks`handles this and lets other snapshots have a chance of cleanup.  

cc @mehtaashish23 