### PR TITLE
Refactor metadata inheritance for manifest rewrites

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -39,6 +39,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
@@ -154,13 +155,11 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
   }
 
   private ManifestFile copyManifest(ManifestFile manifest) {
-    try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), specsById)) {
-      OutputFile newFile = newManifestOutput();
-      return ManifestFiles.copyManifest(
-          ops.current().formatVersion(), reader, newFile, snapshotId(), summaryBuilder, ALLOWED_ENTRY_STATUSES);
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
-    }
+    TableMetadata current = ops.current();
+    InputFile toCopy = ops.io().newInputFile(manifest.path());
+    OutputFile newFile = newManifestOutput();
+    return ManifestFiles.copyRewriteManifest(
+        current.formatVersion(), toCopy, specsById, newFile, snapshotId(), summaryBuilder);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -20,10 +20,8 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -96,23 +94,44 @@ public class ManifestFiles {
     throw new UnsupportedOperationException("Cannot write manifest for table version: " + formatVersion);
   }
 
-  static ManifestFile copyAppendManifest(int formatVersion, ManifestReader reader, OutputFile outputFile,
-                                         long snapshotId, SnapshotSummary.Builder summaryBuilder) {
-    return copyManifest(
-        formatVersion, reader, outputFile, snapshotId, summaryBuilder, Sets.newHashSet(ManifestEntry.Status.ADDED));
+  static ManifestFile copyAppendManifest(int formatVersion,
+                                         InputFile toCopy, Map<Integer, PartitionSpec> specsById,
+                                         OutputFile outputFile, long snapshotId,
+                                         SnapshotSummary.Builder summaryBuilder) {
+    // use metadata that will add the current snapshot's ID for the rewrite
+    InheritableMetadata inheritableMetadata = InheritableMetadataFactory.forCopy(snapshotId);
+    try (ManifestReader reader = new ManifestReader(toCopy, specsById, inheritableMetadata)) {
+      return copyManifestInternal(formatVersion, reader, outputFile, snapshotId, summaryBuilder, ManifestEntry.Status.ADDED);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close manifest: %s", toCopy.location());
+    }
   }
 
-  static ManifestFile copyManifest(int formatVersion, ManifestReader reader, OutputFile outputFile, long snapshotId,
-                                   SnapshotSummary.Builder summaryBuilder,
-                                   Set<ManifestEntry.Status> allowedEntryStatuses) {
+  static ManifestFile copyRewriteManifest(int formatVersion,
+                                          InputFile toCopy, Map<Integer, PartitionSpec> specsById,
+                                          OutputFile outputFile, long snapshotId,
+                                          SnapshotSummary.Builder summaryBuilder) {
+    // for a rewritten manifest all snapshot ids should be set. use empty metadata to throw an exception if it is not
+    InheritableMetadata inheritableMetadata = InheritableMetadataFactory.empty();
+    try (ManifestReader reader = new ManifestReader(toCopy, specsById, inheritableMetadata)) {
+      return copyManifestInternal(
+          formatVersion, reader, outputFile, snapshotId, summaryBuilder, ManifestEntry.Status.EXISTING);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close manifest: %s", toCopy.location());
+    }
+  }
+
+  private static ManifestFile copyManifestInternal(int formatVersion, ManifestReader reader, OutputFile outputFile,
+                                                   long snapshotId, SnapshotSummary.Builder summaryBuilder,
+                                                   ManifestEntry.Status allowedEntryStatus) {
     ManifestWriter writer = write(formatVersion, reader.spec(), outputFile, snapshotId);
     boolean threw = true;
     try {
       for (ManifestEntry entry : reader.entries()) {
         Preconditions.checkArgument(
-            allowedEntryStatuses.contains(entry.status()),
-            "Invalid manifest entry status: %s (allowed statuses: %s)",
-            entry.status(), allowedEntryStatuses);
+            allowedEntryStatus == entry.status(),
+            "Invalid manifest entry status: %s (allowed status: %s)",
+            entry.status(), allowedEntryStatus);
         switch (entry.status()) {
           case ADDED:
             summaryBuilder.addedFile(reader.spec(), entry.file());

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -101,7 +101,8 @@ public class ManifestFiles {
     // use metadata that will add the current snapshot's ID for the rewrite
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.forCopy(snapshotId);
     try (ManifestReader reader = new ManifestReader(toCopy, specsById, inheritableMetadata)) {
-      return copyManifestInternal(formatVersion, reader, outputFile, snapshotId, summaryBuilder, ManifestEntry.Status.ADDED);
+      return copyManifestInternal(
+          formatVersion, reader, outputFile, snapshotId, summaryBuilder, ManifestEntry.Status.ADDED);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest: %s", toCopy.location());
     }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -19,31 +19,23 @@
 
 package org.apache.iceberg.spark.source;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
-import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.GenericManifestFile;
-import org.apache.iceberg.HasTableOperations;
-import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;


### PR DESCRIPTION
This refactors manifest rewrites done by `RewriteManifests`, `FastAppend`, and `MergeAppend`. Previously, the rewrite method was passed a `ManifestReader`, but now the rewrite method handles reader creation so that it can setup inherited metadata. For a rewritten manifest, the snapshot ID should always be present and not inherited because the records were already read and rewritten by the rewrite process. For an appended manifest, this adds `CopyMetadata` that sets the snapshot ID.

After this refactor, all metadata inheritance is setup in `ManifestFiles`.