### PR TITLE
Refactor Parquet visitor

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -187,11 +187,7 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
   }
 
   private void addAlias(String name, int fieldId) {
-    String fullName = name;
-    if (!fieldNames.isEmpty()) {
-      fullName = DOT.join(DOT.join(fieldNames.descendingIterator()), name);
-    }
-    aliasToId.put(fullName, fieldId);
+    aliasToId.put(DOT.join(path(name)), fieldId);
   }
 
   protected int nextId() {


### PR DESCRIPTION
This refactors the Parquet visitor to support #830.

* Adds before and after calls that can be overridden to avoid adding field names
* Makes `fieldNames` private