### PR TITLE
Support timestamp without zone in GenericParquetWriter

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/data/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -38,6 +38,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.DecimalMetadata;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -133,7 +134,9 @@ public class GenericParquetWriter {
           case TIME_MICROS:
             return new TimeWriter(desc);
           case TIMESTAMP_MICROS:
-            return new TimestamptzWriter(desc);
+            boolean withZone = ((TimestampLogicalTypeAnnotation) primitive.getLogicalTypeAnnotation())
+                .isAdjustedToUTC();
+            return withZone ? new TimestamptzWriter(desc) : new TimestampWriter(desc);
           case DECIMAL:
             DecimalMetadata decimal = primitive.getDecimalMetadata();
             switch (primitive.getPrimitiveTypeName()) {

--- a/data/src/test/java/org/apache/iceberg/data/DataTest.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataTest.java
@@ -62,6 +62,11 @@ public abstract class DataTest {
   public TemporaryFolder temp = new TemporaryFolder();
 
   @Test
+  public void testTimestampWithoutZone() throws IOException {
+    writeAndValidate(new Schema(required(0, "timestamp type without zone", Types.TimestampType.withoutZone())));
+  }
+
+  @Test
   public void testSimpleStruct() throws IOException {
     writeAndValidate(new Schema(SUPPORTED_PRIMITIVES.fields()));
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -30,14 +30,15 @@ import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 
 import static org.apache.parquet.schema.OriginalType.DATE;
 import static org.apache.parquet.schema.OriginalType.DECIMAL;
-import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MICROS;
 import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
 import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
@@ -130,7 +131,10 @@ public class TypeToMessageType {
       case TIME:
         return Types.primitive(INT64, repetition).as(TIME_MICROS).id(id).named(name);
       case TIMESTAMP:
-        return Types.primitive(INT64, repetition).as(TIMESTAMP_MICROS).id(id).named(name);
+        boolean shouldAdjustToUTC = ((TimestampType) primitive).shouldAdjustToUTC();
+        LogicalTypeAnnotation.TimeUnit timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
+        return Types.primitive(INT64, repetition).as(LogicalTypeAnnotation.timestampType(shouldAdjustToUTC, timeUnit))
+            .id(id).named(name);
       case STRING:
         return Types.primitive(BINARY, repetition).as(UTF8).id(id).named(name);
       case BINARY:


### PR DESCRIPTION
The PR is to address the following exception when trying to write a type of TimestampType.withoutZone() by GenericParquetWriter:
```
java.time.LocalDateTime cannot be cast to java.time.OffsetDateTime
java.lang.ClassCastException: java.time.LocalDateTime cannot be cast to java.time.OffsetDateTime
	at org.apache.iceberg.data.parquet.GenericParquetWriter$TimestamptzWriter.write(GenericParquetWriter.java:213)
	at org.apache.iceberg.parquet.ParquetValueWriters$StructWriter.write(ParquetValueWriters.java:445)
	at org.apache.iceberg.parquet.ParquetWriter.add(ParquetWriter.java:129)
```
The root cause is that it is hardcoded to new `TimestamptzWriter` when meeting `TIMESTAMP_MICROS`.
The exception above could be triggered by running the test case provided in the PR.