### PR TITLE
Add column reordering to UpdateSchema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -325,4 +325,40 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    */
   UpdateSchema deleteColumn(String name);
 
+  /**
+   * Move a column from its current position to the start of the schema or its parent struct.
+   * @param name name of the column to move
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name doesn't identify a column in the schema or if this
+   *                                  change conflicts with other changes.
+   */
+  UpdateSchema moveFirst(String name);
+
+  /**
+   * Move a column from its current position to directly before a reference column.
+   * <p>
+   * The name is used to find the column to move using {@link Schema#findField(String)}. If the name identifies a nested
+   * column, it can only be moved within the nested struct that contains it.
+   *
+   * @param name name of the column to move
+   * @param beforeName name of the reference column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name doesn't identify a column in the schema or if this
+   *                                  change conflicts with other changes.
+   */
+  UpdateSchema moveBefore(String name, String beforeName);
+
+  /**
+   * Move a column from its current position to directly after a reference column.
+   * <p>
+   * The name is used to find the column to move using {@link Schema#findField(String)}. If the name identifies a nested
+   * column, it can only be moved within the nested struct that contains it.
+   *
+   * @param name name of the column to move
+   * @param afterName name of the reference column
+   * @return this for method chaining
+   * @throws IllegalArgumentException If name doesn't identify a column in the schema or if this
+   *                                  change conflicts with other changes.
+   */
+  UpdateSchema moveAfter(String name, String afterName);
 }

