### PR TITLE
Spark: Move TestRewriteManifestsAction to actions package

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg;
+package org.apache.iceberg.actions;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -26,8 +26,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.RewriteManifestsActionResult;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;


### PR DESCRIPTION
This PR moves `TestRewriteManifestsAction` to the correct package.