### PR TITLE
Update spotless plugin config

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -50,9 +50,9 @@ subprojects {
   pluginManager.withPlugin('com.diffplug.gradle.spotless') {
     spotless {
       java {
-        target 'src/main/java/**/*.java', 'src/main/test/**/*.java'
+        target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/jmh/java/**/*.java'
         removeUnusedImports()
-        importOrder(['', 'static '])
+        importOrder '', 'static '
         trimTrailingWhitespace()
         indentWithSpaces 2
         endWithNewline()


### PR DESCRIPTION
Hello!

I was using the spotless plugin to clean up the relocated Guava imports but had to make a few changes to get it working for the whole project:
- Fixed target path to reference src/test/java
- Added src/jmh/java to include those files in the Spark module

I also found some of the config was outdated so I've updated that: 
```
'importOrder([x, y, z])' is deprecated.
Use 'importOrder x, y, z' instead.
```

Thank you! :D



