### PR TITLE
Merge ManifestEntry and DataFile classes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.ListType;
@@ -38,43 +37,28 @@ import static org.apache.iceberg.types.Types.NestedField.required;
  * Interface for files listed in a table manifest.
  */
 public interface DataFile {
-  Types.NestedField FILE_PATH = required(100, "file_path", StringType.get());
-  Types.NestedField FILE_FORMAT = required(101, "file_format", StringType.get());
-  Types.NestedField RECORD_COUNT = required(103, "record_count", LongType.get());
-  Types.NestedField FILE_SIZE = required(104, "file_size_in_bytes", LongType.get());
-  Types.NestedField BLOCK_SIZE = required(105, "block_size_in_bytes", LongType.get());
-  Types.NestedField COLUMN_SIZES = optional(108, "column_sizes", MapType.ofRequired(117, 118,
-      IntegerType.get(), LongType.get()));
-  Types.NestedField VALUE_COUNTS = optional(109, "value_counts", MapType.ofRequired(119, 120,
-      IntegerType.get(), LongType.get()));
-  Types.NestedField NULL_VALUE_COUNTS = optional(110, "null_value_counts", MapType.ofRequired(121, 122,
-      IntegerType.get(), LongType.get()));
-  Types.NestedField LOWER_BOUNDS = optional(125, "lower_bounds", MapType.ofRequired(126, 127,
-      IntegerType.get(), BinaryType.get()));
-  Types.NestedField UPPER_BOUNDS = optional(128, "upper_bounds", MapType.ofRequired(129, 130,
-      IntegerType.get(), BinaryType.get()));
-  Types.NestedField KEY_METADATA = optional(131, "key_metadata", BinaryType.get());
-  Types.NestedField SPLIT_OFFSETS = optional(132, "split_offsets", ListType.ofRequired(133, LongType.get()));
-  int PARTITION_ID = 102;
-  String PARTITION_NAME = "partition";
-  // NEXT ID TO ASSIGN: 134
-
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry
     return StructType.of(
-        FILE_PATH,
-        FILE_FORMAT,
-        required(PARTITION_ID, PARTITION_NAME, partitionType),
-        RECORD_COUNT,
-        FILE_SIZE,
-        BLOCK_SIZE,
-        COLUMN_SIZES,
-        VALUE_COUNTS,
-        NULL_VALUE_COUNTS,
-        LOWER_BOUNDS,
-        UPPER_BOUNDS,
-        KEY_METADATA,
-        SPLIT_OFFSETS
+        required(100, "file_path", StringType.get()),
+        required(101, "file_format", StringType.get()),
+        required(102, "partition", partitionType),
+        required(103, "record_count", LongType.get()),
+        required(104, "file_size_in_bytes", LongType.get()),
+        required(105, "block_size_in_bytes", LongType.get()),
+        optional(108, "column_sizes", MapType.ofRequired(117, 118,
+            IntegerType.get(), LongType.get())),
+        optional(109, "value_counts", MapType.ofRequired(119, 120,
+            IntegerType.get(), LongType.get())),
+        optional(110, "null_value_counts", MapType.ofRequired(121, 122,
+            IntegerType.get(), LongType.get())),
+        optional(125, "lower_bounds", MapType.ofRequired(126, 127,
+            IntegerType.get(), BinaryType.get())),
+        optional(128, "upper_bounds", MapType.ofRequired(129, 130,
+            IntegerType.get(), BinaryType.get())),
+        optional(131, "key_metadata", BinaryType.get()),
+        optional(132, "split_offsets", ListType.ofRequired(133, LongType.get()))
+        // NEXT ID TO ASSIGN: 134
     );
   }
 

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.ListType;
@@ -37,30 +38,60 @@ import static org.apache.iceberg.types.Types.NestedField.required;
  * Interface for files listed in a table manifest.
  */
 public interface DataFile {
+  Types.NestedField FILE_PATH = required(100, "file_path", StringType.get());
+  Types.NestedField FILE_FORMAT = required(101, "file_format", StringType.get());
+  Types.NestedField RECORD_COUNT = required(103, "record_count", LongType.get());
+  Types.NestedField FILE_SIZE = required(104, "file_size_in_bytes", LongType.get());
+  Types.NestedField BLOCK_SIZE = required(105, "block_size_in_bytes", LongType.get());
+  Types.NestedField COLUMN_SIZES = optional(108, "column_sizes", MapType.ofRequired(117, 118,
+      IntegerType.get(), LongType.get()));
+  Types.NestedField VALUE_COUNTS = optional(109, "value_counts", MapType.ofRequired(119, 120,
+      IntegerType.get(), LongType.get()));
+  Types.NestedField NULL_VALUE_COUNTS = optional(110, "null_value_counts", MapType.ofRequired(121, 122,
+      IntegerType.get(), LongType.get()));
+  Types.NestedField LOWER_BOUNDS = optional(125, "lower_bounds", MapType.ofRequired(126, 127,
+      IntegerType.get(), BinaryType.get()));
+  Types.NestedField UPPER_BOUNDS = optional(128, "upper_bounds", MapType.ofRequired(129, 130,
+      IntegerType.get(), BinaryType.get()));
+  Types.NestedField KEY_METADATA = optional(131, "key_metadata", BinaryType.get());
+  Types.NestedField SPLIT_OFFSETS = optional(132, "split_offsets", ListType.ofRequired(133, LongType.get()));
+  int PARTITION_ID = 102;
+  String PARTITION_NAME = "partition";
+  // NEXT ID TO ASSIGN: 134
+
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry
     return StructType.of(
-        required(100, "file_path", StringType.get()),
-        required(101, "file_format", StringType.get()),
-        required(102, "partition", partitionType),
-        required(103, "record_count", LongType.get()),
-        required(104, "file_size_in_bytes", LongType.get()),
-        required(105, "block_size_in_bytes", LongType.get()),
-        optional(108, "column_sizes", MapType.ofRequired(117, 118,
-            IntegerType.get(), LongType.get())),
-        optional(109, "value_counts", MapType.ofRequired(119, 120,
-            IntegerType.get(), LongType.get())),
-        optional(110, "null_value_counts", MapType.ofRequired(121, 122,
-            IntegerType.get(), LongType.get())),
-        optional(125, "lower_bounds", MapType.ofRequired(126, 127,
-            IntegerType.get(), BinaryType.get())),
-        optional(128, "upper_bounds", MapType.ofRequired(129, 130,
-            IntegerType.get(), BinaryType.get())),
-        optional(131, "key_metadata", BinaryType.get()),
-        optional(132, "split_offsets", ListType.ofRequired(133, LongType.get()))
-        // NEXT ID TO ASSIGN: 134
+        FILE_PATH,
+        FILE_FORMAT,
+        required(PARTITION_ID, PARTITION_NAME, partitionType),
+        RECORD_COUNT,
+        FILE_SIZE,
+        BLOCK_SIZE,
+        COLUMN_SIZES,
+        VALUE_COUNTS,
+        NULL_VALUE_COUNTS,
+        LOWER_BOUNDS,
+        UPPER_BOUNDS,
+        KEY_METADATA,
+        SPLIT_OFFSETS
     );
   }
