### PR TITLE
Inherit snapshot id and sequence number in entries metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -25,7 +25,7 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.types.Types;
 
-class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData.SchemaConstructable {
+class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
   private final org.apache.avro.Schema schema;
   private final V1Metadata.IndexedDataFile fileWrapper;
   private Status status = Status.EXISTING;
@@ -149,6 +149,11 @@ class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData
   }
 
   @Override
+  public <T> void set(int pos, T value) {
+    put(pos, value);
+  }
+
+  @Override
   public Object get(int i) {
     switch (i) {
       case 0:
@@ -169,8 +174,18 @@ class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData
   }
 
   @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    return javaClass.cast(get(pos));
+  }
+
+  @Override
   public org.apache.avro.Schema getSchema() {
     return schema;
+  }
+
+  @Override
+  public int size() {
+    return 4;
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
@@ -80,52 +80,38 @@ public class TestEntriesMetadataTable extends TableTestBase {
   }
 
   @Test
-  public void testSplitPlanningWithSplitSizeOption() {
-    table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
-        .commit();
-
-    int splitSize = 2 * 1024; // 2 KB split size
-
-    table.updateProperties()
-        .set(TableProperties.METADATA_SPLIT_SIZE, String.valueOf(2 * splitSize))
-        .commit();
-
-    Table entriesTable = new ManifestEntriesTable(table.ops(), table);
-    Assert.assertEquals(1, entriesTable.currentSnapshot().manifests().size());
-
-    int expectedSplits =
-        ((int) entriesTable.currentSnapshot().manifests().get(0).length() + splitSize - 1) / splitSize;
-
-    TableScan scan = entriesTable.newScan()
-        .option(TableProperties.SPLIT_SIZE, String.valueOf(splitSize));
-
-    Assert.assertEquals(expectedSplits, Iterables.size(scan.planTasks()));
-  }
-
-  @Test
   public void testSplitPlanningWithMetadataSplitSizeProperty() {
     table.newAppend()
         .appendFile(FILE_A)
         .appendFile(FILE_B)
         .commit();
 
-    int splitSize = 2 * 1024; // 2 KB split size
+    table.newAppend()
+        .appendFile(FILE_C)
+        .appendFile(FILE_D)
+        .commit();
 
+    // set the split size to a large value so that both manifests are in 1 split
     table.updateProperties()
-        .set(TableProperties.METADATA_SPLIT_SIZE, String.valueOf(splitSize))
+        .set(TableProperties.METADATA_SPLIT_SIZE, String.valueOf(128 * 1024 * 1024))
         .commit();
 
     Table entriesTable = new ManifestEntriesTable(table.ops(), table);
-    Assert.assertEquals(1, entriesTable.currentSnapshot().manifests().size());
 
-    int expectedSplits =
-        ((int) entriesTable.currentSnapshot().manifests().get(0).length() + splitSize - 1) / splitSize;
+    Assert.assertEquals(1, Iterables.size(entriesTable.newScan().planTasks()));
 
-    TableScan scan = entriesTable.newScan();
+    // set the split size to a small value so that manifests end up in different splits
+    table.updateProperties()
+        .set(TableProperties.METADATA_SPLIT_SIZE, String.valueOf(1))
+        .commit();
 
-    Assert.assertEquals(expectedSplits, Iterables.size(scan.planTasks()));
+    Assert.assertEquals(2, Iterables.size(entriesTable.newScan().planTasks()));
+
+    // override the table property with a large value so that both manifests are in 1 split
+    TableScan scan = entriesTable.newScan()
+        .option(TableProperties.SPLIT_SIZE, String.valueOf(128 * 1024 * 1024));
+
+    Assert.assertEquals(1, Iterables.size(scan.planTasks()));
   }
 
   @Test


### PR DESCRIPTION
This PR migrates the entries metadata table to `DataTask` so that we can inherit snapshot ids and sequence numbers.