### PR TITLE
Enable linters on Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
 
   - language: python
     python: 3.6
-    install: pip install tox-travis "virtualenv<20.0.0"
+    install: pip install tox "virtualenv<20.0.0"
     before_script:
       - cd python
     script: tox

--- a/python/iceberg/core/avro/avro_to_iceberg.py
+++ b/python/iceberg/core/avro/avro_to_iceberg.py
@@ -203,8 +203,8 @@ class AvroToIceberg(object):
         avro_field_type = avro_field.get(AvroToIceberg.FIELD_TYPE_PROP)
         avro_logical_type = avro_field.get(AvroToIceberg.FIELD_LOGICAL_TYPE_PROP)
         if avro_field_type != "array" or avro_logical_type != "map":
-            raise RuntimeError("Avro type must be array and logical type must be map: %s" % (avro_field_type,
-                                                                                             avro_logical_type))
+            raise RuntimeError("Avro type {} must be array and logical type must be map: {}".format(
+                avro_field_type, avro_logical_type))
         is_optional = False
         items = avro_field.get(AvroToIceberg.FIELD_ITEMS_PROP)
         for field in items.get(AvroToIceberg.FIELD_FIELDS_PROP, list()):

--- a/python/iceberg/core/base_metastore_tables.py
+++ b/python/iceberg/core/base_metastore_tables.py
@@ -50,4 +50,4 @@ class BaseMetastoreTables(Tables):
         if warehouse_location is None:
             raise RuntimeError("Warehouse location is not set: hive.metastore.warehouse.dir=null")
 
-        return "%s/%s.db/%s".format(warehouse_location, database, table)
+        return "{}/{}.db/{}".format(warehouse_location, database, table)


### PR DESCRIPTION
It looks like the linters aren't running on the Python code:

After changing `tox-travis` to `tox` in the first commit, it started picking up the linters again, spotting the following issues:
```
linters run-test: commands[0] | flake8 iceberg setup.py tests
iceberg/core/base_metastore_tables.py:53:16: F523 '...'.format(...) has unused arguments at position(s): 0, 1, 2
iceberg/core/avro/avro_to_iceberg.py:206:32: F507 '...' % ... has 1 placeholder(s) but 2 substitution(s)
ERROR: InvocationError for command /home/travis/build/Fokko/incubator-iceberg/python/.tox/linters/bin/flake8 iceberg setup.py tests (exited with code 1)
```
The second commits fixes the issues.