+
+  /**
+   * @return the status of the file, whether EXISTING, ADDED, or DELETED
+   */
+  FileStatus status();
+
+  /**
+   * @return id of the snapshot in which the file was added to the table
+   */
+  Long snapshotId();
+
+  /**
+   * @return the sequence number of the snapshot in which the file was added to the table
+   */
+  Long sequenceNumber();
 
   /**
    * @return fully qualified path to the file, suitable for constructing a Hadoop Path

--- a/api/src/main/java/org/apache/iceberg/FileStatus.java
+++ b/api/src/main/java/org/apache/iceberg/FileStatus.java
@@ -19,21 +19,24 @@
 
 package org.apache.iceberg;
 
-import org.apache.avro.Schema;
+/**
+ * The status of a data or delete file in a manifest:
+ * 0 - existing (added in a different manifest)
+ * 1 - added to the table in the manifest
+ * 2 - deleted from the table in the manifest
+ */
+public enum FileStatus {
+  EXISTING(0),
+  ADDED(1),
+  DELETED(2);
 
-class GenericManifestEntry extends GenericDataFile.AsManifestEntry {
-  /**
-   * Used by Avro reflection to instantiate this class when reading manifest files.
-   *
-   * @param avroSchema an Avro read schema
-   */
-  GenericManifestEntry(Schema avroSchema) {
-    super(avroSchema);
+  private final int id;
+
+  FileStatus(int id) {
+    this.id = id;
   }
 
-  /**
-   * Constructor for Java serialization.
-   */
-  GenericManifestEntry() {
+  public int id() {
+    return id;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -40,35 +40,58 @@ public class TypeUtil {
 
   public static Schema select(Schema schema, Set<Integer> fieldIds) {
     Preconditions.checkNotNull(schema, "Schema cannot be null");
-    Preconditions.checkNotNull(fieldIds, "Field ids cannot be null");
 
-    Type result = visit(schema, new PruneColumns(fieldIds));
+    Types.StructType result = select(schema.asStruct(), fieldIds);
     if (schema.asStruct() == result) {
       return schema;
     } else if (result != null) {
       if (schema.getAliases() != null) {
-        return new Schema(result.asNestedType().fields(), schema.getAliases());
+        return new Schema(result.fields(), schema.getAliases());
       } else {
-        return new Schema(result.asNestedType().fields());
+        return new Schema(result.fields());
       }
     }
 
     return new Schema(ImmutableList.of(), schema.getAliases());
   }
 
-  public static Set<Integer> getProjectedIds(Schema schema) {
-    return visit(schema, new GetProjectedIds());
+  public static Types.StructType select(Types.StructType struct, Set<Integer> fieldIds) {
+    Preconditions.checkNotNull(struct, "Struct cannot be null");
+    Preconditions.checkNotNull(fieldIds, "Field ids cannot be null");
+
+    Type result = visit(struct, new PruneColumns(fieldIds));
+    if (struct == result) {
+      return struct;
+    } else if (result != null) {
+      return result.asStructType();
+    }
+
+    return Types.StructType.of();
   }
 
-  public static Set<Integer> getProjectedIds(Type schema) {
-    if (schema.isPrimitiveType()) {
+  public static Set<Integer> getProjectedIds(Schema schema) {
+    return ImmutableSet.copyOf(getIdsInternal(schema.asStruct()));
+  }
+
+  public static Set<Integer> getProjectedIds(Type type) {
+    if (type.isPrimitiveType()) {
       return ImmutableSet.of();
     }
-    return ImmutableSet.copyOf(visit(schema, new GetProjectedIds()));
+    return ImmutableSet.copyOf(getIdsInternal(type));
+  }
+
+  private static Set<Integer> getIdsInternal(Type type) {
+    return visit(type, new GetProjectedIds());
+  }
+
+  public static Types.StructType selectNot(Types.StructType struct, Set<Integer> fieldIds) {
+    Set<Integer> projectedIds = getIdsInternal(struct);
+    projectedIds.removeAll(fieldIds);
+    return select(struct, projectedIds);
   }
 
   public static Schema selectNot(Schema schema, Set<Integer> fieldIds) {
-    Set<Integer> projectedIds = getProjectedIds(schema);
+    Set<Integer> projectedIds = getIdsInternal(schema.asStruct());
     projectedIds.removeAll(fieldIds);
     return select(schema, projectedIds);
   }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -304,6 +304,21 @@ public class TestHelpers {
     }
 
     @Override
+    public FileStatus status() {
+      return FileStatus.ADDED;
+    }
+
+    @Override
+    public Long snapshotId() {
+      return 0L;
+    }
+
+    @Override
+    public Long sequenceNumber() {
+      return 0L;
+    }
+
+    @Override
     public CharSequence path() {
       return path;
     }

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -77,7 +77,7 @@ class GenericDataFile
   private static final long DEFAULT_BLOCK_SIZE = 64 * 1024 * 1024;
 
   /**
-   * Used by DelegatingManifestEntry instantiate this class when reading manifest files.
+   * Used by AsManifestEntry to instantiate this class when reading manifest files.
    */
   private GenericDataFile(org.apache.avro.Schema avroSchema, AsManifestEntry asEntry) {
     this.avroSchema = avroSchema;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg;
 
+import com.google.common.collect.Sets;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 
@@ -54,7 +57,12 @@ interface ManifestEntry {
   }
 
   static Schema wrapFileSchema(StructType fileType) {
-    return new Schema(STATUS, SNAPSHOT_ID, SEQUENCE_NUMBER, required(DATA_FILE_ID, "data_file", fileType));
+    // remove ManifestEntry fields from the file type when wrapping to avoid duplication
+    Set<Integer> toRemove = Sets.newHashSet(STATUS.fieldId(), SNAPSHOT_ID.fieldId(), SEQUENCE_NUMBER.fieldId());
+    StructType v1FileType = StructType.of(fileType.fields().stream()
+        .filter(field -> !toRemove.contains(field.fieldId()))
+        .collect(Collectors.toList()));
+    return new Schema(STATUS, SNAPSHOT_ID, SEQUENCE_NUMBER, required(DATA_FILE_ID, "data_file", v1FileType));
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestEntryWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntryWrapper.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+/**
+ * Wrapper used to replace ManifestEntry values when writing entries to a manifest.
+ */
+class ManifestEntryWrapper implements ManifestEntry {
+  private DataFile wrapped = null;
+  private Status status = null;
+  private Long snapshotId = null;
+  private Long sequenceNumber = null;
+
+  ManifestEntry wrapExisting(Long newSnapshotId, Long newSequenceNumber, DataFile newFile) {
+    this.status = Status.EXISTING;
+    this.snapshotId = newSnapshotId;
+    this.sequenceNumber = newSequenceNumber;
+    this.wrapped = newFile;
+    return this;
+  }
+
+  ManifestEntry wrapAppend(Long newSnapshotId, DataFile newFile) {
+    this.status = Status.ADDED;
+    this.snapshotId = newSnapshotId;
+    this.sequenceNumber = null;
+    this.wrapped = newFile;
+    return this;
+  }
+
+  ManifestEntry wrapDelete(Long newSnapshotId, Long newSequenceNumber, DataFile newFile) {
+    this.status = Status.DELETED;
+    this.snapshotId = newSnapshotId;
+    this.sequenceNumber = newSequenceNumber;
+    this.wrapped = newFile;
+    return this;
+  }
+
+  @Override
+  public Status status() {
+    return status;
+  }
+
+  @Override
+  public Long snapshotId() {
+    return snapshotId;
+  }
+
+  @Override
+  public Long sequenceNumber() {
+    return sequenceNumber;
+  }
+
+  @Override
+  public DataFile file() {
+    return wrapped;
+  }
+
+  @Override
+  public void setSnapshotId(long snapshotId) {
+    this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public void setSequenceNumber(long sequenceNumber) {
+    this.sequenceNumber = sequenceNumber;
+  }
+
+  @Override
+  public ManifestEntry copy() {
+    throw new UnsupportedOperationException("Cannot copy a ManifestEntryWrapper");
+  }
+
+  @Override
+  public ManifestEntry copyWithoutStats() {
+    throw new UnsupportedOperationException("Cannot copy a ManifestEntryWrapper");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.iceberg.avro.AvroSchemaUtil;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StructType;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -181,15 +181,34 @@ class V1Metadata {
     }
   }
 
-  static Schema entrySchema(Types.StructType partitionType) {
-    return wrapFileSchema(DataFile.getType(partitionType));
+  static Schema entrySchema(StructType partitionType) {
+    return wrapFileSchema(dataFileSchema(partitionType));
   }
 
-  static Schema wrapFileSchema(Types.StructType fileSchema) {
+  static Schema wrapFileSchema(StructType fileSchema) {
     // this is used to build projection schemas
     return new Schema(
         ManifestEntry.STATUS, ManifestEntry.SNAPSHOT_ID,
         required(ManifestEntry.DATA_FILE_ID, "data_file", fileSchema));
+  }
+
+  static StructType dataFileSchema(StructType partitionType) {
+    // IDs start at 100 to leave room for changes to ManifestEntry
+    return StructType.of(
+        DataFile.FILE_PATH,
+        DataFile.FILE_FORMAT,
+        required(DataFile.PARTITION_ID, DataFile.PARTITION_NAME, partitionType),
+        DataFile.RECORD_COUNT,
+        DataFile.FILE_SIZE,
+        DataFile.BLOCK_SIZE,
+        DataFile.COLUMN_SIZES,
+        DataFile.VALUE_COUNTS,
+        DataFile.NULL_VALUE_COUNTS,
+        DataFile.LOWER_BOUNDS,
+        DataFile.UPPER_BOUNDS,
+        DataFile.KEY_METADATA,
+        DataFile.SPLIT_OFFSETS
+    );
   }
 
   static class IndexedManifestEntry implements ManifestEntry, IndexedRecord {
@@ -197,7 +216,7 @@ class V1Metadata {
     private final IndexedDataFile fileWrapper;
     private ManifestEntry wrapped = null;
 
-    IndexedManifestEntry(Types.StructType partitionType) {
+    IndexedManifestEntry(StructType partitionType) {
       this.avroSchema = AvroSchemaUtil.convert(entrySchema(partitionType), "manifest_entry");
       this.fileWrapper = new IndexedDataFile(avroSchema.getField("data_file").schema());
     }
@@ -335,6 +354,21 @@ class V1Metadata {
     @Override
     public org.apache.avro.Schema getSchema() {
       return avroSchema;
+    }
+
+    @Override
+    public FileStatus status() {
+      return wrapped.status();
+    }
+
+    @Override
+    public Long snapshotId() {
+      return wrapped.snapshotId();
+    }
+
+    @Override
+    public Long sequenceNumber() {
+      return wrapped.sequenceNumber();
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -183,14 +183,14 @@ public class TableTestBase {
   }
 
   ManifestEntry manifestEntry(ManifestEntry.Status status, Long snapshotId, DataFile file) {
-    GenericManifestEntry entry = new GenericManifestEntry(table.spec().partitionType());
+    ManifestEntryWrapper entry = new ManifestEntryWrapper();
     switch (status) {
       case ADDED:
         return entry.wrapAppend(snapshotId, file);
       case EXISTING:
         return entry.wrapExisting(snapshotId, 0L, file);
       case DELETED:
-        return entry.wrapDelete(snapshotId, file);
+        return entry.wrapDelete(snapshotId, 0L, file);
       default:
         throw new IllegalArgumentException("Unexpected entry status: " + status);
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileStatus;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -54,6 +55,21 @@ public class SparkDataFile implements DataFile {
       this.wrappedPartition.wrap(row.getAs(fieldPositions[2]));
     }
     return this;
+  }
+
+  @Override
+  public FileStatus status() {
+    return null;
+  }
+
+  @Override
+  public Long snapshotId() {
+    return null;
+  }
+
+  @Override
+  public Long sequenceNumber() {
+    return null;
   }
 
   @Override

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -129,6 +129,12 @@ public class TestDataFileSerialization {
   }
 
   private void checkDataFile(DataFile expected, DataFile actual) {
+    Assert.assertEquals("Should match the serialized status",
+        expected.status(), actual.status());
+    Assert.assertEquals("Should match the serialized snapshot id",
+        expected.snapshotId(), actual.snapshotId());
+    Assert.assertEquals("Should match the serialized sequence number",
+        expected.sequenceNumber(), actual.sequenceNumber());
     Assert.assertEquals("Should match the serialized record path",
         expected.path(), actual.path());
     Assert.assertEquals("Should match the serialized record format",
@@ -151,7 +157,7 @@ public class TestDataFileSerialization {
         expected.keyMetadata(), actual.keyMetadata());
     Assert.assertEquals("Should match the serialized record offsets",
         expected.splitOffsets(), actual.splitOffsets());
-    Assert.assertEquals("Should match the serialized record offsets",
+    Assert.assertEquals("Should match the serialized key metadata",
         expected.keyMetadata(), actual.keyMetadata());
   }
 


### PR DESCRIPTION
This updates `DataFile` to contain metadata from `ManifestEntry` because the separation no longer makes sense. V1 metadata files still use `ManifestEntry`, but v2 will not.

`GenericManifestEntry` is split into two parts. First, a wrapper class `ManifestEntryWrapper` that is used by `ManifestWriter` to replace fields like status when writing a `DataFile` because the `DataFile` status is not set by the caller. Second, a class that makes a `DataFile` appear like a `ManifestEntry`, called `GenericDataFile.AsManifestEntry`. The `GenericManifestEntry` class now extends `AsManifestEntry` so that reads that used it don't need to be updated.