### PR TITLE
Introduce a CloseableIterator to remove the consfusing currentCloseable in BaseDataReader

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -38,7 +38,11 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
     return new CloseableIterator<T>() {
       @Override
       public void close() throws IOException {
-        CloseableIterable.this.close();
+        // Notice that the CloseableIterable#close will close all open iterators created by Iterable.
+        // Here we only need to close the current iterator instead of all the created iterators.
+        if (iterator instanceof Closeable) {
+          ((Closeable) iterator).close();
+        }
       }
 
       @Override

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -92,13 +92,11 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
       @Override
       public CloseableIterator<O> iterator() {
         return new CloseableIterator<O>() {
-          private final Iterator<I> inner = iterable.iterator();
+          private final CloseableIterator<I> inner = iterable.iterator();
 
           @Override
           public void close() throws IOException {
-            if (inner instanceof Closeable) {
-              ((Closeable) inner).close();
-            }
+            inner.close();
           }
 
           @Override

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -53,7 +53,7 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
 
       @Override
       public CloseableIterator<E> iterator() {
-        return CloseableIterator.withNoopClose(iterable.iterator());
+        return CloseableIterator.withClose(iterable.iterator());
       }
     };
   }
@@ -206,4 +206,5 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
       }
     }
   }
+
 }

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
@@ -20,7 +20,54 @@
 package org.apache.iceberg.io;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Iterator;
 
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
+
+  static <E> CloseableIterator<E> withNoopClose(Iterator<E> iterator) {
+    if (iterator instanceof CloseableIterator) {
+      return (CloseableIterator<E>) iterator;
+    }
+    return new CloseableIterator<E>() {
+      @Override
+      public void close() throws IOException {
+        // do nothing.
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public E next() {
+        return iterator.next();
+      }
+    };
+  }
+
+  static <E> CloseableIterator<E> withClose(Iterator<E> iterator) {
+    if (iterator instanceof CloseableIterator) {
+      return (CloseableIterator<E>) iterator;
+    }
+    return new CloseableIterator<E>() {
+      @Override
+      public void close() throws IOException {
+        if (iterator instanceof Closeable) {
+          ((Closeable) iterator).close();
+        }
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public E next() {
+        return iterator.next();
+      }
+    };
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface CloseableIterator<T> extends Iterator<T>, Closeable {
+}

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
@@ -21,36 +21,20 @@ package org.apache.iceberg.io;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
 
-  static <E> CloseableIterator<E> withNoopClose(Iterator<E> iterator) {
-    if (iterator instanceof CloseableIterator) {
-      return (CloseableIterator<E>) iterator;
-    }
-    return new CloseableIterator<E>() {
-      @Override
-      public void close() throws IOException {
-        // do nothing.
-      }
-
-      @Override
-      public boolean hasNext() {
-        return iterator.hasNext();
-      }
-
-      @Override
-      public E next() {
-        return iterator.next();
-      }
-    };
+  static <E> CloseableIterator<E> empty() {
+    return withClose(Collections.emptyIterator());
   }
 
   static <E> CloseableIterator<E> withClose(Iterator<E> iterator) {
     if (iterator instanceof CloseableIterator) {
       return (CloseableIterator<E>) iterator;
     }
+
     return new CloseableIterator<E>() {
       @Override
       public void close() throws IOException {

--- a/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +38,7 @@ import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.types.Types;
 
@@ -219,11 +219,12 @@ abstract class BaseManifestReader<T, ThisT> extends CloseableGroup implements Cl
    */
   @Override
   @SuppressWarnings("unchecked")
-  public Iterator<T> iterator() {
+  public CloseableIterator<T> iterator() {
     if (dropStats(rowFilter, columns)) {
-      return (Iterator<T>) CloseableIterable.transform(liveEntries(), e -> e.file().copyWithoutStats()).iterator();
+      return (CloseableIterator<T>) CloseableIterable.transform(liveEntries(), e -> e.file().copyWithoutStats())
+          .iterator();
     } else {
-      return (Iterator<T>) CloseableIterable.transform(liveEntries(), e -> e.file().copy()).iterator();
+      return (CloseableIterator<T>) CloseableIterable.transform(liveEntries(), e -> e.file().copy()).iterator();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -73,7 +73,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
   }
 
   @Override
-  public Iterator<D> iterator() {
+  public CloseableIterator<D> iterator() {
     FileReader<D> fileReader = initMetadata(newFileReader());
 
     if (start != null) {
@@ -86,7 +86,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
       return new AvroReuseIterator<>(fileReader);
     }
 
-    return fileReader;
+    return CloseableIterator.withClose(fileReader);
   }
 
   private DataFileReader<D> newFileReader() {

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.avro;
 
 import com.google.common.collect.Maps;
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
@@ -32,6 +31,7 @@ import org.apache.avro.io.DatumReader;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 
 public class AvroIterable<D> extends CloseableGroup implements CloseableIterable<D> {
@@ -173,7 +173,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
     }
   }
 
-  private static class AvroReuseIterator<D> implements Iterator<D>, Closeable {
+  private static class AvroReuseIterator<D> implements CloseableIterator<D> {
     private final FileReader<D> reader;
     private D reused = null;
 

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 
 public class ParallelIterable<T> extends CloseableGroup implements CloseableIterable<T> {
   private final Iterable<? extends Iterable<T>> iterables;
@@ -49,7 +50,7 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
     return iter;
   }
 
-  private static class ParallelIterator<T> implements Iterator<T>, Closeable {
+  private static class ParallelIterator<T> implements CloseableIterator<T> {
     private final Iterator<Runnable> tasks;
     private final ExecutorService workerPool;
     private final Future<?>[] taskFutures;

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -44,7 +44,7 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public CloseableIterator<T> iterator() {
     ParallelIterator<T> iter = new ParallelIterator<>(iterables, workerPool);
     addCloseable(iter);
     return iter;

--- a/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
@@ -128,7 +129,7 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
     super.close(); // close data files
   }
 
-  private class ScanIterator implements Iterator<Record>, Closeable {
+  private class ScanIterator implements CloseableIterator<Record> {
     private final Iterator<FileScanTask> tasks;
     private final boolean caseSensitive;
     private Closeable currentCloseable = null;

--- a/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
@@ -72,7 +72,7 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
   }
 
   @Override
-  public Iterator<Record> iterator() {
+  public CloseableIterator<Record> iterator() {
     ScanIterator iter = new ScanIterator(tasks, caseSensitive);
     addCloseable(iter);
     return iter;

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -373,7 +373,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       } else {
         iterable = open(currentTask, expectedSchema);
       }
-      return iterable.closeableIterator();
+      return iterable.iterator();
     }
 
     private CloseableIterable<T> open(FileScanTask currentTask, Schema readSchema) {

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -361,7 +361,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       DataFile file = currentTask.file();
       // schema of rows returned by readers
       PartitionSpec spec = currentTask.spec();
-      Set<Integer> idColumns = Sets.intersection(spec.identitySourceIds(), TypeUtil.getProjectedIds(expectedSchema));
+      Set<Integer> idColumns =  Sets.intersection(spec.identitySourceIds(), TypeUtil.getProjectedIds(expectedSchema));
       boolean hasJoinedPartitionColumns = !idColumns.isEmpty();
 
       CloseableIterable<T> iterable;

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -373,6 +373,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       } else {
         iterable = open(currentTask, expectedSchema);
       }
+
       return iterable.iterator();
     }
 
@@ -395,6 +396,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
           throw new UnsupportedOperationException(
               String.format("Cannot read %s file: %s", file.format().name(), file.path()));
       }
+
       return iterable;
     }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -20,11 +20,9 @@
 package org.apache.iceberg.mr.mapreduce;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import java.io.Closeable;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -69,6 +67,7 @@ import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mr.SerializationUtil;
 import org.apache.iceberg.orc.ORC;
@@ -288,8 +287,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     private Map<String, Integer> namesToPos;
     private Iterator<FileScanTask> tasks;
     private T currentRow;
-    private Iterator<T> currentIterator;
-    private Closeable currentCloseable;
+    private CloseableIterator<T> currentIterator;
 
     @Override
     public void initialize(InputSplit split, TaskAttemptContext newContext) {
@@ -315,10 +313,10 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
           currentRow = currentIterator.next();
           return true;
         } else if (tasks.hasNext()) {
-          currentCloseable.close();
+          currentIterator.close();
           currentIterator = open(tasks.next());
         } else {
-          currentCloseable.close();
+          currentIterator.close();
           return false;
         }
       }
@@ -347,7 +345,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
 
     @Override
     public void close() throws IOException {
-      currentCloseable.close();
+      currentIterator.close();
     }
 
     private static Map<String, Integer> buildNameToPos(Schema expectedSchema) {
@@ -359,25 +357,26 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       return nameToPos;
     }
 
-    private Iterator<T> open(FileScanTask currentTask) {
+    private CloseableIterator<T> open(FileScanTask currentTask) {
       DataFile file = currentTask.file();
       // schema of rows returned by readers
       PartitionSpec spec = currentTask.spec();
-      Set<Integer> idColumns =  Sets.intersection(spec.identitySourceIds(), TypeUtil.getProjectedIds(expectedSchema));
+      Set<Integer> idColumns = Sets.intersection(spec.identitySourceIds(), TypeUtil.getProjectedIds(expectedSchema));
       boolean hasJoinedPartitionColumns = !idColumns.isEmpty();
 
+      CloseableIterable<T> iterable;
       if (hasJoinedPartitionColumns) {
         Schema readDataSchema = TypeUtil.selectNot(expectedSchema, idColumns);
         Schema identityPartitionSchema = TypeUtil.select(expectedSchema, idColumns);
-        return Iterators.transform(
-            open(currentTask, readDataSchema),
+        iterable = CloseableIterable.transform(open(currentTask, readDataSchema),
             row -> withIdentityPartitionColumns(row, identityPartitionSchema, spec, file.partition()));
       } else {
-        return open(currentTask, expectedSchema);
+        iterable = open(currentTask, expectedSchema);
       }
+      return iterable.closeableIterator();
     }
 
-    private Iterator<T> open(FileScanTask currentTask, Schema readSchema) {
+    private CloseableIterable<T> open(FileScanTask currentTask, Schema readSchema) {
       DataFile file = currentTask.file();
       // TODO we should make use of FileIO to create inputFile
       InputFile inputFile = HadoopInputFile.fromLocation(file.path(), context.getConfiguration());
@@ -396,8 +395,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
           throw new UnsupportedOperationException(
               String.format("Cannot read %s file: %s", file.format().name(), file.path()));
       }
-      currentCloseable = iterable;
-      return iterable.iterator();
+      return iterable;
     }
 
     @SuppressWarnings("unchecked")

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIterable.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIterable.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableGroup;
@@ -36,7 +35,7 @@ public class ParquetIterable<T> extends CloseableGroup implements CloseableItera
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public CloseableIterator<T> iterator() {
     try {
       ParquetReader<T> reader = builder.build();
       addCloseable(reader);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIterable.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIterable.java
@@ -19,13 +19,13 @@
 
 package org.apache.iceberg.parquet;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.parquet.hadoop.ParquetReader;
 
 public class ParquetIterable<T> extends CloseableGroup implements CloseableIterable<T> {
@@ -46,7 +46,7 @@ public class ParquetIterable<T> extends CloseableGroup implements CloseableItera
     }
   }
 
-  private static class ParquetIterator<T> implements Iterator<T>, Closeable {
+  private static class ParquetIterator<T> implements CloseableIterator<T> {
     private final ParquetReader<T> parquet;
     private boolean needsAdvance = false;
     private boolean hasNext = false;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -70,7 +69,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public CloseableIterator<T> iterator() {
     FileIterator<T> iter = new FileIterator<>(init());
     addCloseable(iter);
     return iter;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.function.Function;
@@ -29,6 +28,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.page.PageReadStore;
@@ -76,7 +76,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
     return iter;
   }
 
-  private static class FileIterator<T> implements Iterator<T>, Closeable {
+  private static class FileIterator<T> implements CloseableIterator<T> {
     private final ParquetFileReader reader;
     private final boolean[] shouldSkip;
     private final ParquetValueReader<T> model;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.parquet;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -32,6 +31,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.page.PageReadStore;
@@ -84,7 +84,7 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
     return iter;
   }
 
-  private static class FileIterator<T> implements Iterator<T>, Closeable {
+  private static class FileIterator<T> implements CloseableIterator<T> {
     private final ParquetFileReader reader;
     private final boolean[] shouldSkip;
     private final VectorizedReader<T> model;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedParquetReader.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -78,7 +77,7 @@ public class VectorizedParquetReader<T> extends CloseableGroup implements Closea
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public CloseableIterator<T> iterator() {
     FileIterator<T> iter = new FileIterator<>(init());
     addCloseable(iter);
     return iter;

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -61,7 +61,7 @@ abstract class BaseDataReader<T> implements InputPartitionReader<T> {
     ImmutableMap.Builder<String, InputFile> inputFileBuilder = ImmutableMap.builder();
     decryptedFiles.forEach(decrypted -> inputFileBuilder.put(decrypted.location(), decrypted));
     this.inputFiles = inputFileBuilder.build();
-    this.currentIterator = CloseableIterable.<T>empty().closeableIterator();
+    this.currentIterator = CloseableIterable.<T>empty().iterator();
   }
 
   @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -22,9 +22,7 @@ package org.apache.iceberg.spark.source;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.iceberg.CombinedScanTask;
@@ -32,6 +30,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.spark.rdd.InputFileBlockHolder;
@@ -42,14 +41,12 @@ import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
  *
  * @param <T> is the Java class returned by this reader whose objects contain one or more rows.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 abstract class BaseDataReader<T> implements InputPartitionReader<T> {
   private final Iterator<FileScanTask> tasks;
   private final FileIO fileIo;
   private final Map<String, InputFile> inputFiles;
 
-  private Iterator<T> currentIterator;
-  Closeable currentCloseable;
+  private CloseableIterator<T> currentIterator;
   private T current = null;
 
   BaseDataReader(CombinedScanTask task, FileIO fileIo, EncryptionManager encryptionManager) {
@@ -64,8 +61,7 @@ abstract class BaseDataReader<T> implements InputPartitionReader<T> {
     ImmutableMap.Builder<String, InputFile> inputFileBuilder = ImmutableMap.builder();
     decryptedFiles.forEach(decrypted -> inputFileBuilder.put(decrypted.location(), decrypted));
     this.inputFiles = inputFileBuilder.build();
-    this.currentCloseable = CloseableIterable.empty();
-    this.currentIterator = Collections.emptyIterator();
+    this.currentIterator = CloseableIterable.<T>empty().closeableIterator();
   }
 
   @Override
@@ -75,7 +71,7 @@ abstract class BaseDataReader<T> implements InputPartitionReader<T> {
         this.current = currentIterator.next();
         return true;
       } else if (tasks.hasNext()) {
-        this.currentCloseable.close();
+        this.currentIterator.close();
         this.currentIterator = open(tasks.next());
       } else {
         return false;
@@ -88,14 +84,14 @@ abstract class BaseDataReader<T> implements InputPartitionReader<T> {
     return current;
   }
 
-  abstract Iterator<T> open(FileScanTask task);
+  abstract CloseableIterator<T> open(FileScanTask task);
 
   @Override
   public void close() throws IOException {
     InputFileBlockHolder.unset();
 
     // close the current iterator
-    this.currentCloseable.close();
+    this.currentIterator.close();
 
     // exhaust the task iterator
     while (tasks.hasNext()) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -61,7 +60,7 @@ abstract class BaseDataReader<T> implements InputPartitionReader<T> {
     ImmutableMap.Builder<String, InputFile> inputFileBuilder = ImmutableMap.builder();
     decryptedFiles.forEach(decrypted -> inputFileBuilder.put(decrypted.location(), decrypted));
     this.inputFiles = inputFileBuilder.build();
-    this.currentIterator = CloseableIterable.<T>empty().iterator();
+    this.currentIterator = CloseableIterator.empty();
   }
 
   @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -151,6 +151,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
               "Cannot read unknown format: " + task.file().format());
       }
     }
+
     return iter;
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -102,7 +102,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     if (projectsIdentityPartitionColumns) {
       if (SUPPORTS_CONSTANTS.contains(file.format())) {
         return open(task, expectedSchema, PartitionUtil.constantsMap(task, RowDataReader::convertConstant))
-            .closeableIterator();
+            .iterator();
       }
 
       // schema used to read data files
@@ -118,11 +118,11 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       CloseableIterable<InternalRow> transformedIterable = CloseableIterable.transform(
           CloseableIterable.transform(open(task, readSchema, ImmutableMap.of()), joined::withLeft),
           APPLY_PROJECTION.bind(projection(expectedSchema, joinedSchema))::invoke);
-      return transformedIterable.closeableIterator();
+      return transformedIterable.iterator();
     }
 
     // return the base iterator
-    return open(task, expectedSchema, ImmutableMap.of()).closeableIterator();
+    return open(task, expectedSchema, ImmutableMap.of()).iterator();
   }
 
   private CloseableIterable<InternalRow> open(FileScanTask task, Schema readSchema, Map<Integer, ?> idToConstant) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -21,12 +21,10 @@ package org.apache.iceberg.spark.source;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +41,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.orc.ORC;
@@ -88,7 +87,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
   }
 
   @Override
-  Iterator<InternalRow> open(FileScanTask task) {
+  CloseableIterator<InternalRow> open(FileScanTask task) {
     DataFile file = task.file();
 
     // update the current file for Spark's filename() function
@@ -102,7 +101,8 @@ class RowDataReader extends BaseDataReader<InternalRow> {
 
     if (projectsIdentityPartitionColumns) {
       if (SUPPORTS_CONSTANTS.contains(file.format())) {
-        return open(task, expectedSchema, PartitionUtil.constantsMap(task, RowDataReader::convertConstant));
+        return open(task, expectedSchema, PartitionUtil.constantsMap(task, RowDataReader::convertConstant))
+            .closeableIterator();
       }
 
       // schema used to read data files
@@ -115,16 +115,17 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       InternalRow partition = convertToRow.apply(file.partition());
       joined.withRight(partition);
 
-      return Iterators.transform(
-          Iterators.transform(open(task, readSchema, ImmutableMap.of()), joined::withLeft),
+      CloseableIterable<InternalRow> transformedIterable = CloseableIterable.transform(
+          CloseableIterable.transform(open(task, readSchema, ImmutableMap.of()), joined::withLeft),
           APPLY_PROJECTION.bind(projection(expectedSchema, joinedSchema))::invoke);
+      return transformedIterable.closeableIterator();
     }
 
     // return the base iterator
-    return open(task, expectedSchema, ImmutableMap.of());
+    return open(task, expectedSchema, ImmutableMap.of()).closeableIterator();
   }
 
-  private Iterator<InternalRow> open(FileScanTask task, Schema readSchema, Map<Integer, ?> idToConstant) {
+  private CloseableIterable<InternalRow> open(FileScanTask task, Schema readSchema, Map<Integer, ?> idToConstant) {
     CloseableIterable<InternalRow> iter;
     if (task.isDataTask()) {
       iter = newDataIterable(task.asDataTask(), readSchema);
@@ -150,10 +151,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
               "Cannot read unknown format: " + task.file().format());
       }
     }
-
-    this.currentCloseable = iter;
-
-    return iter.iterator();
+    return iter;
   }
 
   private CloseableIterable<InternalRow> newAvroIterable(


### PR DESCRIPTION
When I read the BaseDataReader.java, I find that there's a member named currentCloseable which would be set with a value in its sub-class (RowDataReader), that confuse me a lot.  This also introduced a checkstyle waring `@SuppressWarnings("checkstyle:VisibilityModifier")`. 

I think it will be more clear if we introduce a CloseableIterator, say for each CloseableIterable we can create a CloseableIterator,  once we iterated all the element then just call the iterator#close to close the resources,  don't have to maintain two instances: one for Iterator and one for Closeable.