### PR TITLE
Fix the size in GenericDataFile

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -377,7 +377,7 @@ class GenericDataFile
 
   @Override
   public int size() {
-    return 15;
+    return 13;
   }
 
   @Override


### PR DESCRIPTION
Fixes the size after removing `file_ordinal` and `sort_columns` in #914 