### PR TITLE
Spark: limit the listing depth in RemoveOrphanFilesAction

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
@@ -280,7 +280,7 @@ public class RemoveOrphanFilesAction implements Action<List<String>> {
       });
 
       if (!subDirs.isEmpty()) {
-        throw new RuntimeException("Could not list dirs: " + subDirs);
+        throw new RuntimeException("Could not list subdirectories, reached maximum subdirectory depth: " + maxDepth);
       }
 
       return files.iterator();

--- a/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
@@ -272,12 +272,16 @@ public class RemoveOrphanFilesAction implements Action<List<String>> {
 
       Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
 
-      int maxDepth = Integer.MAX_VALUE;
+      int maxDepth = 2000;
       int maxDirectSubDirs = Integer.MAX_VALUE;
 
       dirs.forEachRemaining(dir -> {
         listDirRecursively(dir, predicate, conf.value().value(), maxDepth, maxDirectSubDirs, subDirs, files);
       });
+
+      if (!subDirs.isEmpty()) {
+        throw new RuntimeException("Could not list dirs: " + subDirs);
+      }
 
       return files.iterator();
     };


### PR DESCRIPTION
This PR limits the max depth of listing in `RemoveOrphanFilesAction`.