### PR TITLE
Update dev/source-release.sh to add arrow, mr and spark-runtime

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -64,7 +64,7 @@ tarball=$tag.tar.gz
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
-git archive $release_hash --prefix $tag/ -o $tarball .baseline api common core data dev gradle gradlew hive orc parquet pig project runtime spark LICENSE NOTICE DISCLAIMER README.md build.gradle gradle.properties settings.gradle versions.lock versions.props version.txt
+git archive $release_hash --prefix $tag/ -o $tarball .baseline api arrow common core data dev gradle gradlew hive mr orc parquet pig project spark spark-runtime LICENSE NOTICE DISCLAIMER README.md build.gradle gradle.properties settings.gradle versions.lock versions.props version.txt
 
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig $tarball


### PR DESCRIPTION
Update dev/source-release.sh to reflect the changes recently:
- Add "arrow"
- Add "mr"
- Rename "runtime" to "spark-runtime"