### PR TITLE
Correctly catch CommitFailedException in BaseMetastoreCatalog#createTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -67,13 +67,13 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     TableMetadata metadata = TableMetadata.newTableMetadata(
         schema, spec, baseLocation, properties == null ? Maps.newHashMap() : properties);
 
-    ops.commit(null, metadata);
-
     try {
-      return new BaseTable(ops, fullTableName(name(), identifier));
+      ops.commit(null, metadata);
     } catch (CommitFailedException ignored) {
       throw new AlreadyExistsException("Table was created concurrently: " + identifier);
     }
+
+    return new BaseTable(ops, fullTableName(name(), identifier));
   }
 
   @Override


### PR DESCRIPTION
straightforward and checked this is the only case of this kind

cc @rdblue 

One more thing is how `CommitFailedException` to be a `RuntimeException`.