### PR TITLE
Spark: Pass correct types to get data from InternalRow

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -162,7 +162,7 @@ public class AvroSchemaUtil {
     }
   }
 
-  static boolean isKeyValueSchema(Schema schema) {
+  public static boolean isKeyValueSchema(Schema schema) {
     return schema.getType() == RECORD && schema.getFields().size() == 2;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -119,7 +119,7 @@ public class AvroSchemaUtil {
     return false;
   }
 
-  static boolean isOptionSchema(Schema schema) {
+  public static boolean isOptionSchema(Schema schema) {
     if (schema.getType() == UNION && schema.getTypes().size() == 2) {
       if (schema.getTypes().get(0).getType() == Schema.Type.NULL) {
         return true;

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -48,6 +48,14 @@ public class ValueWriters {
     return BooleanWriter.INSTANCE;
   }
 
+  public static ValueWriter<Byte> tinyints() {
+    return ByteToIntegerWriter.INSTANCE;
+  }
+
+  public static ValueWriter<Short> shorts() {
+    return ShortToIntegerWriter.INSTANCE;
+  }
+
   public static ValueWriter<Integer> ints() {
     return IntegerWriter.INSTANCE;
   }
@@ -139,6 +147,30 @@ public class ValueWriters {
     @Override
     public void write(Boolean bool, Encoder encoder) throws IOException {
       encoder.writeBoolean(bool);
+    }
+  }
+
+  private static class ByteToIntegerWriter implements ValueWriter<Byte> {
+    private static final ByteToIntegerWriter INSTANCE = new ByteToIntegerWriter();
+
+    private ByteToIntegerWriter() {
+    }
+
+    @Override
+    public void write(Byte b, Encoder encoder) throws IOException {
+      encoder.writeInt(b.intValue());
+    }
+  }
+
+  private static class ShortToIntegerWriter implements ValueWriter<Short> {
+    private static final ShortToIntegerWriter INSTANCE = new ShortToIntegerWriter();
+
+    private ShortToIntegerWriter() {
+    }
+
+    @Override
+    public void write(Short s, Encoder encoder) throws IOException {
+      encoder.writeInt(s.intValue());
     }
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
+++ b/data/src/main/java/org/apache/iceberg/data/parquet/GenericParquetWriter.java
@@ -126,8 +126,9 @@ public class GenericParquetWriter {
           case INT_8:
           case INT_16:
           case INT_32:
+            return ParquetValueWriters.ints(desc);
           case INT_64:
-            return ParquetValueWriters.unboxed(desc);
+            return ParquetValueWriters.longs(desc);
           case DATE:
             return new DateWriter(desc);
           case TIME_MICROS:
@@ -162,11 +163,15 @@ public class GenericParquetWriter {
         case BINARY:
           return ParquetValueWriters.byteBuffers(desc);
         case BOOLEAN:
+          return ParquetValueWriters.booleans(desc);
         case INT32:
+          return ParquetValueWriters.ints(desc);
         case INT64:
+          return ParquetValueWriters.longs(desc);
         case FLOAT:
+          return ParquetValueWriters.floats(desc);
         case DOUBLE:
-          return ParquetValueWriters.unboxed(desc);
+          return ParquetValueWriters.doubles(desc);
         default:
           throw new UnsupportedOperationException("Unsupported type: " + primitive);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroWriter.java
@@ -118,10 +118,11 @@ public class ParquetAvroWriter {
           case INT_8:
           case INT_16:
           case INT_32:
+            return ParquetValueWriters.ints(desc);
           case INT_64:
           case TIME_MICROS:
           case TIMESTAMP_MICROS:
-            return ParquetValueWriters.unboxed(desc);
+            return ParquetValueWriters.longs(desc);
           case DECIMAL:
             DecimalMetadata decimal = primitive.getDecimalMetadata();
             switch (primitive.getPrimitiveTypeName()) {
@@ -153,11 +154,15 @@ public class ParquetAvroWriter {
         case BINARY:
           return ParquetValueWriters.byteBuffers(desc);
         case BOOLEAN:
+          return ParquetValueWriters.booleans(desc);
         case INT32:
+          return ParquetValueWriters.ints(desc);
         case INT64:
+          return ParquetValueWriters.longs(desc);
         case FLOAT:
+          return ParquetValueWriters.floats(desc);
         case DOUBLE:
-          return ParquetValueWriters.unboxed(desc);
+          return ParquetValueWriters.doubles(desc);
         default:
           throw new UnsupportedOperationException("Unsupported type: " + primitive);
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -49,7 +49,31 @@ public class ParquetValueWriters {
     return writer;
   }
 
-  public static <T> UnboxedWriter<T> unboxed(ColumnDescriptor desc) {
+  public static UnboxedWriter<Boolean> booleans(ColumnDescriptor desc) {
+    return new UnboxedWriter<>(desc);
+  }
+
+  public static UnboxedWriter<Byte> tinyints(ColumnDescriptor desc) {
+    return new ByteWriter(desc);
+  }
+
+  public static UnboxedWriter<Short> shorts(ColumnDescriptor desc) {
+    return new ShortWriter(desc);
+  }
+
+  public static UnboxedWriter<Integer> ints(ColumnDescriptor desc) {
+    return new UnboxedWriter<>(desc);
+  }
+
+  public static UnboxedWriter<Long> longs(ColumnDescriptor desc) {
+    return new UnboxedWriter<>(desc);
+  }
+
+  public static UnboxedWriter<Float> floats(ColumnDescriptor desc) {
+    return new UnboxedWriter<>(desc);
+  }
+
+  public static UnboxedWriter<Double> doubles(ColumnDescriptor desc) {
     return new UnboxedWriter<>(desc);
   }
 
@@ -135,6 +159,28 @@ public class ParquetValueWriters {
 
     public void writeDouble(int repetitionLevel, double value) {
       column.writeDouble(repetitionLevel, value);
+    }
+  }
+
+  private static class ByteWriter extends UnboxedWriter<Byte> {
+    public ByteWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, Byte value) {
+      writeInteger(repetitionLevel, value.intValue());
+    }
+  }
+
+  private static class ShortWriter extends UnboxedWriter<Short> {
+    public ShortWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, Short value) {
+      writeInteger(repetitionLevel, value.intValue());
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -163,7 +163,7 @@ public class ParquetValueWriters {
   }
 
   private static class ByteWriter extends UnboxedWriter<Byte> {
-    public ByteWriter(ColumnDescriptor desc) {
+    private ByteWriter(ColumnDescriptor desc) {
       super(desc);
     }
 
@@ -174,7 +174,7 @@ public class ParquetValueWriters {
   }
 
   private static class ShortWriter extends UnboxedWriter<Short> {
-    public ShortWriter(ColumnDescriptor desc) {
+    private ShortWriter(ColumnDescriptor desc) {
       super(desc);
     }
 

--- a/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -95,7 +95,7 @@ public class SparkParquetWritersFlatDataBenchmark {
   @Threads(1)
   public void writeUsingIcebergWriter() throws IOException {
     try (FileAppender<InternalRow> writer = Parquet.write(Files.localOutput(dataFile))
-        .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(SCHEMA, msgType))
+        .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(SCHEMA), msgType))
         .schema(SCHEMA)
         .build()) {
 

--- a/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -94,7 +94,7 @@ public class SparkParquetWritersNestedDataBenchmark {
   @Threads(1)
   public void writeUsingIcebergWriter() throws IOException {
     try (FileAppender<InternalRow> writer = Parquet.write(Files.localOutput(dataFile))
-        .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(SCHEMA, msgType))
+        .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(SCHEMA), msgType))
         .schema(SCHEMA)
         .build()) {
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/AvroWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/AvroWithSparkSchemaVisitor.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.avro.LogicalMap;
-import org.apache.iceberg.avro.ValueWriters;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;

--- a/spark/src/main/java/org/apache/iceberg/spark/data/AvroWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/AvroWithSparkSchemaVisitor.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.avro.LogicalMap;
+import org.apache.iceberg.avro.ValueWriters;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -92,6 +93,8 @@ public abstract class AvroWithSparkSchemaVisitor<T> {
 
   private static <T> T visitUnion(DataType type, Schema union, AvroWithSparkSchemaVisitor<T> visitor) {
     List<Schema> types = union.getTypes();
+    Preconditions.checkArgument(AvroSchemaUtil.isOptionSchema(union),
+        "Cannot visit non-option union: %s", union);
     List<T> options = Lists.newArrayListWithExpectedSize(types.size());
     for (Schema branch : types) {
       if (branch.getType() == Schema.Type.NULL) {

--- a/spark/src/main/java/org/apache/iceberg/spark/data/AvroWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/AvroWithSparkSchemaVisitor.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.util.Deque;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.avro.LogicalMap;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public abstract class AvroWithSparkSchemaVisitor<T> {
+  public static <T> T visit(StructType struct, Schema schema, AvroWithSparkSchemaVisitor<T> visitor) {
+    return visitRecord(struct, schema, visitor);
+  }
+
+  public static <T> T visit(DataType type, Schema schema, AvroWithSparkSchemaVisitor<T> visitor) {
+    switch (schema.getType()) {
+      case RECORD:
+        Preconditions.checkArgument(type instanceof StructType, "Invalid struct: %s is not a struct", type);
+        return visitRecord((StructType) type, schema, visitor);
+
+      case UNION:
+        return visitUnion(type, schema, visitor);
+
+      case ARRAY:
+        return visitArray(type, schema, visitor);
+
+      case MAP:
+        Preconditions.checkArgument(type instanceof MapType, "Invalid map: %s is not a map", type);
+        MapType map = (MapType) type;
+        Preconditions.checkArgument(map.keyType() instanceof StringType,
+            "Invalid map: %s is not a string", map.keyType());
+        return visitor.map(map, schema, visit(map.valueType(), schema.getValueType(), visitor));
+
+      default:
+        return visitor.primitive(type, schema);
+    }
+  }
+
+  private static <T> T visitRecord(StructType struct, Schema record, AvroWithSparkSchemaVisitor<T> visitor) {
+    // check to make sure this hasn't been visited before
+    String name = record.getFullName();
+    Preconditions.checkState(!visitor.recordLevels.contains(name),
+        "Cannot process recursive Avro record %s", name);
+    StructField[] sFields = struct.fields();
+    List<Schema.Field> fields = record.getFields();
+    Preconditions.checkArgument(sFields.length == fields.size(),
+        "Structs do not match: %s != %s", struct, record);
+
+    visitor.recordLevels.push(name);
+
+    List<String> names = Lists.newArrayListWithExpectedSize(fields.size());
+    List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
+    for (int i = 0; i < sFields.length; i += 1) {
+      StructField sField = sFields[i];
+      Schema.Field field = fields.get(i);
+      Preconditions.checkArgument(AvroSchemaUtil.makeCompatibleName(sField.name()).equals(field.name()),
+          "Structs do not match: field %s != %s", sField.name(), field.name());
+      results.add(visit(sField.dataType(), field.schema(), visitor));
+    }
+
+    visitor.recordLevels.pop();
+
+    return visitor.record(struct, record, names, results);
+  }
+
+  private static <T> T visitUnion(DataType type, Schema union, AvroWithSparkSchemaVisitor<T> visitor) {
+    List<Schema> types = union.getTypes();
+    List<T> options = Lists.newArrayListWithExpectedSize(types.size());
+    for (Schema branch : types) {
+      if (branch.getType() == Schema.Type.NULL) {
+        options.add(visit(DataTypes.NullType, branch, visitor));
+      } else {
+        options.add(visit(type, branch, visitor));
+      }
+    }
+    return visitor.union(type, union, options);
+  }
+
+  private static <T> T visitArray(DataType type, Schema array, AvroWithSparkSchemaVisitor<T> visitor) {
+    if (array.getLogicalType() instanceof LogicalMap || type instanceof MapType) {
+      Preconditions.checkState(
+          AvroSchemaUtil.isKeyValueSchema(array.getElementType()),
+          "Cannot visit invalid logical map type: %s", array);
+      Preconditions.checkArgument(type instanceof MapType, "Invalid map: %s is not a map", type);
+      MapType map = (MapType) type;
+      List<Schema.Field> keyValueFields = array.getElementType().getFields();
+      return visitor.map(map, array,
+          visit(map.keyType(), keyValueFields.get(0).schema(), visitor),
+          visit(map.valueType(), keyValueFields.get(1).schema(), visitor));
+
+    } else {
+      Preconditions.checkArgument(type instanceof ArrayType, "Invalid array: %s is not an array", type);
+      ArrayType list = (ArrayType) type;
+      return visitor.array(list, array, visit(list.elementType(), array.getElementType(), visitor));
+    }
+  }
+
+  private Deque<String> recordLevels = Lists.newLinkedList();
+
+  public T record(StructType struct, Schema record, List<String> names, List<T> fields) {
+    return null;
+  }
+
+  public T union(DataType type, Schema union, List<T> options) {
+    return null;
+  }
+
+  public T array(ArrayType sArray, Schema array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, Schema map, T key, T value) {
+    return null;
+  }
+
+  public T map(MapType sMap, Schema map, T value) {
+    return null;
+  }
+
+  public T primitive(DataType type, Schema primitive) {
+    return null;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
@@ -119,6 +119,7 @@ public class ParquetWithSparkSchemaVisitor<T> {
                   // if there are 2 fields, both key and value are projected
                   keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
                   valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                  break;
                 case 1:
                   // if there is just one, use the name to determine what it is
                   Type keyOrValue = repeatedKeyValue.getType(0);
@@ -129,6 +130,7 @@ public class ParquetWithSparkSchemaVisitor<T> {
                     valueResult = visitField(valueField, keyOrValue, visitor);
                     // key result remains null
                   }
+                  break;
                 default:
                   // both results will remain null
               }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
+
+/**
+ * Visitor for traversing a Parquet type with a companion Spark type.
+ *
+ * @param <T> the Java class returned by the visitor
+ */
+public class ParquetWithSparkSchemaVisitor<T> {
+  protected LinkedList<String> fieldNames = Lists.newLinkedList();
+
+  public static <T> T visit(DataType sType, Type type, ParquetWithSparkSchemaVisitor<T> visitor) {
+    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
+    if (type instanceof MessageType) {
+      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
+      StructType struct = (StructType) sType;
+      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
+
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(sType, type.asPrimitiveType());
+
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            Preconditions.checkArgument(!group.isRepetition(REPEATED),
+                "Invalid list: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid list: does not contain single repeated field: %s", group);
+
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            Preconditions.checkArgument(repeatedElement.isRepetition(REPEATED),
+                "Invalid list: inner group is not repeated");
+            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+                "Invalid list: repeated group is not a single field: %s", group);
+
+            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
+            ArrayType array = (ArrayType) sType;
+            StructField element = new StructField(
+                "element", array.elementType(), array.containsNull(), Metadata.empty());
+
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+              T elementResult = null;
+              if (repeatedElement.getFieldCount() > 0) {
+                elementResult = visitField(element, repeatedElement.getType(0), visitor);
+              }
+
+              return visitor.list(array, group, elementResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          case MAP:
+            Preconditions.checkArgument(!group.isRepetition(REPEATED),
+                "Invalid map: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid map: does not contain single repeated field: %s", group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            Preconditions.checkArgument(repeatedKeyValue.isRepetition(REPEATED),
+                "Invalid map: inner group is not repeated");
+            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                "Invalid map: repeated group does not have 2 fields");
+
+            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
+            MapType map = (MapType) sType;
+            StructField keyField = new StructField("key", map.keyType(), false, Metadata.empty());
+            StructField valueField = new StructField(
+                "value", map.valueType(), map.valueContainsNull(), Metadata.empty());
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+              T keyResult = null;
+              T valueResult = null;
+              switch (repeatedKeyValue.getFieldCount()) {
+                case 2:
+                  // if there are 2 fields, both key and value are projected
+                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
+                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                case 1:
+                  // if there is just one, use the name to determine what it is
+                  Type keyOrValue = repeatedKeyValue.getType(0);
+                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                    keyResult = visitField(keyField, keyOrValue, visitor);
+                    // value result remains null
+                  } else {
+                    valueResult = visitField(valueField, keyOrValue, visitor);
+                    // key result remains null
+                  }
+                default:
+                  // both results will remain null
+              }
+
+              return visitor.map(map, group, keyResult, valueResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          default:
+        }
+      }
+
+      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
+      StructType struct = (StructType) sType;
+      return visitor.struct(struct, group, visitFields(struct, group, visitor));
+    }
+  }
+
+  private static <T> T visitField(StructField sField, Type field, ParquetWithSparkSchemaVisitor<T> visitor) {
+    visitor.fieldNames.push(field.getName());
+    try {
+      return visit(sField.dataType(), field, visitor);
+    } finally {
+      visitor.fieldNames.pop();
+    }
+  }
+
+  private static <T> List<T> visitFields(StructType struct, GroupType group,
+                                         ParquetWithSparkSchemaVisitor<T> visitor) {
+    StructField[] sFields = struct.fields();
+    Preconditions.checkArgument(sFields.length == group.getFieldCount(),
+        "Structs do not match: %s and %s", struct, group);
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < sFields.length; i += 1) {
+      Type field = group.getFields().get(i);
+      StructField sField = sFields[i];
+      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+          "Structs do not match: field %s != %s", field.getName(), sField.name());
+      results.add(visitField(sField, field, visitor));
+    }
+
+    return results;
+  }
+
+  public T message(StructType sStruct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(StructType sStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(ArrayType sArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(DataType sPrimitive,
+                     PrimitiveType primitive) {
+    return null;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
@@ -192,8 +192,7 @@ public class ParquetWithSparkSchemaVisitor<T> {
     return null;
   }
 
-  public T primitive(DataType sPrimitive,
-                     PrimitiveType primitive) {
+  public T primitive(DataType sPrimitive, PrimitiveType primitive) {
     return null;
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
@@ -195,4 +195,14 @@ public class ParquetWithSparkSchemaVisitor<T> {
                      PrimitiveType primitive) {
     return null;
   }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
+import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +50,8 @@ public class StreamingWriter extends Writer implements StreamWriter {
 
   StreamingWriter(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
                   DataSourceOptions options, String queryId, OutputMode mode, String applicationId,
-                  Schema dsSchema) {
-    super(table, io, encryptionManager, options, false, applicationId, dsSchema);
+                  Schema writeSchema, StructType dsSchema) {
+    super(table, io, encryptionManager, options, false, applicationId, writeSchema, dsSchema);
     this.queryId = queryId;
     this.mode = mode;
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -102,8 +102,7 @@ class Writer implements DataSourceWriter {
   Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
          DataSourceOptions options, boolean replacePartitions, String applicationId, Schema writeSchema,
          StructType dsSchema) {
-    this(table, io, encryptionManager, options, replacePartitions, applicationId, null, writeSchema,
-        SparkSchemaUtil.convert(writeSchema));
+    this(table, io, encryptionManager, options, replacePartitions, applicationId, null, writeSchema, dsSchema);
   }
 
   Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.SparkAvroWriter;
 import org.apache.iceberg.spark.data.SparkOrcWriter;
 import org.apache.iceberg.spark.data.SparkParquetWriters;
@@ -66,6 +67,7 @@ import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,16 +96,19 @@ class Writer implements DataSourceWriter {
   private final String applicationId;
   private final String wapId;
   private final long targetFileSize;
-  private final Schema dsSchema;
+  private final Schema writeSchema;
+  private final StructType dsSchema;
 
   Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
-         DataSourceOptions options, boolean replacePartitions, String applicationId, Schema dsSchema) {
-    this(table, io, encryptionManager, options, replacePartitions, applicationId, null, dsSchema);
+         DataSourceOptions options, boolean replacePartitions, String applicationId, Schema writeSchema,
+         StructType dsSchema) {
+    this(table, io, encryptionManager, options, replacePartitions, applicationId, null, writeSchema,
+        SparkSchemaUtil.convert(writeSchema));
   }
 
   Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
          DataSourceOptions options, boolean replacePartitions, String applicationId, String wapId,
-         Schema dsSchema) {
+         Schema writeSchema, StructType dsSchema) {
     this.table = table;
     this.format = getFileFormat(table.properties(), options);
     this.io = io;
@@ -111,6 +116,7 @@ class Writer implements DataSourceWriter {
     this.replacePartitions = replacePartitions;
     this.applicationId = applicationId;
     this.wapId = wapId;
+    this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
 
     long tableTargetFileSize = PropertyUtil.propertyAsLong(
@@ -134,7 +140,7 @@ class Writer implements DataSourceWriter {
   public DataWriterFactory<InternalRow> createWriterFactory() {
     return new WriterFactory(
         table.spec(), format, table.locationProvider(), table.properties(), io, encryptionManager, targetFileSize,
-        dsSchema);
+        writeSchema, dsSchema);
   }
 
   @Override
@@ -260,12 +266,13 @@ class Writer implements DataSourceWriter {
     private final Broadcast<FileIO> io;
     private final Broadcast<EncryptionManager> encryptionManager;
     private final long targetFileSize;
-    private final Schema dsSchema;
+    private final Schema writeSchema;
+    private final StructType dsSchema;
 
     WriterFactory(PartitionSpec spec, FileFormat format, LocationProvider locations,
                   Map<String, String> properties, Broadcast<FileIO> io,
                   Broadcast<EncryptionManager> encryptionManager, long targetFileSize,
-                  Schema dsSchema) {
+                  Schema writeSchema, StructType dsSchema) {
       this.spec = spec;
       this.format = format;
       this.locations = locations;
@@ -273,6 +280,7 @@ class Writer implements DataSourceWriter {
       this.io = io;
       this.encryptionManager = encryptionManager;
       this.targetFileSize = targetFileSize;
+      this.writeSchema = writeSchema;
       this.dsSchema = dsSchema;
     }
 
@@ -284,7 +292,8 @@ class Writer implements DataSourceWriter {
       if (spec.fields().isEmpty()) {
         return new UnpartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
       } else {
-        return new PartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize, dsSchema);
+        return new PartitionedWriter(
+            spec, format, appenderFactory, fileFactory, io.value(), targetFileSize, writeSchema);
       }
     }
 
@@ -299,7 +308,7 @@ class Writer implements DataSourceWriter {
                   .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(dsSchema, msgType))
                   .setAll(properties)
                   .metricsConfig(metricsConfig)
-                  .schema(dsSchema)
+                  .schema(writeSchema)
                   .overwrite()
                   .build();
 
@@ -307,7 +316,7 @@ class Writer implements DataSourceWriter {
               return Avro.write(file)
                   .createWriterFunc(ignored -> new SparkAvroWriter(dsSchema))
                   .setAll(properties)
-                  .schema(dsSchema)
+                  .schema(writeSchema)
                   .overwrite()
                   .build();
 
@@ -315,7 +324,7 @@ class Writer implements DataSourceWriter {
               return ORC.write(file)
                   .createWriterFunc(SparkOrcWriter::new)
                   .setAll(properties)
-                  .schema(dsSchema)
+                  .schema(writeSchema)
                   .overwrite()
                   .build();
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -54,7 +54,6 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
-import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.SparkAvroWriter;
 import org.apache.iceberg.spark.data.SparkOrcWriter;
 import org.apache.iceberg.spark.data.SparkParquetWriters;

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.SparkParquetWriters;
 import org.apache.iceberg.types.Types;
@@ -164,7 +165,7 @@ public class TestDataFileSerialization {
     FileAppender<InternalRow> writer =
         Parquet.write(Files.localOutput(parquetFile))
             .schema(DATE_SCHEMA)
-            .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(DATE_SCHEMA, msgType))
+            .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(DATE_SCHEMA), msgType))
             .build();
     try {
       writer.addAll(records);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.junit.Assert;
@@ -78,7 +79,7 @@ public class TestSparkParquetWriter {
 
     try (FileAppender<InternalRow> writer = Parquet.write(Files.localOutput(testFile))
         .schema(COMPLEX_SCHEMA)
-        .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(COMPLEX_SCHEMA, msgType))
+        .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(COMPLEX_SCHEMA), msgType))
         .build()) {
       writer.addAll(records);
     }


### PR DESCRIPTION
This fixes a problem with Spark 3.0 CTAS queries that use tinyint or smallint types. When Iceberg converts a Dataset schema, it promotes both smaller integers to `int`. Normally, Spark will insert casts in the analyzer so that the values are ints, but during a CTAS query, the table is created and the values may be passed as short or byte in the rows passed to Iceberg.

The problem happens when Iceberg accesses values from `InternalRow`. Before this commit, Iceberg would use the table's type to fetch a value, causing unsafe rows to return a corrupted byte or short value because 4 bytes had been read instead of 1 or 2.

The fix is to keep track of the Dataset schema and use it when accessing fields. This required building visitors for Avro and Parquet that traverse a Spark schema with a file schema.