### PR TITLE
Add assertions for sequence numbers to TestFastAppend

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.LongStream;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.types.Types;
@@ -87,9 +88,13 @@ public class TableTestBase {
   public TestTables.TestTable table = null;
 
   protected final int formatVersion;
+  protected final Assertions V1Assert;
+  protected final Assertions V2Assert;
 
   public TableTestBase(int formatVersion) {
     this.formatVersion = formatVersion;
+    this.V1Assert = new Assertions(1, formatVersion);
+    this.V2Assert = new Assertions(2, formatVersion);
   }
 
   @Before
@@ -197,6 +202,14 @@ public class TableTestBase {
   }
 
   void validateSnapshot(Snapshot old, Snapshot snap, DataFile... newFiles) {
+    validateSnapshot(old, snap, null, newFiles);
+  }
+
+  void validateSnapshot(Snapshot old, Snapshot snap, long sequenceNumber, DataFile... newFiles) {
+    validateSnapshot(old, snap, (Long) sequenceNumber, newFiles);
+  }
+
+  void validateSnapshot(Snapshot old, Snapshot snap, Long sequenceNumber, DataFile... newFiles) {
     List<ManifestFile> oldManifests = old != null ? old.manifests() : ImmutableList.of();
 
     // copy the manifests to a modifiable list and remove the existing manifests
@@ -215,6 +228,10 @@ public class TableTestBase {
 
     for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
+      if (sequenceNumber != null) {
+        V1Assert.assertEquals("Sequence number should default to 0", 0, entry.sequenceNumber().longValue());
+        V2Assert.assertEquals("Sequence number should match expected", sequenceNumber, entry.sequenceNumber());
+      }
       Assert.assertEquals("Path should match expected", newPaths.next(), file.path().toString());
       Assert.assertEquals("File's snapshot ID should match", id, (long) entry.snapshotId());
     }
@@ -242,12 +259,23 @@ public class TableTestBase {
     return paths;
   }
 
-  static void validateManifest(ManifestFile manifest,
-                               Iterator<Long> ids,
-                               Iterator<DataFile> expectedFiles) {
+  void validateManifest(ManifestFile manifest,
+                        Iterator<Long> ids,
+                        Iterator<DataFile> expectedFiles) {
+    validateManifest(manifest, null, ids, expectedFiles);
+  }
+
+  void validateManifest(ManifestFile manifest,
+                        Iterator<Long> seqs,
+                        Iterator<Long> ids,
+                        Iterator<DataFile> expectedFiles) {
     for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
+      if (seqs != null) {
+        V1Assert.assertEquals("Sequence number should default to 0", 0, entry.sequenceNumber().longValue());
+        V2Assert.assertEquals("Sequence number should match expected", seqs.next(), entry.sequenceNumber());
+      }
       Assert.assertEquals("Path should match expected",
           expected.path().toString(), file.path().toString());
       Assert.assertEquals("Snapshot ID should match expected ID",
@@ -280,6 +308,10 @@ public class TableTestBase {
     return Iterators.forArray(statuses);
   }
 
+  static Iterator<Long> seqs(long... seqs) {
+    return LongStream.of(seqs).iterator();
+  }
+
   static Iterator<Long> ids(Long... ids) {
     return Iterators.forArray(ids);
   }
@@ -290,5 +322,34 @@ public class TableTestBase {
 
   static Iterator<DataFile> files(ManifestFile manifest) {
     return ManifestFiles.read(manifest, FILE_IO).iterator();
+  }
+
+  /**
+   * Used for assertions that only apply if the table version is v2.
+   */
+  protected static class Assertions {
+    private final boolean enabled;
+
+    private Assertions(int validForVersion, int formatVersion) {
+      this.enabled = validForVersion == formatVersion;
+    }
+
+    void assertEquals(String context, int expected, int actual) {
+      if (enabled) {
+        Assert.assertEquals(context, expected, actual);
+      }
+    }
+
+    void assertEquals(String context, long expected, long actual) {
+      if (enabled) {
+        Assert.assertEquals(context, expected, actual);
+      }
+    }
+
+    void assertEquals(String context, Object expected, Object actual) {
+      if (enabled) {
+        Assert.assertEquals(context, expected, actual);
+      }
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -88,7 +88,9 @@ public class TableTestBase {
   public TestTables.TestTable table = null;
 
   protected final int formatVersion;
+  @SuppressWarnings("checkstyle:MemberName")
   protected final Assertions V1Assert;
+  @SuppressWarnings("checkstyle:MemberName")
   protected final Assertions V2Assert;
 
   public TableTestBase(int formatVersion) {


### PR DESCRIPTION
This adds assertions for sequence numbers to a couple of methods in `TestFastAppends`. All of the core tests should eventually have assertions for sequence numbers, but we can add them incrementally. This PR is intended to show how we can get good coverage for sequence numbers in existing tests.

The behavior of sequence numbers is different between v1 and v2, so this adds assertions that only apply when using a specific table version.