### PR TITLE
Update release script and rat excludes for 0.8.0

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -1,6 +1,8 @@
 version.txt
 versions.lock
 versions.props
+books.json
+new-books.json
 build
 .gitignore
 .rat-excludes

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -64,7 +64,7 @@ tarball=$tag.tar.gz
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
-git archive $release_hash --prefix $tag/ -o $tarball .baseline api arrow common core data dev gradle gradlew hive mr orc parquet pig project spark spark-runtime LICENSE NOTICE DISCLAIMER README.md build.gradle gradle.properties settings.gradle versions.lock versions.props version.txt
+git archive $release_hash --prefix $tag/ -o $tarball .baseline api arrow common core data dev gradle gradlew hive mr orc parquet pig project spark spark-runtime LICENSE NOTICE DISCLAIMER README.md build.gradle baseline.gradle deploy.gradle tasks.gradle jmh.gradle gradle.properties settings.gradle versions.lock versions.props version.txt
 
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig $tarball


### PR DESCRIPTION
New tests added tests data files that are JSON and cannot contain a license, so this adds the two files to RAT excludes. This also adds missing gradle build files to the tarball.