### PR TITLE
Support time type in GenericAvroReader and Writer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -158,6 +158,9 @@ class GenericAvroReader<T> implements DatumReader<T> {
             // Spark uses the same representation
             return ValueReaders.ints();
 
+          case "time-micros":
+            return ValueReaders.longs();
+
           case "timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroWriter.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroWriter.java
@@ -91,6 +91,9 @@ class GenericAvroWriter<T> implements DatumWriter<T> {
           case "date":
             return ValueWriters.ints();
 
+          case "time-micros":
+            return ValueWriters.longs();
+
           case "timestamp-micros":
             return ValueWriters.longs();
 

--- a/core/src/test/java/org/apache/iceberg/avro/AvroDataTest.java
+++ b/core/src/test/java/org/apache/iceberg/avro/AvroDataTest.java
@@ -55,7 +55,8 @@ public abstract class AvroDataTest {
       optional(113, "bytes", Types.BinaryType.get()),
       required(114, "dec_9_0", Types.DecimalType.of(9, 0)),
       required(115, "dec_11_2", Types.DecimalType.of(11, 2)),
-      required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
+      required(116, "dec_38_10", Types.DecimalType.of(38, 10)), // maximum precision
+      required(117, "time", Types.TimeType.get())
   );
 
   @Rule


### PR DESCRIPTION
I found that GenericAvroReader and Writer do not support the logical type of "time-micros" of Avro.
As a result, it fails when having a transform on a TimeType field, with the following exception:
```
java.lang.IllegalArgumentException: Unsupported logical type: org.apache.iceberg.shaded.org.apache.avro.LogicalTypes$TimeMicros@6d2abe55
        at org.apache.iceberg.avro.GenericAvroWriter$WriteBuilder.primitive(GenericAvroWriter.java:108)
        at org.apache.iceberg.avro.GenericAvroWriter$WriteBuilder.primitive(GenericAvroWriter.java:49)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visit(AvroSchemaVisitor.java:71)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visit(AvroSchemaVisitor.java:56)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visitWithName(AvroSchemaVisitor.java:85)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visit(AvroSchemaVisitor.java:44)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visitWithName(AvroSchemaVisitor.java:85)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visit(AvroSchemaVisitor.java:44)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visitWithName(AvroSchemaVisitor.java:85)
        at org.apache.iceberg.avro.AvroSchemaVisitor.visit(AvroSchemaVisitor.java:44)
        at org.apache.iceberg.avro.GenericAvroWriter.setSchema(GenericAvroWriter.java:41)
        at org.apache.iceberg.avro.GenericAvroWriter.<init>(GenericAvroWriter.java:35)
        at org.apache.iceberg.avro.AvroFileAppender.newAvroWriter(AvroFileAppender.java:88)
        at org.apache.iceberg.avro.AvroFileAppender.<init>(AvroFileAppender.java:45)
        at org.apache.iceberg.avro.Avro$WriteBuilder.build(Avro.java:163)
        at org.apache.iceberg.ManifestWriter$V1Writer.newAppender(ManifestWriter.java:234)
        at org.apache.iceberg.ManifestWriter.<init>(ManifestWriter.java:72)
        at org.apache.iceberg.ManifestWriter.<init>(ManifestWriter.java:32)
        at org.apache.iceberg.ManifestWriter$V1Writer.<init>(ManifestWriter.java:213)
        at org.apache.iceberg.ManifestFiles.write(ManifestFiles.java:89)
        at org.apache.iceberg.ManifestFiles.write(ManifestFiles.java:74)
```