### PR TITLE
Fix RemoveOrphanFilesAction when file_path is not a qualified path

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
@@ -141,7 +141,7 @@ public class RemoveOrphanFilesAction extends BaseAction<List<String>> {
     Dataset<Row> validFileDF = validDataFileDF.union(validMetadataFileDF);
     Dataset<Row> actualFileDF = buildActualFileDF();
 
-    Column joinCond = validFileDF.col("file_path").equalTo(actualFileDF.col("file_path"));
+    Column joinCond = actualFileDF.col("file_path").contains(validFileDF.col("file_path"));
     List<String> orphanFiles = actualFileDF.join(validFileDF, joinCond, "leftanti")
         .as(Encoders.STRING())
         .collectAsList();

--- a/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.actions;
 
 import com.google.common.collect.Lists;
+import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -48,6 +49,9 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +73,14 @@ import org.slf4j.LoggerFactory;
 public class RemoveOrphanFilesAction extends BaseAction<List<String>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoveOrphanFilesAction.class);
+  private static final UserDefinedFunction filename = functions.udf((String path) -> {
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex == -1) {
+      return path;
+    } else {
+      return path.substring(lastIndex + 1);
+    }
+  }, DataTypes.StringType);
 
   private final SparkSession spark;
   private final JavaSparkContext sparkContext;
@@ -141,7 +153,10 @@ public class RemoveOrphanFilesAction extends BaseAction<List<String>> {
     Dataset<Row> validFileDF = validDataFileDF.union(validMetadataFileDF);
     Dataset<Row> actualFileDF = buildActualFileDF();
 
-    Column joinCond = actualFileDF.col("file_path").contains(validFileDF.col("file_path"));
+    Column nameEqual = filename.apply(actualFileDF.col("file_path"))
+        .equalTo(filename.apply(validFileDF.col("file_path")));
+    Column actualContains = actualFileDF.col("file_path").contains(validFileDF.col("file_path"));
+    Column joinCond = nameEqual.and(actualContains);
     List<String> orphanFiles = actualFileDF.join(validFileDF, joinCond, "leftanti")
         .as(Encoders.STRING())
         .collectAsList();

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -85,11 +85,12 @@ public class TestRemoveOrphanFilesAction {
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
   private String tableLocation = null;
 
   @Before
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
+    this.tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
   }
 
@@ -490,5 +491,70 @@ public class TestRemoveOrphanFilesAction {
         .select("file_path")
         .as(Encoders.STRING())
         .collectAsList();
+  }
+
+  @Test
+  public void testRemoveOrphanFilesWithRelativeFilePath() throws IOException, InterruptedException {
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableDir.getAbsolutePath());
+
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    df.select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(tableDir.getAbsolutePath());
+
+    List<String> validFiles = spark.read().format("iceberg")
+        .load(tableLocation + "#files")
+        .select("file_path")
+        .as(Encoders.STRING())
+        .collectAsList();
+    Assert.assertEquals("Should be 1 valid files", 1, validFiles.size());
+    String validFile = validFiles.get(0);
+
+    df.write().mode("append").parquet(tableLocation + "/data");
+
+    Path dataPath = new Path(tableLocation + "/data");
+    FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
+    List<String> allFiles = Arrays.stream(fs.listStatus(dataPath, HiddenPathFilter.get()))
+        .filter(FileStatus::isFile)
+        .map(file -> file.getPath().toString())
+        .collect(Collectors.toList());
+    Assert.assertEquals("Should be 2 files", 2, allFiles.size());
+
+    List<String> invalidFiles = Lists.newArrayList(allFiles);
+    invalidFiles.removeIf(file -> file.contains(validFile));
+    Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
+
+    // sleep for 1 second to unsure files will be old enough
+    Thread.sleep(1000);
+
+    Actions actions = Actions.forTable(table);
+    List<String> result = actions.removeOrphanFiles()
+        .olderThan(System.currentTimeMillis())
+        .deleteWith(s -> { })
+        .execute();
+    Assert.assertEquals("Action should find 1 file", invalidFiles, result);
+    Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+
+    List<String> result1 = actions.removeOrphanFiles()
+        .olderThan(System.currentTimeMillis())
+        .execute();
+    Assert.assertEquals("Action should delete 1 file", invalidFiles, result1);
+    Assert.assertFalse("Invalid file should not be present", fs.exists(new Path(invalidFiles.get(0))));
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -541,20 +541,5 @@ public class TestRemoveOrphanFilesAction {
         .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result);
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
-
-    List<String> result1 = actions.removeOrphanFiles()
-        .olderThan(System.currentTimeMillis())
-        .execute();
-    Assert.assertEquals("Action should delete 1 file", invalidFiles, result1);
-    Assert.assertFalse("Invalid file should not be present", fs.exists(new Path(invalidFiles.get(0))));
-
-    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
-    expectedRecords.addAll(records);
-
-    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
-    List<ThreeColumnRecord> actualRecords = resultDF
-        .as(Encoders.bean(ThreeColumnRecord.class))
-        .collectAsList();
-    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
   }
 }


### PR DESCRIPTION
If we don't use qualified path (`file:/temp/test_db`) to create or save into (Hadoop) table, then the file_path queried out is not a qualified path, for example:

```java
  private Dataset<Row> buildValidDataFileDF() {
    String allDataFilesMetadataTable = metadataTableName(MetadataTableType.ALL_DATA_FILES);
    return spark.read().format("iceberg")
        .load(allDataFilesMetadataTable)
        .select("file_path");
  }
```
The result here could be:

```
+-----------------------------------------------------------------------------------+
|file_path                                                                          |
+-----------------------------------------------------------------------------------+
|tmp/iceberg_test2/data/00000-172-2805f207-2c0d-4717-acc2-fed60430afeb-00000.parquet|
|tmp/iceberg_test2/data/00001-173-bd5e807d-e96f-49de-b84e-2c254c0777bb-00000.parquet|
|tmp/iceberg_test2/data/00002-174-fb7f84f0-d2ed-4e53-b5b9-6ef2f7da8a73-00000.parquet|
+-----------------------------------------------------------------------------------+
```
But the code here `file.getPath().toString()` in `RemoveOrphanFilesAction#listDirRecursively` returns qualified path:

```java
     for (FileStatus file : fs.listStatus(path, HiddenPathFilter.get())) {
        if (file.isDirectory()) {
          subDirs.add(file.getPath().toString());
        } else if (file.isFile() && predicate.test(file)) {
          matchingFiles.add(file.getPath().toString());
        }
      }
```
So the join condition `equalTo` may not correctly get the orphan files and delete the file mistakenly.

So here propose to fix the join condition to `contains`. Another solution is to change the relative path to qualified one in everywhere.



