### PR TITLE
[Python] fix partition spec in python

### DIFF
--- a/python/iceberg/api/partition_spec.py
+++ b/python/iceberg/api/partition_spec.py
@@ -231,56 +231,56 @@ class PartitionSpecBuilder(object):
         return self
 
     def year(self, source_name):
-        name = "%s_year".format(source_name)
+        name = "{}_year".format(source_name)
         self.check_and_add_partition_name(name)
         source_column = self.find_source_column(source_name)
         self.fields.append(PartitionField(source_column.field_id,
-                                          source_name,
+                                          name,
                                           Transforms.year(source_column.types)))
         return self
 
     def month(self, source_name):
-        name = "%s_month".format(source_name)
+        name = "{}_month".format(source_name)
         self.check_and_add_partition_name(name)
         source_column = self.find_source_column(source_name)
         self.fields.append(PartitionField(source_column.field_id,
-                                          source_name,
+                                          name,
                                           Transforms.month(source_column.types)))
         return self
 
     def day(self, source_name):
-        name = "%s_day".format(source_name)
+        name = "{}_day".format(source_name)
         self.check_and_add_partition_name(name)
         source_column = self.find_source_column(source_name)
         self.fields.append(PartitionField(source_column.field_id,
-                                          source_name,
+                                          name,
                                           Transforms.day(source_column.types)))
         return self
 
     def hour(self, source_name):
-        name = "%s_hour".format(source_name)
+        name = "{}_hour".format(source_name)
         self.check_and_add_partition_name(name)
         source_column = self.find_source_column(source_name)
         self.fields.append(PartitionField(source_column.field_id,
-                                          source_name,
+                                          name,
                                           Transforms.hour(source_column.type)))
         return self
 
     def bucket(self, source_name, num_buckets):
-        name = "%s_bucket".format(source_name)
+        name = "{}_bucket".format(source_name)
         self.check_and_add_partition_name(name)
         source_column = self.find_source_column(source_name)
         self.fields.append(PartitionField(source_column.field_id,
-                                          source_name,
+                                          name,
                                           Transforms.bucket(source_column.type, num_buckets)))
         return self
 
     def truncate(self, source_name, width):
-        name = "%s_truncate".format(source_name)
+        name = "{}_truncate".format(source_name)
         self.check_and_add_partition_name(name)
         source_column = self.find_source_column(source_name)
         self.fields.append(PartitionField(source_column.field_id,
-                                          source_name,
+                                          name,
                                           Transforms.truncate(source_column.types, width)))
         return self
 

--- a/python/tests/core/test_partition_spec_parser.py
+++ b/python/tests/core/test_partition_spec_parser.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from iceberg.api import PartitionSpec, Schema
+from iceberg.api.types import IntegerType, NestedField, StringType
+from iceberg.core import PartitionSpecParser
+
+
+class TestPartitionSpecParser(unittest.TestCase):
+
+    def test_to_json_conversion(self):
+        spec_schema = Schema(NestedField.required(1, "id", IntegerType.get()),
+                             NestedField.required(2, "data", StringType.get()))
+
+        spec = PartitionSpec\
+            .builder_for(spec_schema) \
+            .identity("id")\
+            .bucket("data", 16)\
+            .build()
+
+        expected = '{"spec-id": 0, "fields": [' \
+                   '{"name": "id", "transform": "identity", "source-id": 1}, ' \
+                   '{"name": "data_bucket", "transform": "bucket[16]", "source-id": 2}]}'
+        assert expected == PartitionSpecParser.to_json(spec)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/core/test_partition_spec_parser.py
+++ b/python/tests/core/test_partition_spec_parser.py
@@ -15,30 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
-
 from iceberg.api import PartitionSpec, Schema
 from iceberg.api.types import IntegerType, NestedField, StringType
 from iceberg.core import PartitionSpecParser
 
 
-class TestPartitionSpecParser(unittest.TestCase):
+def test_to_json_conversion():
+    spec_schema = Schema(NestedField.required(1, "id", IntegerType.get()),
+                         NestedField.required(2, "data", StringType.get()))
 
-    def test_to_json_conversion(self):
-        spec_schema = Schema(NestedField.required(1, "id", IntegerType.get()),
-                             NestedField.required(2, "data", StringType.get()))
+    spec = PartitionSpec\
+        .builder_for(spec_schema) \
+        .identity("id")\
+        .bucket("data", 16)\
+        .build()
 
-        spec = PartitionSpec\
-            .builder_for(spec_schema) \
-            .identity("id")\
-            .bucket("data", 16)\
-            .build()
-
-        expected = '{"spec-id": 0, "fields": [' \
-                   '{"name": "id", "transform": "identity", "source-id": 1}, ' \
-                   '{"name": "data_bucket", "transform": "bucket[16]", "source-id": 2}]}'
-        assert expected == PartitionSpecParser.to_json(spec)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    expected = '{"spec-id": 0, "fields": [' \
+               '{"name": "id", "transform": "identity", "source-id": 1}, ' \
+               '{"name": "data_bucket", "transform": "bucket[16]", "source-id": 2}]}'
+    assert expected == PartitionSpecParser.to_json(spec)


### PR DESCRIPTION
This PR fixed two issues in partition spec class
- Python use `{}` instead of `%s` in the `string.format` 
- partition field name should be the constructed name instead of original `source_name`