--- a/api/src/main/java/org/apache/iceberg/types/IndexParents.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexParents.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+
+public class IndexParents extends TypeUtil.SchemaVisitor<Map<Integer, Integer>> {
+  private final Map<Integer, Integer> idToParent = Maps.newHashMap();
+  private final Deque<Integer> idStack = Lists.newLinkedList();
+
+  @Override
+  public void beforeField(Types.NestedField field) {
+    idStack.push(field.fieldId());
+  }
+
+  @Override
+  public void afterField(Types.NestedField field) {
+    idStack.pop();
+  }
+
+  @Override
+  public Map<Integer, Integer> schema(Schema schema, Map<Integer, Integer> structResult) {
+    return idToParent;
+  }
+
+  @Override
+  public Map<Integer, Integer> struct(Types.StructType struct, List<Map<Integer, Integer>> fieldResults) {
+    for (Types.NestedField field : struct.fields()) {
+      Integer parentId = idStack.peek();
+      if (parentId != null) {
+        // fields in the root struct are not added
+        idToParent.put(field.fieldId(), parentId);
+      }
+    }
+    return idToParent;
+  }
+
+  @Override
+  public Map<Integer, Integer> field(Types.NestedField field, Map<Integer, Integer> fieldResult) {
+    return idToParent;
+  }
+
+  @Override
+  public Map<Integer, Integer> list(Types.ListType list, Map<Integer, Integer> element) {
+    idToParent.put(list.elementId(), idStack.peek());
+    return idToParent;
+  }
+
+  @Override
+  public Map<Integer, Integer> map(Types.MapType map, Map<Integer, Integer> key, Map<Integer, Integer> value) {
+    idToParent.put(map.keyId(), idStack.peek());
+    idToParent.put(map.valueId(), idStack.peek());
+    return idToParent;
+  }
+
+  @Override
+  public Map<Integer, Integer> primitive(Type.PrimitiveType primitive) {
+    return idToParent;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.types;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -93,6 +94,10 @@ public class TypeUtil {
 
   public static Map<Integer, Types.NestedField> indexById(Types.StructType struct) {
     return visit(struct, new IndexById());
+  }
+
+  public static Map<Integer, Integer> indexParents(Types.StructType struct) {
+    return ImmutableMap.copyOf(visit(struct, new IndexParents()));
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -586,6 +586,7 @@ class SchemaUpdate implements UpdateSchema {
     return newFields;
   }
 
+  @SuppressWarnings("checkstyle:IllegalType")
   private static List<Types.NestedField> moveFields(List<Types.NestedField> fields,
                                                     Collection<Move> moves) {
     LinkedList<Types.NestedField> reordered = Lists.newLinkedList(fields);

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -20,11 +20,13 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -47,18 +49,23 @@ class SchemaUpdate implements UpdateSchema {
   private final TableOperations ops;
   private final TableMetadata base;
   private final Schema schema;
+  private final Map<Integer, Integer> idToParent;
   private final List<Integer> deletes = Lists.newArrayList();
   private final Map<Integer, Types.NestedField> updates = Maps.newHashMap();
   private final Multimap<Integer, Types.NestedField> adds =
       Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
+  private final Map<String, Integer> addedNameToId = Maps.newHashMap();
+  private final Multimap<Integer, Move> moves = Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
   private int lastColumnId;
   private boolean allowIncompatibleChanges = false;
+
 
   SchemaUpdate(TableOperations ops) {
     this.ops = ops;
     this.base = ops.current();
     this.schema = base.schema();
     this.lastColumnId = base.lastColumnId();
+    this.idToParent = Maps.newHashMap(TypeUtil.indexParents(schema.asStruct()));
   }
 
   /**
@@ -69,6 +76,7 @@ class SchemaUpdate implements UpdateSchema {
     this.base = null;
     this.schema = schema;
     this.lastColumnId = lastColumnId;
+    this.idToParent = Maps.newHashMap(TypeUtil.indexParents(schema.asStruct()));
   }
 
   @Override
@@ -108,6 +116,7 @@ class SchemaUpdate implements UpdateSchema {
 
   private void internalAddColumn(String parent, String name, boolean isOptional, Type type, String doc) {
     int parentId = TABLE_ROOT_ID;
+    String fullName;
     if (parent != null) {
       Types.NestedField parentField = schema.findField(parent);
       Preconditions.checkArgument(parentField != null, "Cannot find parent struct: %s", parent);
@@ -130,13 +139,22 @@ class SchemaUpdate implements UpdateSchema {
           "Cannot add to a column that will be deleted: %s", parent);
       Preconditions.checkArgument(schema.findField(parent + "." + name) == null,
           "Cannot add column, name already exists: %s.%s", parent, name);
+      fullName = schema.findColumnName(parentId) + "." + name;
     } else {
       Preconditions.checkArgument(schema.findField(name) == null,
           "Cannot add column, name already exists: %s", name);
+      fullName = name;
     }
 
     // assign new IDs in order
     int newId = assignNewColumnId();
+
+    // update tracking for moves
+    addedNameToId.put(fullName, newId);
+    if (parentId != TABLE_ROOT_ID) {
+      idToParent.put(newId, parentId);
+    }
+
     adds.put(parentId, Types.NestedField.of(newId, isOptional, name,
         TypeUtil.assignFreshIds(type, this::assignNewColumnId), doc));
   }
@@ -260,6 +278,69 @@ class SchemaUpdate implements UpdateSchema {
     return this;
   }
 
+  @Override
+  public UpdateSchema moveFirst(String name) {
+    Integer fieldId = findForMove(name);
+    Preconditions.checkArgument(fieldId != null, "Cannot move missing column: %s", name);
+    internalMove(name, Move.first(fieldId));
+    return this;
+  }
+
+  @Override
+  public UpdateSchema moveBefore(String name, String beforeName) {
+    Integer fieldId = findForMove(name);
+    Preconditions.checkArgument(fieldId != null, "Cannot move missing column: %s", name);
+    Integer beforeId = findForMove(beforeName);
+    Preconditions.checkArgument(beforeId != null, "Cannot move %s before missing column: %s", name, beforeName);
+    Preconditions.checkArgument(!fieldId.equals(beforeId), "Cannot move %s before itself", name);
+    internalMove(name, Move.before(fieldId, beforeId));
+    return this;
+  }
+
+  @Override
+  public UpdateSchema moveAfter(String name, String afterName) {
+    Integer fieldId = findForMove(name);
+    Preconditions.checkArgument(fieldId != null, "Cannot move missing column: %s", name);
+    Integer afterId = findForMove(afterName);
+    Preconditions.checkArgument(afterId != null, "Cannot move %s after missing column: %s", name, afterName);
+    Preconditions.checkArgument(!fieldId.equals(afterId), "Cannot move %s after itself", name);
+    internalMove(name, Move.after(fieldId, afterId));
+    return this;
+  }
+
+  private Integer findForMove(String name) {
+    Types.NestedField field = schema.findField(name);
+    if (field != null) {
+      return field.fieldId();
+    }
+    return addedNameToId.get(name);
+  }
+
+  private void internalMove(String name, Move move) {
+    Integer parentId = idToParent.get(move.fieldId());
+    if (parentId != null) {
+      Types.NestedField parent = schema.findField(parentId);
+      Preconditions.checkArgument(parent.type().isStructType(),
+          "Cannot move fields in non-struct type: %s", parent.type());
+
+      if (move.type() == Move.MoveType.AFTER || move.type() == Move.MoveType.BEFORE) {
+        Preconditions.checkArgument(
+            parentId.equals(idToParent.get(move.referenceFieldId())),
+            "Cannot move field %s to a different struct", name);
+      }
+
+      moves.put(parentId, move);
+    } else {
+      if (move.type() == Move.MoveType.AFTER || move.type() == Move.MoveType.BEFORE) {
+        Preconditions.checkArgument(
+            idToParent.get(move.referenceFieldId()) == null,
+            "Cannot move field %s to a different struct", name);
+      }
+
+      moves.put(TABLE_ROOT_ID, move);
+    }
+  }
+
   /**
    * Apply the pending changes to the original schema and returns the result.
    * <p>
@@ -269,7 +350,7 @@ class SchemaUpdate implements UpdateSchema {
    */
   @Override
   public Schema apply() {
-    return applyChanges(schema, deletes, updates, adds);
+    return applyChanges(schema, deletes, updates, adds, moves);
   }
 
   @Override
@@ -310,9 +391,10 @@ class SchemaUpdate implements UpdateSchema {
 
   private static Schema applyChanges(Schema schema, List<Integer> deletes,
                                      Map<Integer, Types.NestedField> updates,
-                                     Multimap<Integer, Types.NestedField> adds) {
+                                     Multimap<Integer, Types.NestedField> adds,
+                                     Multimap<Integer, Move> moves) {
     Types.StructType struct = TypeUtil
-        .visit(schema, new ApplyChanges(deletes, updates, adds))
+        .visit(schema, new ApplyChanges(deletes, updates, adds, moves))
         .asNestedType().asStructType();
     return new Schema(struct.fields());
   }
@@ -321,20 +403,25 @@ class SchemaUpdate implements UpdateSchema {
     private final List<Integer> deletes;
     private final Map<Integer, Types.NestedField> updates;
     private final Multimap<Integer, Types.NestedField> adds;
+    private final Multimap<Integer, Move> moves;
 
     private ApplyChanges(List<Integer> deletes,
-                        Map<Integer, Types.NestedField> updates,
-                        Multimap<Integer, Types.NestedField> adds) {
+                         Map<Integer, Types.NestedField> updates,
+                         Multimap<Integer, Types.NestedField> adds,
+                         Multimap<Integer, Move> moves) {
       this.deletes = deletes;
       this.updates = updates;
       this.adds = adds;
+      this.moves = moves;
     }
 
     @Override
     public Type schema(Schema schema, Type structResult) {
-      Collection<Types.NestedField> newColumns = adds.get(TABLE_ROOT_ID);
-      if (newColumns != null) {
-        return addFields(structResult.asNestedType().asStructType(), newColumns);
+      List<Types.NestedField> fields = addAndMoveFields(structResult.asStructType().fields(),
+          adds.get(TABLE_ROOT_ID), moves.get(TABLE_ROOT_ID));
+
+      if (fields != null) {
+        return Types.StructType.of(fields);
       }
 
       return structResult;
@@ -399,8 +486,14 @@ class SchemaUpdate implements UpdateSchema {
 
       // handle adds
       Collection<Types.NestedField> newFields = adds.get(fieldId);
-      if (newFields != null && !newFields.isEmpty()) {
-        return addFields(fieldResult.asNestedType().asStructType(), newFields);
+      Collection<Move> columnsToMove = moves.get(fieldId);
+      if (!newFields.isEmpty() || !columnsToMove.isEmpty()) {
+        // if either collection is non-null, then this must be a struct type. try to apply the changes
+        List<Types.NestedField> fields = addAndMoveFields(
+            fieldResult.asStructType().fields(), newFields, columnsToMove);
+        if (fields != null) {
+          return Types.StructType.of(fields);
+        }
       }
 
       return fieldResult;
@@ -470,10 +563,105 @@ class SchemaUpdate implements UpdateSchema {
     }
   }
 
-  private static Types.StructType addFields(Types.StructType struct,
-                                            Collection<Types.NestedField> adds) {
-    List<Types.NestedField> newFields = Lists.newArrayList(struct.fields());
+  private static List<Types.NestedField> addAndMoveFields(List<Types.NestedField> fields,
+                                                          Collection<Types.NestedField> adds,
+                                                          Collection<Move> moves) {
+    if (adds != null && !adds.isEmpty()) {
+      if (moves != null && !moves.isEmpty()) {
+        // always apply adds first so that added fields can be moved
+        return moveFields(addFields(fields, adds), moves);
+      } else {
+        return addFields(fields, adds);
+      }
+    } else if (moves != null && !moves.isEmpty()) {
+      return moveFields(fields, moves);
+    }
+    return null;
+  }
+
+  private static List<Types.NestedField> addFields(List<Types.NestedField> fields,
+                                                   Collection<Types.NestedField> adds) {
+    List<Types.NestedField> newFields = Lists.newArrayList(fields);
     newFields.addAll(adds);
-    return Types.StructType.of(newFields);
+    return newFields;
+  }
+
+  private static List<Types.NestedField> moveFields(List<Types.NestedField> fields,
+                                                    Collection<Move> moves) {
+    LinkedList<Types.NestedField> reordered = Lists.newLinkedList(fields);
+
+    for (Move move : moves) {
+      Types.NestedField toMove = Iterables.find(reordered, field -> field.fieldId() == move.fieldId());
+      reordered.remove(toMove);
+
+      switch (move.type()) {
+        case FIRST:
+          reordered.addFirst(toMove);
+          break;
+
+        case BEFORE:
+          Types.NestedField before = Iterables.find(reordered, field -> field.fieldId() == move.referenceFieldId());
+          int beforeIndex = reordered.indexOf(before);
+          // insert the new node at the index of the existing node
+          reordered.add(beforeIndex, toMove);
+          break;
+
+        case AFTER:
+          Types.NestedField after = Iterables.find(reordered, field -> field.fieldId() == move.referenceFieldId());
+          int afterIndex = reordered.indexOf(after);
+          reordered.add(afterIndex + 1, toMove);
+          break;
+
+        default:
+          throw new UnsupportedOperationException("Unknown move type: " + move.type());
+      }
+    }
+
+    return reordered;
+  }
+
+  /**
+   * Represents a requested column move in a struct.
+   */
+  private static class Move {
+    private enum MoveType {
+      FIRST,
+      BEFORE,
+      AFTER
+    }
+
+    static Move first(int fieldId) {
+      return new Move(fieldId, -1, MoveType.FIRST);
+    }
+
+    static Move before(int fieldId, int referenceFieldId) {
+      return new Move(fieldId, referenceFieldId, MoveType.BEFORE);
+    }
+
+    static Move after(int fieldId, int referenceFieldId) {
+      return new Move(fieldId, referenceFieldId, MoveType.AFTER);
+    }
+
+    private final int fieldId;
+    private final int referenceFieldId;
+    private final MoveType type;
+
+    private Move(int fieldId, int referenceFieldId, MoveType type) {
+      this.fieldId = fieldId;
+      this.referenceFieldId = referenceFieldId;
+      this.type = type;
+    }
+
+    public int fieldId() {
+      return fieldId;
+    }
+
+    public int referenceFieldId() {
+      return referenceFieldId;
+    }
+
+    public MoveType type() {
+      return type;
+    }
   }
 }


### PR DESCRIPTION
This adds new methods to UpdateSchema to reorder columns in a table:
* `moveFirst` moves a column first in the schema or a nested struct
* `moveAfter` moves a column after a reference column
* `moveBefore` moves a column before a reference column

Columns that are added in an update can also be moved to support SQL syntax `ADD COLUMN ... AFTER ...`.

This adds new tests for the new methods.