### PR TITLE
Fix GenericOrcReader OutOfBoundsException when reading ORC file with …

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -101,7 +101,7 @@ public class GenericOrcReader implements OrcValueReader<Record> {
       if (!vector.noNulls && vector.isNull[rowIndex]) {
         return null;
       } else {
-        return convertNonNullValue(vector, row);
+        return convertNonNullValue(vector, rowIndex);
       }
     }
 

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericData.java
@@ -49,53 +49,18 @@ public class TestGenericData extends DataTest {
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomGenericData.generate(schema, 100, 0L);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    writeAndValidateRecords(schema, expected);
+  }
 
-    try (FileAppender<Record> writer = ORC.write(Files.localOutput(testFile))
-        .schema(schema)
-        .createWriterFunc(GenericOrcWriter::buildWriter)
-        .build()) {
-      for (Record rec : expected) {
-        writer.add(rec);
-      }
-    }
+  @Test
+  public void writeAndValidateRepeatingRecords() throws IOException {
+    Schema structSchema = new Schema(
+        required(100, "id", Types.LongType.get()),
+        required(101, "data", Types.StringType.get())
+    );
+    List<Record> expectedRepeating = Collections.nCopies(100, RandomGenericData.generate(structSchema, 1, 0L).get(0));
 
-    List<Record> rows;
-    try (CloseableIterable<Record> reader = ORC.read(Files.localInput(testFile))
-        .project(schema)
-        .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
-        .build()) {
-      rows = Lists.newArrayList(reader);
-    }
-
-    for (int i = 0; i < expected.size(); i += 1) {
-      DataTestHelpers.assertEquals(schema.asStruct(), expected.get(i), rows.get(i));
-    }
-
-    // Also write and validate where all rows are the same (repeating)
-    List<Record> expectedRepeating = Collections.nCopies(100, expected.get(0));
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
-    try (FileAppender<Record> writer = ORC.write(Files.localOutput(testFile))
-        .schema(schema)
-        .createWriterFunc(GenericOrcWriter::buildWriter)
-        .build()) {
-      for (Record rec : expectedRepeating) {
-        writer.add(rec);
-      }
-    }
-
-    try (CloseableIterable<Record> reader = ORC.read(Files.localInput(testFile))
-        .project(schema)
-        .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
-        .build()) {
-      rows = Lists.newArrayList(reader);
-    }
-
-    for (int i = 0; i < expectedRepeating.size(); i += 1) {
-      DataTestHelpers.assertEquals(schema.asStruct(), expectedRepeating.get(i), rows.get(i));
-    }
+    writeAndValidateRecords(structSchema, expectedRepeating);
   }
 
   @Test
@@ -151,5 +116,31 @@ public class TestGenericData extends DataTest {
     Assert.assertEquals(LocalDateTime.parse("1935-01-01T00:01:00"), rows.get(2).getField("tsCol"));
     Assert.assertEquals(OffsetDateTime.parse("1935-05-17T01:10:34Z"), rows.get(3).getField("tsTzCol"));
     Assert.assertEquals(LocalDateTime.parse("1935-05-01T00:01:00"), rows.get(3).getField("tsCol"));
+  }
+
+  private void writeAndValidateRecords(Schema schema, List<Record> expected) throws IOException {
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (FileAppender<Record> writer = ORC.write(Files.localOutput(testFile))
+        .schema(schema)
+        .createWriterFunc(GenericOrcWriter::buildWriter)
+        .build()) {
+      for (Record rec : expected) {
+        writer.add(rec);
+      }
+    }
+
+    List<Record> rows;
+    try (CloseableIterable<Record> reader = ORC.read(Files.localInput(testFile))
+        .project(schema)
+        .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
+        .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      DataTestHelpers.assertEquals(schema.asStruct(), expected.get(i), rows.get(i));
+    }
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.data;
 
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -23,15 +23,19 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.junit.Assert;
+import org.junit.Test;
 
 import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestSparkOrcReader extends AvroDataTest {
   @Override
@@ -39,6 +43,22 @@ public class TestSparkOrcReader extends AvroDataTest {
     final Iterable<InternalRow> expected = RandomData
         .generateSpark(schema, 100, 0L);
 
+    writeAndValidateRecords(schema, expected);
+  }
+
+  @Test
+  public void writeAndValidateRepeatingRecords() throws IOException {
+    Schema structSchema = new Schema(
+        required(100, "id", Types.LongType.get()),
+        required(101, "data", Types.StringType.get())
+    );
+    List<InternalRow> expectedRepeating = Collections.nCopies(100,
+        RandomData.generateSpark(structSchema, 1, 0L).iterator().next());
+
+    writeAndValidateRecords(structSchema, expectedRepeating);
+  }
+
+  private void writeAndValidateRecords(Schema schema, Iterable<InternalRow> expected) throws IOException {
     final File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
 
@@ -55,30 +75,6 @@ public class TestSparkOrcReader extends AvroDataTest {
         .build()) {
       final Iterator<InternalRow> actualRows = reader.iterator();
       final Iterator<InternalRow> expectedRows = expected.iterator();
-      while (expectedRows.hasNext()) {
-        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
-        assertEquals(schema, expectedRows.next(), actualRows.next());
-      }
-      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
-    }
-
-    // Also write and validate where all rows are the same (repeating)
-    final Iterable<InternalRow> expectedRepeating = Collections.nCopies(100, expected.iterator().next());
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
-    try (FileAppender<InternalRow> writer = ORC.write(Files.localOutput(testFile))
-        .createWriterFunc(SparkOrcWriter::new)
-        .schema(schema)
-        .build()) {
-      writer.addAll(expectedRepeating);
-    }
-
-    try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(testFile))
-        .project(schema)
-        .createReaderFunc(SparkOrcReader::new)
-        .build()) {
-      final Iterator<InternalRow> actualRows = reader.iterator();
-      final Iterator<InternalRow> expectedRows = expectedRepeating.iterator();
       while (expectedRows.hasNext()) {
         Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
         assertEquals(schema, expectedRows.next(), actualRows.next());


### PR DESCRIPTION
…repeating rows

#889 introduced a typo/bug at https://github.com/apache/incubator-iceberg/commit/45a44f4cf49300db9a89e205d172146591b0bad1#diff-00f918f8e7f8149323b1c7086f77ab7dR104 where an incorrect index was being passed which fails for an ORC RowBatch with all rows repeating.