### PR TITLE
[BUG] snapshotId() does not reflect the right snapshot id of the snapshot being committed during rollback/cherrypick

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -163,7 +163,9 @@ public class SnapshotManager extends MergingSnapshotProducer<ManageSnapshots> im
         }
 
       case ROLLBACK:
+        snapshotId();
         return base.snapshot(targetSnapshotId);
+
 
       default:
         throw new ValidationException("Invalid SnapshotManagerOperation: only cherrypick, rollback are supported");


### PR DESCRIPTION
The following code highlights the bug. It is not a fix.