### PR TITLE
Spark: Implement an adapter to wrap Row into DataFile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,7 @@ project(':iceberg-spark') {
     compile project(':iceberg-api')
     compile project(':iceberg-common')
     compile project(':iceberg-core')
+    compile project(':iceberg-data')
     compile project(':iceberg-orc')
     compile project(':iceberg-parquet')
     compile project(':iceberg-arrow')
@@ -317,7 +318,6 @@ project(':iceberg-spark') {
       exclude group: 'org.apache.avro', module: 'avro'
     }
 
-    testCompile project(':iceberg-data')
     testCompile "org.apache.hadoop:hadoop-hdfs::tests"
     testCompile "org.apache.hadoop:hadoop-common::tests"
     testCompile("org.apache.hadoop:hadoop-minicluster") {

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -29,41 +29,41 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
 
 public class SparkDataFile implements DataFile {
 
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
-  private final int fieldShift;
   private final SparkStructLike wrappedPartition;
+  private final int[] fieldPositions;
   private Row wrapped;
 
-  public SparkDataFile(Types.StructType type) {
+  public SparkDataFile(Types.StructType type, StructType sparkType) {
     this.lowerBoundsType = type.fieldType("lower_bounds");
     this.upperBoundsType = type.fieldType("upper_bounds");
     this.keyMetadataType = type.fieldType("key_metadata");
     this.wrappedPartition = new SparkStructLike(type.fieldType("partition").asStructType());
-    // the partition field is absent for unpartitioned tables
-    this.fieldShift = wrappedPartition.size() != 0 ? 1 : 0;
+    this.fieldPositions = indexFields(type, sparkType);
   }
 
   public SparkDataFile wrap(Row row) {
     this.wrapped = row;
     if (wrappedPartition.size() > 0) {
-      this.wrappedPartition.wrap(row.getAs(2));
+      this.wrappedPartition.wrap(row.getAs(fieldPositions[2]));
     }
     return this;
   }
 
   @Override
   public CharSequence path() {
-    return wrapped.getAs(0);
+    return wrapped.getAs(fieldPositions[0]);
   }
 
   @Override
   public FileFormat format() {
-    String formatAsString = wrapped.getString(1).toUpperCase(Locale.ROOT);
+    String formatAsString = wrapped.getString(fieldPositions[1]).toUpperCase(Locale.ROOT);
     return FileFormat.valueOf(formatAsString);
   }
 
@@ -74,42 +74,42 @@ public class SparkDataFile implements DataFile {
 
   @Override
   public long recordCount() {
-    return wrapped.getAs(fieldShift + 2);
+    return wrapped.getAs(fieldPositions[3]);
   }
 
   @Override
   public long fileSizeInBytes() {
-    return wrapped.getAs(fieldShift + 3);
+    return wrapped.getAs(fieldPositions[4]);
   }
 
   @Override
   public Map<Integer, Long> columnSizes() {
-    return wrapped.getJavaMap(fieldShift + 5);
+    return wrapped.getJavaMap(fieldPositions[6]);
   }
 
   @Override
   public Map<Integer, Long> valueCounts() {
-    return wrapped.getJavaMap(fieldShift + 6);
+    return wrapped.getJavaMap(fieldPositions[7]);
   }
 
   @Override
   public Map<Integer, Long> nullValueCounts() {
-    return wrapped.getJavaMap(fieldShift + 7);
+    return wrapped.getJavaMap(fieldPositions[8]);
   }
 
   @Override
   public Map<Integer, ByteBuffer> lowerBounds() {
-    return convert(lowerBoundsType, wrapped.getJavaMap(fieldShift + 8));
+    return convert(lowerBoundsType, wrapped.getJavaMap(fieldPositions[9]));
   }
 
   @Override
   public Map<Integer, ByteBuffer> upperBounds() {
-    return convert(upperBoundsType, wrapped.getJavaMap(fieldShift + 9));
+    return convert(upperBoundsType, wrapped.getJavaMap(fieldPositions[10]));
   }
 
   @Override
   public ByteBuffer keyMetadata() {
-    return convert(keyMetadataType, wrapped.get(fieldShift + 10));
+    return convert(keyMetadataType, wrapped.get(fieldPositions[11]));
   }
 
   @Override
@@ -124,7 +124,29 @@ public class SparkDataFile implements DataFile {
 
   @Override
   public List<Long> splitOffsets() {
-    return wrapped.getList(fieldShift + 11);
+    return wrapped.getList(fieldPositions[12]);
+  }
+
+  private int[] indexFields(Types.StructType type, StructType sparkType) {
+    List<Types.NestedField> fields = type.fields();
+    int[] positions = new int[fields.size()];
+    for (int index = 0; index < fields.size(); index++) {
+      Types.NestedField field = fields.get(index);
+      positions[index] = fieldPosition(field.name(), sparkType);
+    }
+    return positions;
+  }
+
+  private int fieldPosition(String name, StructType sparkType) {
+    try {
+      return sparkType.fieldIndex(name);
+    } catch (IllegalArgumentException e) {
+      // the partition field is absent for unpartitioned tables
+      if (name.equals("partition") && wrappedPartition.size() == 0) {
+        return -1;
+      }
+      throw e;
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Row;
+
+public class SparkDataFile implements DataFile {
+
+  private final Type lowerBoundsType;
+  private final Type upperBoundsType;
+  private final Type keyMetadataType;
+  private final int fieldShift;
+  private final SparkStructLike wrappedPartition;
+  private Row wrapped;
+
+  public SparkDataFile(Types.StructType type) {
+    this.lowerBoundsType = type.fieldType("lower_bounds");
+    this.upperBoundsType = type.fieldType("upper_bounds");
+    this.keyMetadataType = type.fieldType("key_metadata");
+    this.wrappedPartition = new SparkStructLike(type.fieldType("partition").asStructType());
+    // the partition field is absent for unpartitioned tables
+    this.fieldShift = wrappedPartition.size() != 0 ? 1 : 0;
+  }
+
+  public SparkDataFile wrap(Row row) {
+    this.wrapped = row;
+    if (wrappedPartition.size() > 0) {
+      this.wrappedPartition.wrap(row.getAs(2));
+    }
+    return this;
+  }
+
+  @Override
+  public CharSequence path() {
+    return wrapped.getAs(0);
+  }
+
+  @Override
+  public FileFormat format() {
+    String formatAsString = wrapped.getString(1).toUpperCase(Locale.ROOT);
+    return FileFormat.valueOf(formatAsString);
+  }
+
+  @Override
+  public StructLike partition() {
+    return wrappedPartition;
+  }
+
+  @Override
+  public long recordCount() {
+    return wrapped.getAs(fieldShift + 2);
+  }
+
+  @Override
+  public long fileSizeInBytes() {
+    return wrapped.getAs(fieldShift + 3);
+  }
+
+  @Override
+  public Map<Integer, Long> columnSizes() {
+    return wrapped.getJavaMap(fieldShift + 5);
+  }
+
+  @Override
+  public Map<Integer, Long> valueCounts() {
+    return wrapped.getJavaMap(fieldShift + 6);
+  }
+
+  @Override
+  public Map<Integer, Long> nullValueCounts() {
+    return wrapped.getJavaMap(fieldShift + 7);
+  }
+
+  @Override
+  public Map<Integer, ByteBuffer> lowerBounds() {
+    return convert(lowerBoundsType, wrapped.getJavaMap(fieldShift + 8));
+  }
+
+  @Override
+  public Map<Integer, ByteBuffer> upperBounds() {
+    return convert(upperBoundsType, wrapped.getJavaMap(fieldShift + 9));
+  }
+
+  @Override
+  public ByteBuffer keyMetadata() {
+    return convert(keyMetadataType, wrapped.get(fieldShift + 10));
+  }
+
+  @Override
+  public DataFile copy() {
+    throw new UnsupportedOperationException("Not implemented: copy");
+  }
+
+  @Override
+  public DataFile copyWithoutStats() {
+    throw new UnsupportedOperationException("Not implemented: copyWithoutStats");
+  }
+
+  @Override
+  public List<Long> splitOffsets() {
+    return wrapped.getList(fieldShift + 11);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T convert(Type valueType, Object value) {
+    return (T) SparkValueConverter.convert(valueType, value);
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkStructLike.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkStructLike.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Row;
+
+public class SparkStructLike implements StructLike {
+
+  private final Types.StructType type;
+  private Row wrapped;
+
+  public SparkStructLike(Types.StructType type) {
+    this.type = type;
+  }
+
+  public SparkStructLike wrap(Row row) {
+    this.wrapped = row;
+    return this;
+  }
+
+  @Override
+  public int size() {
+    return type.fields().size();
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    Types.NestedField field = type.fields().get(pos);
+    return javaClass.cast(SparkValueConverter.convert(field.type(), wrapped.get(pos)));
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    throw new UnsupportedOperationException("Not implemented: set");
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+
+public class SparkValueConverter {
+
+  private SparkValueConverter() {}
+
+  public static Record convert(Schema schema, Row row) {
+    return convert(schema.asStruct(), row);
+  }
+
+  public static Object convert(Type type, Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    switch (type.typeId()) {
+      case STRUCT:
+        return convert(type.asStructType(), (Row) object);
+
+      case LIST:
+        List<Object> convertedList = Lists.newArrayList();
+        List<?> list = (List<?>) object;
+        for (Object element : list) {
+          convertedList.add(convert(type.asListType().elementType(), element));
+        }
+        return convertedList;
+
+      case MAP:
+        Map<Object, Object> convertedMap = Maps.newLinkedHashMap();
+        Map<?, ?> map = (Map<?, ?>) object;
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+          convertedMap.put(
+              convert(type.asMapType().keyType(), entry.getKey()),
+              convert(type.asMapType().valueType(), entry.getValue()));
+        }
+        return convertedMap;
+
+      case DATE:
+        return DateTimeUtils.fromJavaDate((Date) object);
+      case TIMESTAMP:
+        return DateTimeUtils.fromJavaTimestamp((Timestamp) object);
+      case BINARY:
+        return ByteBuffer.wrap((byte[]) object);
+      case BOOLEAN:
+      case INTEGER:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case DECIMAL:
+      case STRING:
+      case FIXED:
+        return object;
+      default:
+        throw new UnsupportedOperationException("Not a supported type: " + type);
+    }
+  }
+
+  private static Record convert(Types.StructType struct, Row row) {
+    Record record = GenericRecord.create(struct);
+    List<Types.NestedField> fields = struct.fields();
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+
+      Type fieldType = field.type();
+
+      switch (fieldType.typeId()) {
+        case STRUCT:
+          record.set(i, convert(fieldType.asStructType(), row.getStruct(i)));
+          break;
+        case LIST:
+          record.set(i, convert(fieldType.asListType(), row.getList(i)));
+          break;
+        case MAP:
+          record.set(i, convert(fieldType.asMapType(), row.getJavaMap(i)));
+          break;
+        default:
+          record.set(i, convert(fieldType, row.get(i)));
+      }
+    }
+    return record;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -35,7 +35,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 
 /**
- * A utility class that converts Spark {@link Row rows} to Iceberg's internal representation.
+ * A utility class that converts Spark values to Iceberg's internal representation.
  */
 public class SparkValueConverter {
 

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -34,6 +34,9 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 
+/**
+ * A utility class that converts Spark {@link Row rows} to Iceberg's internal representation.
+ */
 public class SparkValueConverter {
 
   private SparkValueConverter() {}

--- a/spark/src/test/java/org/apache/iceberg/spark/TestSparkDataFile.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/TestSparkDataFile.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestSparkDataFile {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  private static final Schema SCHEMA = new Schema(
+      required(100, "id", Types.LongType.get()),
+      optional(101, "data", Types.StringType.get()),
+      required(102, "b", Types.BooleanType.get()),
+      optional(103, "i", Types.IntegerType.get()),
+      required(104, "l", Types.LongType.get()),
+      optional(105, "f", Types.FloatType.get()),
+      required(106, "d", Types.DoubleType.get()),
+      optional(107, "date", Types.DateType.get()),
+      required(108, "ts", Types.TimestampType.withZone()),
+      required(110, "s", Types.StringType.get()),
+      optional(113, "bytes", Types.BinaryType.get()),
+      required(114, "dec_9_0", Types.DecimalType.of(9, 0)),
+      required(115, "dec_11_2", Types.DecimalType.of(11, 2)),
+      required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
+  );
+  private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA)
+      .identity("b")
+      .bucket("i", 2)
+      .identity("l")
+      .identity("f")
+      .identity("d")
+      .identity("date")
+      .hour("ts")
+      .identity("ts")
+      .truncate("s", 2)
+      .identity("bytes")
+      .bucket("dec_9_0", 2)
+      .bucket("dec_11_2", 2)
+      .bucket("dec_38_10", 2)
+      .build();
+
+  private static SparkSession spark;
+  private static JavaSparkContext sparkContext = null;
+
+  @BeforeClass
+  public static void startSpark() {
+    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
+    TestSparkDataFile.sparkContext = new JavaSparkContext(spark.sparkContext());
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestSparkDataFile.spark;
+    TestSparkDataFile.spark = null;
+    TestSparkDataFile.sparkContext = null;
+    currentSpark.stop();
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private String tableLocation = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    File tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @Test
+  public void testValueConversion() throws IOException {
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
+    checkSparkDataFile(table);
+  }
+
+  @Test
+  public void testValueConversionPartitionedTable() throws IOException {
+    Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+    checkSparkDataFile(table);
+  }
+
+  @Test
+  public void testValueConversionWithEmptyStats() throws IOException {
+    Map<String, String> props = Maps.newHashMap();
+    props.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none");
+    Table table = TABLES.create(SCHEMA, SPEC, props, tableLocation);
+    checkSparkDataFile(table);
+  }
+
+  private void checkSparkDataFile(Table table) throws IOException {
+    Iterable<InternalRow> rows = RandomData.generateSpark(table.schema(), 200, 0);
+    JavaRDD<InternalRow> rdd = sparkContext.parallelize(Lists.newArrayList(rows));
+    Dataset<Row> df = spark.internalCreateDataFrame(JavaRDD.toRDD(rdd), SparkSchemaUtil.convert(table.schema()), false);
+
+    df.write().format("iceberg").mode("append").save(tableLocation);
+
+    table.refresh();
+
+    List<ManifestFile> manifests = table.currentSnapshot().manifests();
+    Assert.assertEquals("Should have 1 manifest", 1, manifests.size());
+
+    List<DataFile> dataFiles = Lists.newArrayList();
+    try (ManifestReader reader = ManifestFiles.read(manifests.get(0), table.io())) {
+      reader.forEach(dataFile -> dataFiles.add(dataFile.copy()));
+    }
+
+    List<Row> sparkDataFiles = spark.read().format("iceberg")
+        .load(tableLocation + "#files")
+        .collectAsList();
+
+    Assert.assertEquals("The number of files should match", dataFiles.size(), sparkDataFiles.size());
+
+    SparkDataFile wrapper = new SparkDataFile(DataFile.getType(table.spec().partitionType()));
+
+    for (int i = 0; i < dataFiles.size(); i++) {
+      checkDataFile(dataFiles.get(i), wrapper.wrap(sparkDataFiles.get(i)));
+    }
+  }
+
+  private void checkDataFile(DataFile expected, DataFile actual) {
+    Assert.assertEquals("Path must match", expected.path(), actual.path());
+    Assert.assertEquals("Format must match", expected.format(), actual.format());
+    Assert.assertEquals("Record count must match", expected.recordCount(), actual.recordCount());
+    Assert.assertEquals("Size must match", expected.fileSizeInBytes(), actual.fileSizeInBytes());
+    Assert.assertEquals("Record value counts must match", expected.valueCounts(), actual.valueCounts());
+    Assert.assertEquals("Record null value counts must match", expected.nullValueCounts(), actual.nullValueCounts());
+    Assert.assertEquals("Lower bounds must match", expected.lowerBounds(), actual.lowerBounds());
+    Assert.assertEquals("Upper bounds must match", expected.upperBounds(), actual.upperBounds());
+    Assert.assertEquals("Key metadata must match", expected.keyMetadata(), actual.keyMetadata());
+    Assert.assertEquals("Split offsets must match", expected.splitOffsets(), actual.splitOffsets());
+
+    checkStructLike(expected.partition(), actual.partition());
+  }
+
+  private void checkStructLike(StructLike expected, StructLike actual) {
+    Assert.assertEquals("Struct size should match", expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); i++) {
+      Assert.assertEquals("Struct values must match", expected.get(i, Object.class), actual.get(i, Object.class));
+    }
+  }
+}


### PR DESCRIPTION
This PR implements an adapter to wrap Spark `Row`s into `DataFile`s so that we can write Spark `Row`s to a manifest.